### PR TITLE
feat(build-logic): introduce keystore management plugin and dependencies

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -32,6 +32,14 @@ dependencies {
     compileOnly(libs.androidx.room.gradle.plugin)
     compileOnly(libs.firebase.crashlytics.gradlePlugin)
     compileOnly(libs.firebase.performance.gradlePlugin)
+    
+    // Keystore management dependencies
+    implementation(libs.github.api)
+    implementation(libs.okhttp)
+    implementation(libs.jackson.core)
+    implementation(libs.jackson.databind)
+    implementation(libs.jackson.module.kotlin)
+    implementation(libs.commons.codec)
 }
 
 tasks {
@@ -111,5 +119,14 @@ gradlePlugin {
             implementationClass = "KMPRoomConventionPlugin"
             description = "Configures Room for the project"
         }
+
+        // NEW ===============================
+
+        register("keystoreManagement") {
+            id = "org.convention.keystore.management"
+            implementationClass = "KeystoreManagementConventionPlugin"
+            description = "Configures keystore management tasks for the project"
+        }
+
     }
 }

--- a/build-logic/convention/src/main/kotlin/KeystoreManagementConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KeystoreManagementConventionPlugin.kt
@@ -1,0 +1,52 @@
+
+import org.convention.keystore.KeystoreConfig
+import org.convention.keystore.SecretsConfig
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Convention plugin for keystore management following your existing patterns
+ */
+class KeystoreManagementConventionPlugin : Plugin<Project> {
+
+    override fun apply(target: Project) {
+        with(target) {
+            // Create extension for configuration
+            val keystoreExtension = extensions.create("keystoreManagement", KeystoreManagementExtension::class.java)
+
+            // Set default configurations
+            keystoreExtension.keystoreConfig.convention(KeystoreConfig())
+            keystoreExtension.secretsConfig.convention(SecretsConfig())
+
+            // Add task group description
+            tasks.register("keystoreHelp") {
+                group = "keystore"
+                description = "Shows available keystore management commands"
+                doLast {
+                    logger.lifecycle("""
+                        |Keystore Management Plugin
+                        |
+                        |Available tasks:
+                        |  - keystoreHelp: Shows this help message
+                        |
+                        |Configuration example:
+                        |  keystoreManagement {
+                        |    keystoreConfig {
+                        |      companyName = "Your Company"
+                        |      organization = "Your Org"
+                        |    }
+                        |  }
+                    """.trimMargin())
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Extension class for keystore management configuration
+ */
+abstract class KeystoreManagementExtension {
+    abstract val keystoreConfig: org.gradle.api.provider.Property<KeystoreConfig>
+    abstract val secretsConfig: org.gradle.api.provider.Property<SecretsConfig>
+}

--- a/build-logic/convention/src/main/kotlin/org/convention/keystore/BaseKeystoreTask.kt
+++ b/build-logic/convention/src/main/kotlin/org/convention/keystore/BaseKeystoreTask.kt
@@ -1,0 +1,95 @@
+package org.convention.keystore
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import java.io.File
+
+/**
+ * Base class for keystore management tasks following your existing convention patterns
+ */
+abstract class BaseKeystoreTask : DefaultTask() {
+
+    @get:Input
+    @get:Optional
+    abstract val keystoreConfig: Property<KeystoreConfig>
+
+    @get:Input
+    @get:Optional
+    abstract val secretsConfig: Property<SecretsConfig>
+
+    init {
+        group = "keystore"
+        description = "Base task for keystore management operations"
+
+        // Set default configurations
+        keystoreConfig.convention(KeystoreConfig())
+        secretsConfig.convention(SecretsConfig())
+    }
+
+    /**
+     * Logs task execution with consistent formatting
+     */
+    protected fun logInfo(message: String) {
+        logger.lifecycle("[KEYSTORE] $message")
+    }
+
+    protected fun logWarning(message: String) {
+        logger.warn("[KEYSTORE] $message")
+    }
+
+    protected fun logError(message: String) {
+        logger.error("[KEYSTORE] $message")
+    }
+
+    /**
+     * Validates configurations before task execution
+     */
+    protected fun validateConfiguration(): Boolean {
+        val keystoreErrors = keystoreConfig.get().validate()
+        if (keystoreErrors.isNotEmpty()) {
+            logError("Keystore configuration errors:")
+            keystoreErrors.forEach { logError("  - $it") }
+            return false
+        }
+        return true
+    }
+
+    /**
+     * Creates directory if it doesn't exist
+     */
+    protected fun ensureDirectoryExists(directory: File): Boolean {
+        return if (!directory.exists()) {
+            val created = directory.mkdirs()
+            if (created) {
+                logInfo("Created directory: ${directory.absolutePath}")
+            } else {
+                logError("Failed to create directory: ${directory.absolutePath}")
+            }
+            created
+        } else {
+            true
+        }
+    }
+
+    /**
+     * Checks if keytool is available (matches script check_keytool function)
+     */
+    protected fun checkKeytoolAvailable(): Boolean {
+        return try {
+            val process = ProcessBuilder("keytool", "-help").start()
+            val exitCode = process.waitFor()
+            if (exitCode == 0) {
+                logInfo("keytool is available")
+                true
+            } else {
+                logError("keytool command failed")
+                false
+            }
+        } catch (e: Exception) {
+            logError("keytool not found. Please ensure JDK is installed and keytool is in PATH")
+            false
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/org/convention/keystore/KeystoreConfig.kt
+++ b/build-logic/convention/src/main/kotlin/org/convention/keystore/KeystoreConfig.kt
@@ -1,0 +1,76 @@
+package org.convention.keystore
+
+import java.io.File
+
+/**
+ * Configuration for keystore generation matching keystore-manager.sh script parameters
+ */
+data class KeystoreConfig(
+    // Basic keystore parameters
+    val keystorePassword: String = "android",
+    val keyAlias: String = "upload",
+    val keyPassword: String = "android",
+    val keyAlgorithm: String = "RSA",
+    val keySize: Int = 2048,
+    val validity: Int = 25, // years
+
+    // Certificate DN components (mapped from script variables)
+    val companyName: String = "Android Debug",    // COMPANY_NAME -> CN
+    val department: String = "Android",           // DEPARTMENT -> OU
+    val organization: String = "Android",         // ORGANIZATION -> O
+    val city: String = "Unknown",                 // CITY -> L
+    val state: String = "Unknown",                // STATE -> ST
+    val country: String = "US",                   // COUNTRY -> C
+
+    // File paths (matching script defaults)
+    val keystoreDir: File = File("keystores"),
+    val originalKeystoreName: String = "original.keystore",  // ORIGINAL_KEYSTORE_NAME
+    val uploadKeystoreName: String = "upload.keystore",      // UPLOAD_KEYSTORE_NAME
+
+    // Behavior flags
+    val overwriteExisting: Boolean = false        // OVERWRITE in script
+) {
+
+    /**
+     * Distinguished Name for certificate generation (matches script DN construction)
+     */
+    val distinguishedName: String
+        get() = "CN=$companyName, OU=$department, O=$organization, L=$city, ST=$state, C=$country"
+
+    val originalKeystorePath: File get() = File(keystoreDir, originalKeystoreName)
+    val uploadKeystorePath: File get() = File(keystoreDir, uploadKeystoreName)
+
+    /**
+     * Validates configuration parameters
+     */
+    fun validate(): List<String> {
+        val errors = mutableListOf<String>()
+        if (keystorePassword.isBlank()) errors.add("Keystore password cannot be blank")
+        if (keyAlias.isBlank()) errors.add("Key alias cannot be blank")
+        if (keyPassword.isBlank()) errors.add("Key password cannot be blank")
+        if (keySize < 1024) errors.add("Key size must be at least 1024 bits")
+        if (validity <= 0) errors.add("Validity period must be positive")
+        if (country.length != 2) errors.add("Country code must be exactly 2 characters")
+        return errors
+    }
+
+    companion object {
+        /**
+         * Creates default configuration matching script's ORIGINAL keystore
+         */
+        fun original(): KeystoreConfig = KeystoreConfig(
+            companyName = "Android Debug",
+            keyAlias = "androiddebugkey",
+            originalKeystoreName = "original.keystore"
+        )
+
+        /**
+         * Creates default configuration matching script's UPLOAD keystore
+         */
+        fun upload(): KeystoreConfig = KeystoreConfig(
+            companyName = "Android Release",
+            keyAlias = "upload",
+            uploadKeystoreName = "upload.keystore"
+        )
+    }
+}

--- a/build-logic/convention/src/main/kotlin/org/convention/keystore/KeystoreLogger.kt
+++ b/build-logic/convention/src/main/kotlin/org/convention/keystore/KeystoreLogger.kt
@@ -1,0 +1,46 @@
+package org.convention.keystore
+
+import org.gradle.api.logging.Logger
+
+/**
+ * Utility class for consistent keystore task logging
+ */
+class KeystoreLogger(private val logger: Logger) {
+
+    companion object {
+        private const val PREFIX = "[KEYSTORE]"
+        private const val SEPARATOR = "=============================================================================="
+    }
+
+    fun info(message: String) {
+        logger.lifecycle("$PREFIX $message")
+    }
+
+    fun warning(message: String) {
+        logger.warn("$PREFIX $message")
+    }
+
+    fun error(message: String) {
+        logger.error("$PREFIX $message")
+    }
+
+    fun success(message: String) {
+        logger.lifecycle("$PREFIX ✅ $message")
+    }
+
+    fun section(title: String) {
+        logger.lifecycle("")
+        logger.lifecycle("$PREFIX $SEPARATOR")
+        logger.lifecycle("$PREFIX $title")
+        logger.lifecycle("$PREFIX $SEPARATOR")
+    }
+
+    fun summary(title: String, items: List<Pair<String, Boolean>>) {
+        logger.lifecycle("")
+        section(title)
+        items.forEach { (item, success) ->
+            val status = if (success) "✅ SUCCESS" else "❌ FAILED"
+            logger.lifecycle("$PREFIX $item: $status")
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/org/convention/keystore/SecretsConfig.kt
+++ b/build-logic/convention/src/main/kotlin/org/convention/keystore/SecretsConfig.kt
@@ -1,0 +1,65 @@
+package org.convention.keystore
+
+import java.io.File
+
+/**
+ * Configuration for secrets.env file management matching keystore-manager.sh functionality
+ */
+data class SecretsConfig(
+    // File paths
+    val secretsEnvFile: File = File("secrets.env"),
+    val backupDir: File = File("secrets-backup"),
+
+    // GitHub secret names from script
+    val originalKeystorePasswordKey: String = "ORIGINAL_KEYSTORE_FILE_PASSWORD",
+    val originalKeystoreAliasKey: String = "ORIGINAL_KEYSTORE_ALIAS",
+    val originalKeystoreAliasPasswordKey: String = "ORIGINAL_KEYSTORE_ALIAS_PASSWORD",
+    val originalKeystoreFileKey: String = "ORIGINAL_KEYSTORE_FILE",
+
+    val uploadKeystorePasswordKey: String = "UPLOAD_KEYSTORE_FILE_PASSWORD",
+    val uploadKeystoreAliasKey: String = "UPLOAD_KEYSTORE_ALIAS",
+    val uploadKeystoreAliasPasswordKey: String = "UPLOAD_KEYSTORE_ALIAS_PASSWORD",
+    val uploadKeystoreFileKey: String = "UPLOAD_KEYSTORE_FILE",
+
+    // Excluded keys from GitHub (matching script EXCLUDED_GITHUB_KEYS)
+    val excludedGitHubKeys: Set<String> = setOf(
+        "COMPANY_NAME", "DEPARTMENT", "ORGANIZATION", "CITY", "STATE", "COUNTRY",
+        "VALIDITY", "KEYALG", "KEYSIZE", "OVERWRITE",
+        "ORIGINAL_KEYSTORE_NAME", "UPLOAD_KEYSTORE_NAME",
+        "CN", "OU", "O", "L", "ST", "C"
+    ),
+
+    // Base64 encoding settings
+    val base64LineLength: Int = 76,
+    val useHeredocFormat: Boolean = true,
+    val heredocDelimiter: String = "EOF",
+
+    // File processing options
+    val createBackup: Boolean = true,
+    val preserveComments: Boolean = true
+) {
+
+    /**
+     * Checks if a key should be excluded from GitHub secrets
+     */
+    fun isKeyExcluded(key: String): Boolean = excludedGitHubKeys.contains(key)
+
+    /**
+     * Formats a multiline value using heredoc syntax (matching script format)
+     */
+    fun formatMultilineValue(key: String, value: String): String {
+        return if (useHeredocFormat) {
+            "$key<<$heredocDelimiter\n$value\n$heredocDelimiter"
+        } else {
+            val escapedValue = value.replace("\n", "\\n").replace("\"", "\\\"")
+            "$key=\"$escapedValue\""
+        }
+    }
+
+    /**
+     * Gets backup file path with timestamp
+     */
+    fun getBackupFile(timestamp: String = System.currentTimeMillis().toString()): File {
+        return File(backupDir, "secrets.env.backup.$timestamp")
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,10 +4,12 @@ androidDesugarJdkLibs = "2.1.5"
 androidGradlePlugin = "8.10.0"
 androidTools = "31.10.0"
 
+commonsCodec = "1.19.0"
 firebaseBom = "33.16.0"
 firebaseCrashlyticsPlugin = "3.0.4"
 firebasePerfPlugin = "1.4.2"
 androidxMacroBenchmark = "1.3.4"
+githubApi = "1.329"
 gmsPlugin = "4.4.3"
 
 # AndroidX Dependencies
@@ -26,6 +28,10 @@ appcompatVersion = "1.7.1"
 calfPermissions = "0.8.0"
 coreKtxVersion = "1.16.0"
 
+jacksonCore = "2.19.2"
+jacksonDatabind = "2.19.2"
+jacksonModuleKotlin = "2.19.2"
+okhttp = "4.12.0"
 robolectric = "4.15.1"
 roborazzi = "1.45.1"
 
@@ -149,6 +155,7 @@ androidx-metrics = { group = "androidx.metrics", name = "metrics-performance", v
 androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "androidxProfileinstaller" }
 
 androidx-room-gradle-plugin = { module = "androidx.room:room-gradle-plugin", version.ref = "room" }
+commons-codec = { module = "commons-codec:commons-codec", version.ref = "commonsCodec" }
 firebase-crashlytics-gradlePlugin = { group = "com.google.firebase", name = "firebase-crashlytics-gradle", version.ref = "firebaseCrashlyticsPlugin" }
 firebase-performance-gradlePlugin = { group = "com.google.firebase", name = "perf-plugin", version.ref = "firebasePerfPlugin" }
 
@@ -161,8 +168,13 @@ androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version
 androidx-tracing-ktx = { group = "androidx.tracing", name = "tracing-ktx", version.ref = "androidxTracing" }
 
 calf-permissions = { module = "com.mohamedrejeb.calf:calf-permissions", version.ref = "calfPermissions" }
+github-api = { module = "org.kohsuke:github-api", version.ref = "githubApi" }
+jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jacksonCore" }
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jacksonDatabind" }
+jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jacksonModuleKotlin" }
 ktlint-gradlePlugin = { group = "org.jlleitschuh.gradle", name = "ktlint-gradle", version.ref = "ktlint" }
 detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 spotless-gradle = { group = "com.diffplug.spotless", name = "spotless-plugin-gradle", version.ref = "spotlessVersion" }
 detekt-gradlePlugin = { group = "io.gitlab.arturbosch.detekt", name = "detekt-gradle-plugin", version.ref = "detekt" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }


### PR DESCRIPTION
## 🎫 TICKET
- [KMPPT-53](https://mifosforge.jira.com/browse/KMPPT-53)

Key changes:
- Implement `KeystoreManagementConventionPlugin` for managing keystore-related tasks.
- Add `KeystoreConfig` and `SecretsConfig` for configurable keystore and secrets handling.
- Create `BaseKeystoreTask` and `KeystoreLogger` for task operations and consistent logging.
- Update `libs.versions.toml` with new dependencies: `commons-codec`, `github-api`, `jackson` (core, databind, module-kotlin), and `okhttp`.
- Update `convention` module to include keystore management library dependencies.

[KMPPT-53]: https://mifosforge.jira.com/browse/KMPPT-53?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ