### PR TITLE
chore: Simplify cache cleanup workflow

### DIFF
--- a/.github/workflows/cache-cleanup.yaml
+++ b/.github/workflows/cache-cleanup.yaml
@@ -2,18 +2,15 @@ name: Cache Cleanup
 
 on:
   pull_request:
-    types: [closed]
+    types: [ closed ]
   workflow_dispatch:
 
 jobs:
   cleanup:
     name: Cache Cleanup
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cleanup Caches
-        uses: openMF/mifos-mobile-github-actions/.github/workflows/cache-cleanup.yaml@main
-        with:
-          cleanup_pr: ${{ github.event_name == 'pull_request' && github.event.repository.private == true }}
-          cleanup_all: ${{ github.event_name == 'workflow_dispatch' }}
-        secrets:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: openMF/mifos-mobile-github-actions/.github/workflows/cache-cleanup.yaml@main
+    with:
+      cleanup_pr: ${{ github.event_name == 'pull_request' && github.event.repository.private == true }}
+      cleanup_all: ${{ github.event_name == 'workflow_dispatch' }}
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Refactor the cache cleanup workflow to use a reusable workflow from the `openMF/mifos-mobile-github-actions` repository.

This change removes redundant steps and streamlines the workflow, making it more maintainable and efficient. It also ensures that the cleanup process is consistent across different projects that utilize the reusable workflow.