### PR TITLE
Fix: Add missing App Store Connect submission metadata and privacy details

### DIFF
--- a/fastlane-config/ios_config.rb
+++ b/fastlane-config/ios_config.rb
@@ -21,7 +21,8 @@ module FastlaneConfig
       issuer_id: "8er9e361-9603-4c3e-b147-be3b1o816099",
       key_filepath: "./secrets/Auth_Key.p8",
       version_number: "1.0.0",
-      metadata_path: "./fastlane/metadata"
+      metadata_path: "./fastlane/metadata",
+      app_rating_config_path: "./fastlane/age_rating.json"
     }
   end
 end

--- a/fastlane/FastFile
+++ b/fastlane/FastFile
@@ -516,7 +516,26 @@ platform :ios do
         api_key: Actions.lane_context[SharedValues::APP_STORE_CONNECT_API_KEY],
         skip_app_version_update: true,
         force: true, # Skips HTML report verification
-        precheck_include_in_app_purchases: false
+        precheck_include_in_app_purchases: false,
+        app_rating_config_path: ios_config[:app_rating_config_path],
+        submission_information: {
+          add_id_info_uses_idfa: false,
+          add_id_info_limits_tracking: false,
+          add_id_info_serves_ads: false,
+          add_id_info_tracks_action: false,
+          add_id_info_tracks_install: false,
+          content_rights_has_rights: true,
+          content_rights_contains_third_party_content: false,
+          export_compliance_platform: 'ios',
+          export_compliance_compliance_required: false,
+          export_compliance_encryption_updated: false,
+          export_compliance_app_type: nil,
+          export_compliance_uses_encryption: false,
+          export_compliance_is_exempt: true,
+          export_compliance_contains_third_party_cryptography: false,
+          export_compliance_contains_proprietary_cryptography: false,
+          export_compliance_available_on_french_store: true
+        }
       )
   end
 end

--- a/fastlane/age_rating.json
+++ b/fastlane/age_rating.json
@@ -1,0 +1,17 @@
+{
+  "violenceCartoonOrFantasy": "NONE",
+  "violenceRealistic": "NONE",
+  "violenceRealisticProlongedGraphicOrSadistic": "NONE",
+  "sexualContentGraphicAndNudity": "NONE",
+  "sexualContentOrNudity": "NONE",
+  "matureOrSuggestiveThemes": "NONE",
+  "profanityOrCrudeHumor": "NONE",
+  "horrorOrFearThemes": "NONE",
+  "alcoholTobaccoOrDrugUseOrReferences": "NONE",
+  "medicalOrTreatmentInformation": "NONE",
+  "gamblingSimulated": "NONE",
+  "contests": "NONE",
+  "gambling": false,
+  "seventeenPlus": false,
+  "unrestrictedWebAccess": false
+}

--- a/fastlane/app_privacy_details.json
+++ b/fastlane/app_privacy_details.json
@@ -1,0 +1,7 @@
+[
+  {
+    "data_protections": [
+      "DATA_NOT_COLLECTED"
+    ]
+  }
+]


### PR DESCRIPTION
Hi @niyajali ,

Previously, our Fastlane setup for App Store deployment uploaded the build and metadata, but didn't automate the “submit for review” step — we would manually click “Submit for Review” after configuring any remaining details.

Now, I’ve updated the process to fully automate the review submission. This includes:

- Setting submit_for_review: true and automatic_release: true
- Adding all required submission metadata (e.g. violence_cartoon_or_fantasy, export compliance fields)
- Including additional optional flags (e.g. for ads, encryption) to make the setup future-proof if we introduce those features later

Regarding privacy details:
I didn’t automate it, but just want to note that Fastlane provides a manual action called `upload_app_privacy_details_to_app_store` which lets us upload what data the app collects. The downside is that it doesn’t support App Store Connect API authentication (the preferred method); instead, it relies on a session-based login via fastlane spaceauth, which:

- Requires generating the session on the same machine/region as your CI
- Has an unpredictable expiration window (anywhere from 1 day to a month)

Because of those limitations, I’ve already run the action manually and uploaded the current privacy config.

If our data collection policy changes in the future, we can just update the app_privacy_details.json file and re-run:

```
fastlane run upload_app_privacy_details_to_app_store \
  username:"your@email.com" \
  team_name:"Your Team" \
  app_identifier:"com.your.bundle" \
  json_path:"fastlane/app_privacy_details.json"
```  
We should document this step in the README.md so the team knows it's a manual prerequisite before pushing a new version to the App Store.

<img width="838" alt="image" src="https://github.com/user-attachments/assets/8e296873-fff9-47f7-8746-436f78500989" />
