### PR TITLE
refactor: Centralize build paths for Android and iOS

### DIFF
--- a/.github/workflows/cache-cleanup.yaml
+++ b/.github/workflows/cache-cleanup.yaml
@@ -1,16 +1,18 @@
-name: Cache Cleanup
+name: Cleanup Cache
 
 on:
   pull_request:
-    types: [ closed ]
+    types: [closed]
   workflow_dispatch:
 
 jobs:
   cleanup:
-    name: Cache Cleanup
-    uses: openMF/mifos-mobile-github-actions/.github/workflows/cache-cleanup.yaml@main
-    with:
-      cleanup_pr: ${{ github.event_name == 'pull_request' && github.event.repository.private == true }}
-      cleanup_all: ${{ github.event_name == 'workflow_dispatch' }}
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Cache Cleanup
+        uses: openMF/mifos-mobile-github-actions/.github/workflows/cache-cleanup.yaml@main
+        with:
+          cleanup_pr: ${{ github.event_name == 'pull_request' && github.event.repository.private == true }}
+          cleanup_all: ${{ github.event_name == 'workflow_dispatch' }}
+        secrets:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cache-cleanup.yaml
+++ b/.github/workflows/cache-cleanup.yaml
@@ -2,17 +2,14 @@ name: Cleanup Cache
 
 on:
   pull_request:
-    types: [closed]
+    types: [ closed ]
   workflow_dispatch:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run Cache Cleanup
-        uses: openMF/mifos-mobile-github-actions/.github/workflows/cache-cleanup.yaml@main
-        with:
-          cleanup_pr: ${{ github.event_name == 'pull_request' && github.event.repository.private == true }}
-          cleanup_all: ${{ github.event_name == 'workflow_dispatch' }}
-        secrets:
-          token: ${{ secrets.GITHUB_TOKEN }}
+    uses: openMF/mifos-mobile-github-actions/.github/workflows/cache-cleanup.yaml@main
+    with:
+      cleanup_pr: ${{ github.event_name == 'pull_request' && github.event.repository.private == true }}
+      cleanup_all: ${{ github.event_name == 'workflow_dispatch' }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/fastlane/FastFile
+++ b/fastlane/FastFile
@@ -46,6 +46,7 @@ platform :android do
   lane :deployReleaseApkOnFirebase do |options|
     signing_config = FastlaneConfig.get_android_signing_config(options)
     firebase_config = FastlaneConfig.get_firebase_config(:android, :prod)
+    build_paths = FastlaneConfig::AndroidConfig::BUILD_PATHS
 
     # Generate version
     generateVersion = generateVersion(
@@ -65,7 +66,7 @@ platform :android do
     firebase_app_distribution(
       app: firebase_config[:appId],
       android_artifact_type: "APK",
-      android_artifact_path: FastlaneConfig::ANDROID_CONFIG[:prod_apk_path],
+      android_artifact_path: build_paths[:prod_apk_path],
       service_credentials_file: firebase_config[:serviceCredsFile],
       groups: firebase_config[:groups],
       release_notes: releaseNotes
@@ -76,6 +77,7 @@ platform :android do
   lane :deployDemoApkOnFirebase do |options|
     signing_config = FastlaneConfig.get_android_signing_config(options)
     firebase_config = FastlaneConfig.get_firebase_config(:android, :demo)
+    build_paths = FastlaneConfig::AndroidConfig::BUILD_PATHS
 
     # Generate version
     generateVersion = generateVersion(
@@ -95,7 +97,7 @@ platform :android do
     firebase_app_distribution(
       app: firebase_config[:appId],
       android_artifact_type: "APK",
-      android_artifact_path: FastlaneConfig::ANDROID_CONFIG[:demo_apk_path],
+      android_artifact_path: build_paths[:demo_apk_path],
       service_credentials_file: firebase_config[:serviceCredsFile],
       groups: firebase_config[:groups],
       release_notes: releaseNotes
@@ -105,6 +107,7 @@ platform :android do
   desc "Deploy internal tracks to Google Play"
   lane :deployInternal do |options|
     signing_config = FastlaneConfig.get_android_signing_config(options)
+    build_paths = FastlaneConfig::AndroidConfig::BUILD_PATHS
 
     # Generate version
     generateVersion = generateVersion(platform: "playstore")
@@ -125,7 +128,7 @@ platform :android do
 
     upload_to_play_store(
       track: 'internal',
-      aab: FastlaneConfig::ANDROID_CONFIG[:prod_aab_path],
+      aab: build_paths[:prod_aab_path],
       skip_upload_metadata: true,
       skip_upload_images: true,
       skip_upload_screenshots: true,
@@ -320,24 +323,26 @@ platform :ios do
   lane :build_ios do |options|
     # Set default configuration if not provided
     options[:configuration] ||= "Debug"
+    ios_config = FastlaneConfig::IosConfig::BUILD_CONFIG
 
     update_code_signing_settings(
       use_automatic_signing: true,
-      path: FastlaneConfig::IOS_CONFIG[:project_path]
+      path: ios_config[:project_path]
     )
 
     build_ios_app(
-      project: FastlaneConfig::IOS_CONFIG[:project_path],
-      scheme: FastlaneConfig::IOS_CONFIG[:scheme],
+      project: ios_config[:project_path],
+      scheme: ios_config[:scheme],
       configuration: options[:configuration],
       skip_codesigning: "true",
-      output_directory: FastlaneConfig::IOS_CONFIG[:output_directory],
+      output_directory: ios_config[:output_directory],
       skip_archive: "true"
     )
   end
 
   lane :increment_version do |options|
     firebase_config = FastlaneConfig.get_firebase_config(:ios)
+    ios_config = FastlaneConfig::IosConfig::BUILD_CONFIG
 
     latest_release = firebase_app_distribution_get_latest_release(
       app: firebase_config[:appId],
@@ -345,7 +350,7 @@ platform :ios do
     )
 
     increment_build_number(
-      xcodeproj: FastlaneConfig::IOS_CONFIG[:project_path],
+      xcodeproj: ios_config[:project_path],
       build_number: latest_release[:buildVersion].to_i + 1
     )
   end


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow and the Fastlane configuration for both Android and iOS platforms. The main goal is to standardize and simplify the configuration paths and token names.

Changes to GitHub Actions workflow:

* [`.github/workflows/cache-cleanup.yaml`](diffhunk://#diff-b644b2208d13049de573762ee324ec4c16a76cc98e358b3ef59f74cb600a6ab8L1-R1): Renamed the job and token name for consistency. [[1]](diffhunk://#diff-b644b2208d13049de573762ee324ec4c16a76cc98e358b3ef59f74cb600a6ab8L1-R1) [[2]](diffhunk://#diff-b644b2208d13049de573762ee324ec4c16a76cc98e358b3ef59f74cb600a6ab8L10-R15)

Changes to Fastlane configuration:

* [`fastlane/FastFile`](diffhunk://#diff-e30097a0ed43aef0a006519ab5c05544953ddee15819ca578fddf637fec4d22eR49): Updated Android and iOS build paths to use centralized configuration constants for better maintainability and consistency. [[1]](diffhunk://#diff-e30097a0ed43aef0a006519ab5c05544953ddee15819ca578fddf637fec4d22eR49) [[2]](diffhunk://#diff-e30097a0ed43aef0a006519ab5c05544953ddee15819ca578fddf637fec4d22eL68-R69) [[3]](diffhunk://#diff-e30097a0ed43aef0a006519ab5c05544953ddee15819ca578fddf637fec4d22eR80) [[4]](diffhunk://#diff-e30097a0ed43aef0a006519ab5c05544953ddee15819ca578fddf637fec4d22eL98-R100) [[5]](diffhunk://#diff-e30097a0ed43aef0a006519ab5c05544953ddee15819ca578fddf637fec4d22eR110) [[6]](diffhunk://#diff-e30097a0ed43aef0a006519ab5c05544953ddee15819ca578fddf637fec4d22eL128-R131) [[7]](diffhunk://#diff-e30097a0ed43aef0a006519ab5c05544953ddee15819ca578fddf637fec4d22eR326-R353)