### PR TITLE
docs: Add documentation to entry points

### DIFF
--- a/cmp-android/src/main/kotlin/cmp/android/app/AndroidApp.kt
+++ b/cmp-android/src/main/kotlin/cmp/android/app/AndroidApp.kt
@@ -15,10 +15,18 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.GlobalContext.startKoin
 
+/**
+ * Android application class.
+ * This class is used to initialize Koin modules.
+ *
+ * @constructor Create empty Android app
+ * @see Application
+ */
 class AndroidApp : Application() {
     override fun onCreate() {
         super.onCreate()
 
+        // Start Koin
         startKoin {
             androidContext(this@AndroidApp)
             androidLogger()

--- a/cmp-android/src/main/kotlin/cmp/android/app/MainActivity.kt
+++ b/cmp-android/src/main/kotlin/cmp/android/app/MainActivity.kt
@@ -21,10 +21,21 @@ import org.mifos.core.data.utils.NetworkMonitor
 import org.mifos.core.data.utils.TimeZoneMonitor
 import org.mifos.core.ui.utils.ShareUtils
 
+/**
+ * Main activity class.
+ * This class is used to set the content view of the activity.
+ *
+ * @constructor Create empty Main activity
+ * @see ComponentActivity
+ */
 class MainActivity : ComponentActivity() {
     private val networkMonitor: NetworkMonitor by inject()
     private val timeZoneMonitor: TimeZoneMonitor by inject()
 
+    /**
+     * Called when the activity is starting.
+     * This is where most initialization should go: calling [setContentView(int)] to inflate the activity's UI,
+     */
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 

--- a/cmp-desktop/src/jvmMain/kotlin/main.kt
+++ b/cmp-desktop/src/jvmMain/kotlin/main.kt
@@ -14,6 +14,12 @@ import androidx.compose.ui.window.rememberWindowState
 import cmp.shared.SharedApp
 import cmp.shared.di.initKoin
 
+/**
+ * Main function.
+ * This function is used to start the application.
+ * @see application
+ * @see rememberWindowState
+ */
 fun main() {
     application {
         initKoin()

--- a/cmp-web/src/jsMain/kotlin/Application.kt
+++ b/cmp-web/src/jsMain/kotlin/Application.kt
@@ -5,6 +5,12 @@ import org.jetbrains.skiko.wasm.onWasmReady
 import cmp.shared.SharedApp
 import cmp.shared.di.initKoin
 
+/**
+ * Main function.
+ * This function is used to start the application.
+ * @see ComposeViewport
+ * @see SharedApp
+ */
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
     initKoin()

--- a/cmp-web/src/wasmJsMain/kotlin/Main.kt
+++ b/cmp-web/src/wasmJsMain/kotlin/Main.kt
@@ -4,6 +4,12 @@ import cmp.shared.SharedApp
 import cmp.shared.di.initKoin
 import org.jetbrains.compose.resources.configureWebResources
 
+/**
+ * Main function.
+ * This function is used to start the application.
+ * @see CanvasBasedWindow
+ * @see SharedApp
+ */
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
     initKoin()


### PR DESCRIPTION
Added documentation to the entry points of the application for Android, Desktop, and Web platforms. This includes the AndroidApp, MainActivity, and main functions for each platform. The documentation provides a brief description of the purpose and functionality of each entry point.