### PR TITLE
chore: Update sync-cmp-dirs workflow

### DIFF
--- a/.github/workflows/sync-cmp-dirs.yaml
+++ b/.github/workflows/sync-cmp-dirs.yaml
@@ -78,8 +78,10 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v7
         with:
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           title: "chore: Sync CMP directories from upstream"
           body: |
             Automated sync of CMP directories from upstream repository.


### PR DESCRIPTION
Update the `create-pull-request` action to v7 and set committer and author information.