### PR TITLE
feat(build-logic): add secrets.env parser and environment override handler

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -40,12 +40,26 @@ dependencies {
     implementation(libs.jackson.databind)
     implementation(libs.jackson.module.kotlin)
     implementation(libs.commons.codec)
+    
+    // Test dependencies for keystore management
+    testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.junit.jupiter.engine)
+    testImplementation(libs.junit.jupiter.params)
+    testRuntimeOnly(libs.platform.junit.platform.launcher)
 }
 
 tasks {
     validatePlugins {
         enableStricterValidation = true
         failOnWarning = true
+    }
+    
+    // Configure JUnit 5 for testing keystore management functionality
+    test {
+        useJUnitPlatform()
+        testLogging {
+            events("passed", "skipped", "failed")
+        }
     }
 }
 

--- a/build-logic/convention/src/main/kotlin/org/convention/keystore/BaseKeystoreTask.kt
+++ b/build-logic/convention/src/main/kotlin/org/convention/keystore/BaseKeystoreTask.kt
@@ -2,6 +2,7 @@ package org.convention.keystore
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import java.io.File
@@ -9,6 +10,7 @@ import java.io.File
 /**
  * Base class for keystore management tasks following your existing convention patterns
  */
+@CacheableTask
 abstract class BaseKeystoreTask : DefaultTask() {
 
     @get:Input

--- a/build-logic/convention/src/main/kotlin/org/convention/keystore/ConfigurationValidator.kt
+++ b/build-logic/convention/src/main/kotlin/org/convention/keystore/ConfigurationValidator.kt
@@ -1,0 +1,332 @@
+package org.convention.keystore
+
+/**
+ * Validates configuration parameters for keystore management
+ * Implements comprehensive validation logic matching keystore-manager.sh script validation
+ */
+class ConfigurationValidator {
+
+    /**
+     * Validation result containing errors and warnings
+     */
+    data class ValidationResult(
+        val errors: List<String>,
+        val warnings: List<String>
+    ) {
+        val isValid: Boolean get() = errors.isEmpty()
+        val hasWarnings: Boolean get() = warnings.isNotEmpty()
+    }
+
+    /**
+     * Validates keystore configuration
+     */
+    fun validateKeystoreConfig(config: KeystoreConfig): ValidationResult {
+        val errors = mutableListOf<String>()
+        val warnings = mutableListOf<String>()
+
+        // Validate passwords
+        validatePassword(config.keystorePassword, "keystore password", errors, warnings)
+        validatePassword(config.keyPassword, "key password", errors, warnings)
+
+        // Validate key alias
+        if (config.keyAlias.isBlank()) {
+            errors.add("Key alias cannot be blank")
+        } else if (config.keyAlias.length < 3) {
+            warnings.add("Key alias is very short (${config.keyAlias.length} characters)")
+        }
+
+        // Validate algorithm and key size
+        validateKeyAlgorithm(config.keyAlgorithm, config.keySize, errors, warnings)
+
+        // Validate validity period
+        if (config.validity <= 0) {
+            errors.add("Validity period must be positive")
+        } else if (config.validity < 1) {
+            warnings.add("Validity period is very short (${config.validity} years)")
+        } else if (config.validity > 50) {
+            warnings.add("Validity period is very long (${config.validity} years)")
+        }
+
+        // Validate distinguished name components
+        validateDistinguishedName(config, errors, warnings)
+
+        // Validate file paths
+        validateFilePaths(config, errors, warnings)
+
+        return ValidationResult(errors, warnings)
+    }
+
+    /**
+     * Validates secrets configuration
+     */
+    fun validateSecretsConfig(config: SecretsConfig): ValidationResult {
+        val errors = mutableListOf<String>()
+        val warnings = mutableListOf<String>()
+
+        // Validate file paths
+        if (config.secretsEnvFile.name.isBlank()) {
+            errors.add("Secrets file name cannot be blank")
+        }
+
+        if (!config.secretsEnvFile.name.endsWith(".env")) {
+            warnings.add("Secrets file should have .env extension")
+        }
+
+        // Validate backup settings
+        if (config.createBackup && config.backupDir.name.isBlank()) {
+            errors.add("Backup directory name cannot be blank when backup is enabled")
+        }
+
+        // Validate heredoc settings
+        if (config.useHeredocFormat && config.heredocDelimiter.isBlank()) {
+            errors.add("Heredoc delimiter cannot be blank when heredoc format is enabled")
+        }
+
+        if (config.base64LineLength <= 0) {
+            errors.add("Base64 line length must be positive")
+        }
+
+        // Validate secret key names
+        validateSecretKeyNames(config, errors, warnings)
+
+        return ValidationResult(errors, warnings)
+    }
+
+    /**
+     * Validates environment configuration by checking system properties and environment variables
+     */
+    fun validateEnvironmentConfiguration(): ValidationResult {
+        val errors = mutableListOf<String>()
+        val warnings = mutableListOf<String>()
+
+        // Check Java version for keytool compatibility
+        val javaVersion = System.getProperty("java.version")
+        if (javaVersion != null) {
+            val majorVersion = extractJavaMajorVersion(javaVersion)
+            if (majorVersion < 8) {
+                errors.add("Java 8 or higher is required for keytool. Current version: $javaVersion")
+            }
+        } else {
+            warnings.add("Unable to determine Java version")
+        }
+
+        // Check OS compatibility
+        val osName = System.getProperty("os.name")?.lowercase()
+        if (osName?.contains("windows") == true) {
+            warnings.add("Windows detected. Ensure proper path handling for keystore files")
+        }
+
+        // Check available memory
+        val maxMemory = Runtime.getRuntime().maxMemory()
+        val availableMemory = maxMemory / (1024 * 1024) // Convert to MB
+        if (availableMemory < 256) {
+            warnings.add("Low available memory ($availableMemory MB). Keystore operations may be slow")
+        }
+
+        return ValidationResult(errors, warnings)
+    }
+
+    /**
+     * Validates parsed secrets from secrets.env file
+     */
+    fun validateParsedSecrets(parseResult: SecretsEnvParser.ParseResult, config: SecretsConfig): ValidationResult {
+        val errors = mutableListOf<String>()
+        val warnings = mutableListOf<String>()
+
+        // First check if parsing was successful
+        if (!parseResult.isValid) {
+            errors.addAll(parseResult.errors)
+            return ValidationResult(errors, warnings)
+        }
+
+        val allSecrets = parseResult.allSecrets
+
+        // Validate required keystore secrets
+        validateRequiredKeystoreSecrets(allSecrets, config, errors)
+
+        // Validate secret values
+        validateSecretValues(allSecrets, warnings)
+
+        // Check for potential issues
+        validateSecretPatterns(allSecrets, warnings)
+
+        return ValidationResult(errors, warnings)
+    }
+
+    private fun validatePassword(password: String, passwordType: String, errors: MutableList<String>, warnings: MutableList<String>) {
+        when {
+            password.isBlank() -> errors.add("$passwordType cannot be blank")
+            password.length < 6 -> warnings.add("$passwordType is weak (less than 6 characters)")
+            password == "android" || password == "password" -> warnings.add("$passwordType is using a default/common value")
+            !password.any { it.isDigit() } -> warnings.add("$passwordType should contain at least one digit")
+            !password.any { it.isLetter() } -> warnings.add("$passwordType should contain at least one letter")
+        }
+    }
+
+    private fun validateKeyAlgorithm(algorithm: String, keySize: Int, errors: MutableList<String>, warnings: MutableList<String>) {
+        when (algorithm.uppercase()) {
+            "RSA" -> {
+                when {
+                    keySize < 2048 -> errors.add("RSA key size must be at least 2048 bits")
+                    keySize > 4096 -> warnings.add("RSA key size is very large ($keySize bits), may slow down operations")
+                }
+            }
+            "DSA" -> {
+                if (keySize < 1024) {
+                    errors.add("DSA key size must be at least 1024 bits")
+                }
+                warnings.add("DSA algorithm is less commonly used than RSA")
+            }
+            "EC" -> {
+                if (keySize < 256) {
+                    errors.add("EC key size must be at least 256 bits")
+                }
+            }
+            else -> {
+                warnings.add("Unknown or uncommon key algorithm: $algorithm")
+            }
+        }
+    }
+
+    private fun validateDistinguishedName(config: KeystoreConfig, errors: MutableList<String>, warnings: MutableList<String>) {
+        // Validate country code
+        if (config.country.length != 2) {
+            errors.add("Country code must be exactly 2 characters")
+        } else if (!config.country.matches(Regex("[A-Z]{2}"))) {
+            warnings.add("Country code should be uppercase letters")
+        }
+
+        // Check for common DN issues
+        if (config.companyName.contains("Android Debug") && config.keyAlias != "androiddebugkey") {
+            warnings.add("Using debug certificate info for non-debug keystore")
+        }
+
+        // Validate required DN components
+        if (config.companyName.isBlank()) {
+            warnings.add("Company name (CN) is blank")
+        }
+
+        if (config.organization.isBlank()) {
+            warnings.add("Organization (O) is blank")
+        }
+    }
+
+    private fun validateFilePaths(config: KeystoreConfig, errors: MutableList<String>, warnings: MutableList<String>) {
+        // Check keystore directory
+        if (!config.keystoreDir.exists() && !config.keystoreDir.mkdirs()) {
+            errors.add("Cannot create keystore directory: ${config.keystoreDir.absolutePath}")
+        }
+
+        // Check file names
+        if (!config.originalKeystoreName.endsWith(".keystore") && !config.originalKeystoreName.endsWith(".jks")) {
+            warnings.add("Original keystore file should have .keystore or .jks extension")
+        }
+
+        if (!config.uploadKeystoreName.endsWith(".keystore") && !config.uploadKeystoreName.endsWith(".jks")) {
+            warnings.add("Upload keystore file should have .keystore or .jks extension")
+        }
+
+        // Check for file conflicts
+        if (config.originalKeystorePath.exists() && !config.overwriteExisting) {
+            warnings.add("Original keystore file already exists and overwrite is disabled")
+        }
+
+        if (config.uploadKeystorePath.exists() && !config.overwriteExisting) {
+            warnings.add("Upload keystore file already exists and overwrite is disabled")
+        }
+    }
+
+    private fun validateSecretKeyNames(config: SecretsConfig, errors: MutableList<String>, warnings: MutableList<String>) {
+        val secretKeys = listOf(
+            config.originalKeystorePasswordKey,
+            config.originalKeystoreAliasKey,
+            config.originalKeystoreAliasPasswordKey,
+            config.originalKeystoreFileKey,
+            config.uploadKeystorePasswordKey,
+            config.uploadKeystoreAliasKey,
+            config.uploadKeystoreAliasPasswordKey,
+            config.uploadKeystoreFileKey
+        )
+
+        secretKeys.forEach { key ->
+            if (key.isBlank()) {
+                errors.add("Secret key name cannot be blank")
+            } else if (!key.matches(Regex("[A-Z_][A-Z0-9_]*"))) {
+                warnings.add("Secret key '$key' should follow UPPER_SNAKE_CASE convention")
+            }
+        }
+    }
+
+    private fun validateRequiredKeystoreSecrets(secrets: Map<String, String>, config: SecretsConfig, errors: MutableList<String>) {
+        val requiredKeys = listOf(
+            config.originalKeystorePasswordKey,
+            config.originalKeystoreAliasKey,
+            config.originalKeystoreAliasPasswordKey,
+            config.uploadKeystorePasswordKey,
+            config.uploadKeystoreAliasKey,
+            config.uploadKeystoreAliasPasswordKey
+        )
+
+        requiredKeys.forEach { key ->
+            when {
+                !secrets.containsKey(key) -> errors.add("Missing required secret: $key")
+                secrets[key].isNullOrBlank() -> errors.add("Empty value for required secret: $key")
+            }
+        }
+    }
+
+    private fun validateSecretValues(secrets: Map<String, String>, warnings: MutableList<String>) {
+        secrets.forEach { (key, value) ->
+            when {
+                key.contains("PASSWORD") && value.length < 6 ->
+                    warnings.add("Password secret '$key' is weak (less than 6 characters)")
+
+                key.contains("ALIAS") && value.length < 3 ->
+                    warnings.add("Alias secret '$key' is very short")
+
+                value.contains("android") && !key.contains("ORIGINAL") ->
+                    warnings.add("Secret '$key' contains 'android' which might be a default value")
+            }
+        }
+    }
+
+    private fun validateSecretPatterns(secrets: Map<String, String>, warnings: MutableList<String>) {
+        // Check for duplicate values
+        val valueGroups = secrets.values.groupBy { it }
+        valueGroups.forEach { (value, occurrences) ->
+            if (occurrences.size > 1 && value.isNotBlank()) {
+                val keys = secrets.filterValues { it == value }.keys
+                warnings.add("Duplicate value found in secrets: ${keys.joinToString(", ")}")
+            }
+        }
+
+        // Check for suspicious patterns
+        secrets.forEach { (key, value) ->
+            when {
+                value.matches(Regex(".*test.*", RegexOption.IGNORE_CASE)) ->
+                    warnings.add("Secret '$key' contains 'test' - ensure this is not a test value")
+
+                value.matches(Regex(".*demo.*", RegexOption.IGNORE_CASE)) ->
+                    warnings.add("Secret '$key' contains 'demo' - ensure this is not a demo value")
+
+                value.matches(Regex(".*example.*", RegexOption.IGNORE_CASE)) ->
+                    warnings.add("Secret '$key' contains 'example' - ensure this is not an example value")
+            }
+        }
+    }
+
+    private fun extractJavaMajorVersion(version: String): Int {
+        return try {
+            val parts = version.split(".")
+            if (parts[0] == "1" && parts.size > 1) {
+                // Java 1.8 format
+                parts[1].toInt()
+            } else {
+                // Java 9+ format
+                parts[0].toInt()
+            }
+        } catch (e: Exception) {
+            0 // Unknown version
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/org/convention/keystore/EnvironmentOverrideHandler.kt
+++ b/build-logic/convention/src/main/kotlin/org/convention/keystore/EnvironmentOverrideHandler.kt
@@ -1,0 +1,306 @@
+package org.convention.keystore
+
+import java.io.File
+
+/**
+ * Handles environment variable overrides for keystore configuration
+ * Matches the behavior of keystore-manager.sh script's environment variable handling
+ */
+class EnvironmentOverrideHandler {
+
+    /**
+     * Result of applying environment overrides
+     */
+    data class OverrideResult(
+        val updatedSecrets: Map<String, String>,
+        val overriddenKeys: Set<String>,
+        val warnings: List<String>
+    )
+
+    /**
+     * Applies environment variable overrides to parsed secrets
+     * Environment variables take precedence over secrets.env file values
+     */
+    fun applyEnvironmentOverrides(
+        parsedSecrets: Map<String, String>,
+        config: SecretsConfig
+    ): OverrideResult {
+        val updatedSecrets = parsedSecrets.toMutableMap()
+        val overriddenKeys = mutableSetOf<String>()
+        val warnings = mutableListOf<String>()
+
+        // Get all environment variables
+        val envVars = System.getenv()
+
+        // Apply overrides for all secrets
+        parsedSecrets.keys.forEach { key ->
+            val envValue = envVars[key]
+            if (envValue != null) {
+                if (envValue != parsedSecrets[key]) {
+                    updatedSecrets[key] = envValue
+                    overriddenKeys.add(key)
+
+                    // Warn about excluded keys being overridden
+                    if (config.isKeyExcluded(key)) {
+                        warnings.add("Environment variable override for excluded key: $key")
+                    }
+                }
+            }
+        }
+
+        // Check for additional environment variables that might be keystore-related
+        val keystoreRelatedEnvVars = findKeystoreRelatedEnvVars(envVars)
+        keystoreRelatedEnvVars.forEach { (key, value) ->
+            if (!updatedSecrets.containsKey(key)) {
+                updatedSecrets[key] = value
+                overriddenKeys.add(key)
+                warnings.add("Added new secret from environment variable: $key")
+            }
+        }
+
+        return OverrideResult(
+            updatedSecrets = updatedSecrets,
+            overriddenKeys = overriddenKeys,
+            warnings = warnings
+        )
+    }
+
+    /**
+     * Creates a KeystoreConfig with environment variable overrides applied
+     */
+    fun createOverriddenKeystoreConfig(baseConfig: KeystoreConfig): KeystoreConfig {
+        val env = System.getenv()
+
+        return baseConfig.copy(
+            // Basic keystore parameters
+            keystorePassword = env["KEYSTORE_PASSWORD"] ?: baseConfig.keystorePassword,
+            keyAlias = env["KEY_ALIAS"] ?: env["KEYSTORE_ALIAS"] ?: baseConfig.keyAlias,
+            keyPassword = env["KEY_PASSWORD"] ?: env["KEYSTORE_KEY_PASSWORD"] ?: baseConfig.keyPassword,
+            keyAlgorithm = env["KEYALG"] ?: baseConfig.keyAlgorithm,
+            keySize = env["KEYSIZE"]?.toIntOrNull() ?: baseConfig.keySize,
+            validity = env["VALIDITY"]?.toIntOrNull() ?: baseConfig.validity,
+
+            // Certificate DN components (using both descriptive and traditional names)
+            companyName = env["COMPANY_NAME"] ?: env["CN"] ?: baseConfig.companyName,
+            department = env["DEPARTMENT"] ?: env["OU"] ?: baseConfig.department,
+            organization = env["ORGANIZATION"] ?: env["O"] ?: baseConfig.organization,
+            city = env["CITY"] ?: env["L"] ?: baseConfig.city,
+            state = env["STATE"] ?: env["ST"] ?: baseConfig.state,
+            country = env["COUNTRY"] ?: env["C"] ?: baseConfig.country,
+
+            // File paths
+            keystoreDir = env["KEYSTORE_DIR"]?.let { File(it) } ?: baseConfig.keystoreDir,
+            originalKeystoreName = env["ORIGINAL_KEYSTORE_NAME"] ?: baseConfig.originalKeystoreName,
+            uploadKeystoreName = env["UPLOAD_KEYSTORE_NAME"] ?: baseConfig.uploadKeystoreName,
+
+            // Behavior flags
+            overwriteExisting = env["OVERWRITE"]?.toBoolean() ?: baseConfig.overwriteExisting
+        )
+    }
+
+    /**
+     * Creates a SecretsConfig with environment variable overrides applied
+     */
+    fun createOverriddenSecretsConfig(baseConfig: SecretsConfig): SecretsConfig {
+        val env = System.getenv()
+
+        return baseConfig.copy(
+            // File paths
+            secretsEnvFile = env["SECRETS_ENV_FILE"]?.let { File(it) } ?: baseConfig.secretsEnvFile,
+            backupDir = env["SECRETS_BACKUP_DIR"]?.let { File(it) } ?: baseConfig.backupDir,
+
+            // Base64 encoding settings
+            base64LineLength = env["BASE64_LINE_LENGTH"]?.toIntOrNull() ?: baseConfig.base64LineLength,
+            useHeredocFormat = env["USE_HEREDOC_FORMAT"]?.toBoolean() ?: baseConfig.useHeredocFormat,
+            heredocDelimiter = env["HEREDOC_DELIMITER"] ?: baseConfig.heredocDelimiter,
+
+            // File processing options
+            createBackup = env["CREATE_BACKUP"]?.toBoolean() ?: baseConfig.createBackup,
+            preserveComments = env["PRESERVE_COMMENTS"]?.toBoolean() ?: baseConfig.preserveComments
+        )
+    }
+
+    /**
+     * Gets environment variables that override keystore file paths
+     */
+    fun getKeystorePathOverrides(): Map<String, String> {
+        val env = System.getenv()
+        val pathOverrides = mutableMapOf<String, String>()
+
+        // Check for common keystore path environment variables
+        env["KEYSTORE_PATH"]?.let { pathOverrides["KEYSTORE_PATH"] = it }
+        env["ORIGINAL_KEYSTORE_PATH"]?.let { pathOverrides["ORIGINAL_KEYSTORE_PATH"] = it }
+        env["UPLOAD_KEYSTORE_PATH"]?.let { pathOverrides["UPLOAD_KEYSTORE_PATH"] = it }
+        env["RELEASE_KEYSTORE_PATH"]?.let { pathOverrides["RELEASE_KEYSTORE_PATH"] = it }
+        env["DEBUG_KEYSTORE_PATH"]?.let { pathOverrides["DEBUG_KEYSTORE_PATH"] = it }
+
+        return pathOverrides
+    }
+
+    /**
+     * Checks if environment contains CI/CD specific variables
+     */
+    fun isRunningInCiCd(): Boolean {
+        val env = System.getenv()
+
+        // Common CI/CD environment indicators
+        val ciIndicators = listOf(
+            "CI", "CONTINUOUS_INTEGRATION",
+            "GITHUB_ACTIONS", "GITLAB_CI", "JENKINS_URL", "TEAMCITY_VERSION",
+            "TRAVIS", "CIRCLECI", "BUILDKITE", "BUILD_NUMBER"
+        )
+
+        return ciIndicators.any { env.containsKey(it) }
+    }
+
+    /**
+     * Gets CI/CD specific environment information
+     */
+    fun getCiCdEnvironmentInfo(): Map<String, String> {
+        val env = System.getenv()
+        val ciInfo = mutableMapOf<String, String>()
+
+        // GitHub Actions
+        env["GITHUB_ACTIONS"]?.let { ciInfo["platform"] = "GitHub Actions" }
+        env["GITHUB_REPOSITORY"]?.let { ciInfo["repository"] = it }
+        env["GITHUB_REF"]?.let { ciInfo["ref"] = it }
+
+        // GitLab CI
+        env["GITLAB_CI"]?.let { ciInfo["platform"] = "GitLab CI" }
+        env["CI_PROJECT_PATH"]?.let { ciInfo["repository"] = it }
+        env["CI_COMMIT_REF_NAME"]?.let { ciInfo["ref"] = it }
+
+        // Jenkins
+        env["JENKINS_URL"]?.let { ciInfo["platform"] = "Jenkins" }
+        env["JOB_NAME"]?.let { ciInfo["job"] = it }
+        env["BUILD_NUMBER"]?.let { ciInfo["build"] = it }
+
+        // Generic CI info
+        env["CI"]?.let { if (ciInfo["platform"] == null) ciInfo["platform"] = "Generic CI" }
+
+        return ciInfo
+    }
+
+    /**
+     * Validates that required environment variables are set for CI/CD
+     */
+    fun validateCiCdEnvironment(requiredSecrets: List<String>): List<String> {
+        val env = System.getenv()
+        val errors = mutableListOf<String>()
+
+        if (isRunningInCiCd()) {
+            requiredSecrets.forEach { secret ->
+                if (!env.containsKey(secret)) {
+                    errors.add("Required environment variable not set in CI/CD: $secret")
+                } else if (env[secret].isNullOrBlank()) {
+                    errors.add("Required environment variable is empty in CI/CD: $secret")
+                }
+            }
+
+            // Check for common CI/CD keystore secrets
+            val commonCiSecrets = listOf(
+                "KEYSTORE_PASSWORD", "KEY_PASSWORD", "KEYSTORE_ALIAS"
+            )
+
+            commonCiSecrets.forEach { secret ->
+                if (!env.containsKey(secret)) {
+                    errors.add("Common CI/CD keystore secret not found: $secret")
+                }
+            }
+        }
+
+        return errors
+    }
+
+    /**
+     * Finds environment variables that appear to be keystore-related
+     */
+    private fun findKeystoreRelatedEnvVars(envVars: Map<String, String>): Map<String, String> {
+        val keystorePatterns = listOf(
+            ".*KEYSTORE.*", ".*KEY_.*", ".*ALIAS.*", ".*STORE_.*",
+            ".*UPLOAD.*", ".*ORIGINAL.*", ".*RELEASE.*", ".*DEBUG.*"
+        )
+
+        return envVars.filterKeys { key ->
+            keystorePatterns.any { pattern ->
+                key.matches(Regex(pattern, RegexOption.IGNORE_CASE))
+            }
+        }
+    }
+
+    /**
+     * Sanitizes environment variable values for logging (hides sensitive data)
+     */
+    fun sanitizeEnvVarForLogging(key: String, value: String): String {
+        val sensitivePatterns = listOf(
+            ".*PASSWORD.*", ".*SECRET.*", ".*KEY.*", ".*TOKEN.*", ".*PRIVATE.*"
+        )
+
+        return if (sensitivePatterns.any { key.matches(Regex(it, RegexOption.IGNORE_CASE)) }) {
+            if (value.length <= 4) "***" else "${value.take(2)}${"*".repeat(value.length - 4)}${value.takeLast(2)}"
+        } else {
+            value
+        }
+    }
+
+    /**
+     * Creates a summary of all environment overrides applied
+     */
+    fun createOverrideSummary(overrideResult: OverrideResult): String {
+        val summary = StringBuilder()
+
+        summary.appendLine("Environment Override Summary:")
+        summary.appendLine("=".repeat(50))
+
+        if (overrideResult.overriddenKeys.isEmpty()) {
+            summary.appendLine("No environment overrides applied")
+        } else {
+            summary.appendLine("Overridden keys (${overrideResult.overriddenKeys.size}):")
+            overrideResult.overriddenKeys.sorted().forEach { key ->
+                val value = overrideResult.updatedSecrets[key] ?: ""
+                val sanitizedValue = sanitizeEnvVarForLogging(key, value)
+                summary.appendLine("  $key = $sanitizedValue")
+            }
+        }
+
+        if (overrideResult.warnings.isNotEmpty()) {
+            summary.appendLine("\nWarnings:")
+            overrideResult.warnings.forEach { warning ->
+                summary.appendLine("  • $warning")
+            }
+        }
+
+        // Add CI/CD information if applicable
+        if (isRunningInCiCd()) {
+            summary.appendLine("\nCI/CD Environment Detected:")
+            getCiCdEnvironmentInfo().forEach { (key, value) ->
+                summary.appendLine("  $key: $value")
+            }
+        }
+
+        return summary.toString()
+    }
+
+    companion object {
+        /**
+         * Standard environment variable names for keystore configuration
+         */
+        object StandardEnvVars {
+            const val KEYSTORE_PASSWORD = "KEYSTORE_PASSWORD"
+            const val KEY_PASSWORD = "KEY_PASSWORD"
+            const val KEYSTORE_ALIAS = "KEYSTORE_ALIAS"
+            const val KEYSTORE_PATH = "KEYSTORE_PATH"
+            const val KEYSTORE_DIR = "KEYSTORE_DIR"
+
+            // Original keystore specific
+            const val ORIGINAL_KEYSTORE_PASSWORD = "ORIGINAL_KEYSTORE_FILE_PASSWORD"
+            const val ORIGINAL_KEYSTORE_ALIAS = "ORIGINAL_KEYSTORE_ALIAS"
+            const val ORIGINAL_KEYSTORE_ALIAS_PASSWORD = "ORIGINAL_KEYSTORE_ALIAS_PASSWORD"
+
+            // Upload keystore specific
+            const val UPLOAD_KEYSTORE_PASSWORD = "UPLOAD_KEYSTORE_FILE_PASSWORD"
+            const val UPLOAD_KEYSTORE_ALIAS = "UPLOAD_KEYSTORE_ALIAS"
+            const val UPLOAD_KEYSTORE_ALIAS_PASSWORD = "UPLOAD_KEYSTORE_ALIAS_PASSWORD"
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/org/convention/keystore/SecretsEnvParser.kt
+++ b/build-logic/convention/src/main/kotlin/org/convention/keystore/SecretsEnvParser.kt
@@ -1,0 +1,243 @@
+package org.convention.keystore
+
+import java.io.File
+
+/**
+ * Parser for secrets.env file with multiline (heredoc) support
+ * Matches the functionality of the keystore-manager.sh script's load_env_vars function
+ */
+class SecretsEnvParser(private val config: SecretsConfig) {
+
+    /**
+     * Parsed result containing all secrets and metadata
+     */
+    data class ParseResult(
+        val secrets: Map<String, String>,
+        val multilineSecrets: Map<String, String>,
+        val comments: List<String>,
+        val errors: List<String>
+    ) {
+        val allSecrets: Map<String, String>
+            get() = secrets + multilineSecrets
+
+        val isValid: Boolean
+            get() = errors.isEmpty()
+    }
+
+    /**
+     * Parses the secrets.env file with full heredoc support
+     * Matches the exact behavior of the bash script's multiline parsing
+     */
+    fun parseFile(file: File = config.secretsEnvFile): ParseResult {
+        if (!file.exists()) {
+            return ParseResult(
+                secrets = emptyMap(),
+                multilineSecrets = emptyMap(),
+                comments = emptyList(),
+                errors = listOf("File not found: ${file.absolutePath}")
+            )
+        }
+
+        val secrets = mutableMapOf<String, String>()
+        val multilineSecrets = mutableMapOf<String, String>()
+        val comments = mutableListOf<String>()
+        val errors = mutableListOf<String>()
+
+        var lineNumber = 0
+        var inMultilineBlock = false
+        var multilineKey = ""
+        var multilineEnd = ""
+        val multilineValue = StringBuilder()
+
+        try {
+            file.forEachLine { line ->
+                lineNumber++
+
+                when {
+                    // Handle multiline block termination
+                    inMultilineBlock && line.trim() == multilineEnd -> {
+                        multilineSecrets[multilineKey] = multilineValue.toString()
+                        inMultilineBlock = false
+                        multilineKey = ""
+                        multilineEnd = ""
+                        multilineValue.clear()
+                    }
+
+                    // Handle content inside multiline blocks
+                    inMultilineBlock -> {
+                        if (multilineValue.isNotEmpty()) {
+                            multilineValue.appendLine()
+                        }
+                        multilineValue.append(line)
+                    }
+
+                    // Skip empty lines and comments when not in multiline mode
+                    line.isBlank() || line.trimStart().startsWith("#") -> {
+                        if (config.preserveComments && line.trimStart().startsWith("#")) {
+                            comments.add(line)
+                        }
+                    }
+
+                    // Check for multiline block start (KEY<<DELIMITER)
+                    line.contains("<<") -> {
+                        val parts = line.split("<<", limit = 2)
+                        if (parts.size == 2) {
+                            multilineKey = parts[0].trim()
+                            multilineEnd = parts[1].trim()
+
+                            if (multilineKey.isBlank()) {
+                                errors.add("Line $lineNumber: Empty key in multiline declaration")
+                            } else if (multilineEnd.isBlank()) {
+                                errors.add("Line $lineNumber: Empty delimiter in multiline declaration")
+                            } else {
+                                inMultilineBlock = true
+                                multilineValue.clear()
+                            }
+                        } else {
+                            errors.add("Line $lineNumber: Invalid multiline syntax")
+                        }
+                    }
+
+                    // Handle regular KEY=VALUE pairs
+                    line.contains("=") -> {
+                        val parts = line.split("=", limit = 2)
+                        if (parts.size == 2) {
+                            val key = parts[0].trim()
+                            val rawValue = parts[1]
+
+                            if (key.isBlank()) {
+                                errors.add("Line $lineNumber: Empty key")
+                            } else {
+                                val cleanValue = stripQuotes(rawValue)
+                                secrets[key] = cleanValue
+                            }
+                        } else {
+                            errors.add("Line $lineNumber: Invalid key=value syntax")
+                        }
+                    }
+
+                    else -> {
+                        errors.add("Line $lineNumber: Unrecognized line format: $line")
+                    }
+                }
+            }
+
+            // Check for unterminated multiline blocks
+            if (inMultilineBlock) {
+                errors.add("Unterminated multiline block. Missing closing delimiter: $multilineEnd")
+            }
+
+        } catch (e: Exception) {
+            errors.add("Failed to read file: ${e.message}")
+        }
+
+        return ParseResult(
+            secrets = secrets,
+            multilineSecrets = multilineSecrets,
+            comments = comments,
+            errors = errors
+        )
+    }
+
+    /**
+     * Strips surrounding quotes from values and handles escape sequences (matches script's strip_quotes function)
+     */
+    private fun stripQuotes(value: String): String {
+        var cleaned = value.trim()
+
+        // Remove surrounding double quotes and handle escape sequences
+        if (cleaned.startsWith("\"") && cleaned.endsWith("\"") && cleaned.length > 1) {
+            cleaned = cleaned.substring(1, cleaned.length - 1)
+            // Unescape common escape sequences in double-quoted strings
+            cleaned = cleaned
+                .replace("\\\"", "\"")  // Unescape double quotes
+                .replace("\\\\", "\\")  // Unescape backslashes
+                .replace("\\n", "\n")   // Unescape newlines
+                .replace("\\t", "\t")   // Unescape tabs
+                .replace("\\r", "\r")   // Unescape carriage returns
+        }
+
+        // Remove surrounding single quotes (no escape sequence processing for single quotes)
+        if (cleaned.startsWith("'") && cleaned.endsWith("'") && cleaned.length > 1) {
+            cleaned = cleaned.substring(1, cleaned.length - 1)
+        }
+
+        return cleaned
+    }
+
+    /**
+     * Creates a formatted table view of secrets (matches script's view_secrets function)
+     */
+    fun formatSecretsTable(parseResult: ParseResult): String {
+        if (!parseResult.isValid) {
+            return "Error parsing secrets file:\n${parseResult.errors.joinToString("\n")}"
+        }
+
+        val keyWidth = 30
+        val valueWidth = 50
+        val totalWidth = keyWidth + valueWidth + 5
+
+        val output = StringBuilder()
+
+        // Table header
+        output.appendLine("═".repeat(totalWidth))
+        output.appendLine("║ %-${keyWidth}s ║ %-${valueWidth}s ║".format("SECRET KEY", "VALUE"))
+        output.appendLine("═".repeat(totalWidth))
+
+        // Regular secrets
+        parseResult.secrets.forEach { (key, value) ->
+            val displayValue = if (value.length > valueWidth) {
+                value.take(valueWidth - 3) + "..."
+            } else {
+                value
+            }
+            output.appendLine("║ %-${keyWidth}s ║ %-${valueWidth}s ║".format(key, displayValue))
+        }
+
+        // Multiline secrets
+        parseResult.multilineSecrets.forEach { (key, _) ->
+            output.appendLine("║ %-${keyWidth}s ║ %-${valueWidth}s ║".format(key, "[MULTILINE VALUE]"))
+        }
+
+        // Table footer
+        output.appendLine("═".repeat(totalWidth))
+
+        return output.toString()
+    }
+
+    /**
+     * Validates that all required keystore secrets are present
+     */
+    fun validateKeystoreSecrets(parseResult: ParseResult): List<String> {
+        val errors = mutableListOf<String>()
+        val allSecrets = parseResult.allSecrets
+
+        // Required ORIGINAL keystore secrets
+        listOf(
+            config.originalKeystorePasswordKey,
+            config.originalKeystoreAliasKey,
+            config.originalKeystoreAliasPasswordKey
+        ).forEach { key ->
+            if (!allSecrets.containsKey(key)) {
+                errors.add("Missing required ORIGINAL keystore secret: $key")
+            } else if (allSecrets[key].isNullOrBlank()) {
+                errors.add("Empty value for required ORIGINAL keystore secret: $key")
+            }
+        }
+
+        // Required UPLOAD keystore secrets
+        listOf(
+            config.uploadKeystorePasswordKey,
+            config.uploadKeystoreAliasKey,
+            config.uploadKeystoreAliasPasswordKey
+        ).forEach { key ->
+            if (!allSecrets.containsKey(key)) {
+                errors.add("Missing required UPLOAD keystore secret: $key")
+            } else if (allSecrets[key].isNullOrBlank()) {
+                errors.add("Empty value for required UPLOAD keystore secret: $key")
+            }
+        }
+
+        return errors
+    }
+}

--- a/build-logic/convention/src/test/kotlin/org/convention/keystore/SecretsEnvParserTest.kt
+++ b/build-logic/convention/src/test/kotlin/org/convention/keystore/SecretsEnvParserTest.kt
@@ -1,0 +1,389 @@
+package org.convention.keystore
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * Unit tests for SecretsEnvParser covering edge cases and various file formats
+ * Tests the parsing logic against the keystore-manager.sh script behavior
+ */
+class SecretsEnvParserTest {
+
+    private lateinit var parser: SecretsEnvParser
+    private lateinit var config: SecretsConfig
+
+    @TempDir
+    lateinit var tempDir: File
+
+    @BeforeEach
+    fun setup() {
+        config = SecretsConfig()
+        parser = SecretsEnvParser(config)
+    }
+
+    @Test
+    fun `should parse simple key-value pairs`() {
+        val testFile = createTestFile(
+            """
+            # Simple key-value pairs
+            KEY1=value1
+            KEY2=value2
+            KEY3="quoted value"
+            KEY4='single quoted'
+        """.trimIndent(),
+        )
+
+        val result = parser.parseFile(testFile)
+
+        assertTrue(result.isValid)
+        assertEquals("value1", result.secrets["KEY1"])
+        assertEquals("value2", result.secrets["KEY2"])
+        assertEquals("quoted value", result.secrets["KEY3"])
+        assertEquals("single quoted", result.secrets["KEY4"])
+    }
+
+    @Test
+    fun `should parse multiline heredoc values`() {
+        val testFile = createTestFile(
+            """
+            # Multiline value test
+            MULTILINE_KEY<<EOF
+            line 1
+            line 2
+            line 3
+            EOF
+            
+            ANOTHER_KEY=simple_value
+        """.trimIndent(),
+        )
+
+        val result = parser.parseFile(testFile)
+
+        assertTrue(result.isValid)
+        assertEquals("line 1\nline 2\nline 3", result.multilineSecrets["MULTILINE_KEY"])
+        assertEquals("simple_value", result.secrets["ANOTHER_KEY"])
+    }
+
+    @Test
+    fun `should handle different heredoc delimiters`() {
+        val testFile = createTestFile(
+            """
+            KEY1<<END
+            content 1
+            END
+            
+            KEY2<<DELIMITER
+            content 2
+            DELIMITER
+        """.trimIndent(),
+        )
+
+        val result = parser.parseFile(testFile)
+
+        assertTrue(result.isValid)
+        assertEquals("content 1", result.multilineSecrets["KEY1"])
+        assertEquals("content 2", result.multilineSecrets["KEY2"])
+    }
+
+    @Test
+    fun `should handle empty multiline values`() {
+        val testFile = createTestFile(
+            """
+            EMPTY_MULTILINE<<EOF
+            EOF
+        """.trimIndent(),
+        )
+
+        val result = parser.parseFile(testFile)
+
+        assertTrue(result.isValid)
+        assertEquals("", result.multilineSecrets["EMPTY_MULTILINE"])
+    }
+
+    @Test
+    fun `should handle quotes in various formats`() {
+        val testFile = createTestFile(
+            """
+            UNQUOTED=value
+            DOUBLE_QUOTED="value with spaces"
+            SINGLE_QUOTED='value with spaces'
+            MIXED_QUOTES="value with 'inner' quotes"
+            ESCAPED="value with \"escaped\" quotes"
+        """.trimIndent(),
+        )
+
+        val result = parser.parseFile(testFile)
+
+        assertTrue(result.isValid)
+        assertEquals("value", result.secrets["UNQUOTED"])
+        assertEquals("value with spaces", result.secrets["DOUBLE_QUOTED"])
+        assertEquals("value with spaces", result.secrets["SINGLE_QUOTED"])
+        assertEquals("value with 'inner' quotes", result.secrets["MIXED_QUOTES"])
+        val value = "value with \"escaped\" quotes"
+        assertEquals(value, result.secrets["ESCAPED"])
+    }
+
+    @Test
+    fun `should preserve comments when configured`() {
+        val testFile = createTestFile(
+            """
+            # This is a comment
+            KEY1=value1
+            # Another comment
+            KEY2=value2
+        """.trimIndent(),
+        )
+
+        val result = parser.parseFile(testFile)
+
+        assertTrue(result.isValid)
+        assertEquals(2, result.comments.size)
+        assertTrue(result.comments.contains("# This is a comment"))
+        assertTrue(result.comments.contains("# Another comment"))
+    }
+
+    @Test
+    fun `should handle malformed multiline blocks`() {
+        val testFile = createTestFile(
+            """
+            # Missing delimiter
+            BAD_KEY<<
+            some content
+            
+            # Unterminated block
+            UNTERMINATED<<EOF
+            content without end
+        """.trimIndent(),
+        )
+
+        val result = parser.parseFile(testFile)
+
+        assertFalse(result.isValid)
+        assertTrue(result.errors.any { it.contains("Empty delimiter") })
+        assertTrue(result.errors.any { it.contains("Unterminated multiline block") })
+    }
+
+    @Test
+    fun `should flag mismatched heredoc terminator`() {
+        val testFile = createTestFile(
+            """
+            MISMATCHED<<EOF
+            some content
+            END
+            """.trimIndent(),
+        )
+
+        val result = parser.parseFile(testFile)
+
+        assertFalse(result.isValid)
+        // Should report unterminated block mentioning the expected delimiter
+        assertTrue(result.errors.any { it.contains("Unterminated multiline block") && it.contains("EOF") })
+    }
+
+    @Test
+    fun `should flag stray terminator without start`() {
+        val testFile = createTestFile(
+            """
+            # A terminator without a corresponding start
+            END
+            """.trimIndent(),
+        )
+
+        val result = parser.parseFile(testFile)
+
+        assertFalse(result.isValid)
+        assertTrue(result.errors.any { it.contains("Unrecognized line format: END") })
+    }
+
+    @Test
+    fun `should handle empty and whitespace-only lines`() {
+        val testFile = createTestFile(
+            """
+            KEY1=value1
+            
+                
+            KEY2=value2
+                    
+            KEY3=value3
+        """.trimIndent(),
+        )
+
+        val result = parser.parseFile(testFile)
+
+        assertTrue(result.isValid)
+        assertEquals(3, result.secrets.size)
+    }
+
+    @Test
+    fun `should handle special characters in values`() {
+        val testFile = createTestFile(
+            """
+            SPECIAL_CHARS="value with @#$%^&*()+={}[]|\\:;\"'<>,.?/~"
+            URL_VALUE="https://example.com/path?param=value&other=123"
+            BASE64_LIKE="SGVsbG8gV29ybGQ="
+        """.trimIndent(),
+        )
+
+        val result = parser.parseFile(testFile)
+
+        assertTrue(result.isValid)
+        assertNotNull(result.secrets["SPECIAL_CHARS"])
+        assertNotNull(result.secrets["URL_VALUE"])
+        assertNotNull(result.secrets["BASE64_LIKE"])
+    }
+
+    @Test
+    fun `should handle real keystore file format`() {
+        val testFile = createTestFile(
+            """
+            # Keystore configuration
+            ORIGINAL_KEYSTORE_FILE_PASSWORD=password123
+            ORIGINAL_KEYSTORE_ALIAS=myalias
+            ORIGINAL_KEYSTORE_ALIAS_PASSWORD=aliaspass
+            
+            ORIGINAL_KEYSTORE_FILE<<EOF
+            MIILEAIBAzCCCroGCSqGSIb3DQEHAaCCCqsEggqnMIIKozCCBcoGCSqGSIb3DQEHAaCCBbsEggW3
+            MIIFszCCBa8GCyqGSIb3DQEMCgECoIIFQDCCBTwwZgYJKoZIhvcNAQUNMFkwOAYJKoZIhvcNAQUM
+            EOF
+            
+            UPLOAD_KEYSTORE_FILE_PASSWORD=password456
+        """.trimIndent(),
+        )
+
+        val result = parser.parseFile(testFile)
+
+        assertTrue(result.isValid)
+        assertEquals("password123", result.secrets["ORIGINAL_KEYSTORE_FILE_PASSWORD"])
+        assertEquals("myalias", result.secrets["ORIGINAL_KEYSTORE_ALIAS"])
+        assertTrue(result.multilineSecrets["ORIGINAL_KEYSTORE_FILE"]?.contains("MIILEAIBAzCCCroGCSqGSIb3DQEH") == true)
+        assertEquals("password456", result.secrets["UPLOAD_KEYSTORE_FILE_PASSWORD"])
+    }
+
+    @Test
+    fun `should validate required keystore secrets`() {
+        val testFile = createTestFile(
+            """
+            # Missing some required secrets
+            ORIGINAL_KEYSTORE_FILE_PASSWORD=password
+            # Missing ORIGINAL_KEYSTORE_ALIAS
+            ORIGINAL_KEYSTORE_ALIAS_PASSWORD=aliaspass
+        """.trimIndent(),
+        )
+
+        val result = parser.parseFile(testFile)
+        val validationErrors = parser.validateKeystoreSecrets(result)
+
+        assertTrue(result.isValid) // Parsing is valid
+        assertFalse(validationErrors.isEmpty()) // But validation fails
+        assertTrue(validationErrors.any { it.contains("ORIGINAL_KEYSTORE_ALIAS") })
+    }
+
+    @Test
+    fun `should handle values with equals signs`() {
+        val testFile = createTestFile(
+            """
+            URL_WITH_PARAMS="https://api.example.com/v1/auth?token=abc123&user=test"
+            EQUATION="x = y + z"
+            BASE64_VALUE="YWxnb3JpdGhtPVJTQSZrZXlzaXplPTIwNDg="
+        """.trimIndent(),
+        )
+
+        val result = parser.parseFile(testFile)
+
+        assertTrue(result.isValid)
+        assertTrue(result.secrets["URL_WITH_PARAMS"]?.contains("token=abc123&user=test") == true)
+        assertEquals("x = y + z", result.secrets["EQUATION"])
+        assertNotNull(result.secrets["BASE64_VALUE"])
+    }
+
+    @Test
+    fun `should format secrets table correctly`() {
+        val testFile = createTestFile(
+            """
+            SHORT_KEY=value
+            VERY_LONG_KEY_NAME_THAT_EXCEEDS_NORMAL_LENGTH=short
+            MULTILINE<<EOF
+            line1
+            line2
+            EOF
+        """.trimIndent(),
+        )
+
+        val result = parser.parseFile(testFile)
+        val tableOutput = parser.formatSecretsTable(result)
+
+        assertTrue(tableOutput.contains("SHORT_KEY"))
+        assertTrue(tableOutput.contains("VERY_LONG_KEY_NAME_THAT_EXCEEDS_NORMAL_LENGTH"))
+        assertTrue(tableOutput.contains("[MULTILINE VALUE]"))
+        assertTrue(tableOutput.contains("═"))
+        assertTrue(tableOutput.contains("║"))
+    }
+
+    @Test
+    fun `should handle file not found gracefully`() {
+        val nonExistentFile = File(tempDir, "nonexistent.env")
+        val result = parser.parseFile(nonExistentFile)
+
+        assertFalse(result.isValid)
+        assertTrue(result.errors.any { it.contains("File not found") })
+        assertTrue(result.secrets.isEmpty())
+        assertTrue(result.multilineSecrets.isEmpty())
+    }
+
+    @Test
+    fun `should handle malformed key-value pairs`() {
+        val testFile = createTestFile(
+            """
+            VALID_KEY=valid_value
+            =value_without_key
+            key_without_value=
+            just_text_no_equals
+            =
+        """.trimIndent(),
+        )
+
+        val result = parser.parseFile(testFile)
+
+        // Should parse what it can and report errors for malformed lines
+        assertTrue(result.secrets.containsKey("VALID_KEY"))
+        assertTrue(result.secrets.containsKey("key_without_value"))
+        assertEquals("", result.secrets["key_without_value"])
+        assertFalse(result.isValid) // Should have errors for malformed lines
+    }
+
+    @Test
+    fun `should handle nested heredoc delimiters`() {
+        val testFile = createTestFile(
+            """
+            OUTER_KEY<<OUTER
+            Some content
+            INNER_KEY<<INNER
+            nested content
+            INNER
+            More outer content
+            OUTER
+        """.trimIndent(),
+        )
+
+        val result = parser.parseFile(testFile)
+
+        // The parser should handle this by treating everything between OUTER delimiters as content
+        assertTrue(result.isValid)
+        val content = result.multilineSecrets["OUTER_KEY"]
+        assertNotNull(content)
+        assertTrue(content?.contains("INNER_KEY<<INNER") == true)
+        assertTrue(content?.contains("nested content") == true)
+    }
+
+    private fun createTestFile(content: String): File {
+        val file = File(tempDir, "test-secrets.env")
+        file.writeText(content)
+        return file
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,8 +29,8 @@ calfPermissions = "0.8.0"
 coreKtxVersion = "1.16.0"
 
 jacksonCore = "2.19.2"
-jacksonDatabind = "2.19.2"
-jacksonModuleKotlin = "2.19.2"
+junitJupiterApi = "5.13.4"
+junitPlatformLauncherVersion = "1.13.4"
 okhttp = "4.12.0"
 robolectric = "4.15.1"
 roborazzi = "1.45.1"
@@ -170,11 +170,15 @@ androidx-tracing-ktx = { group = "androidx.tracing", name = "tracing-ktx", versi
 calf-permissions = { module = "com.mohamedrejeb.calf:calf-permissions", version.ref = "calfPermissions" }
 github-api = { module = "org.kohsuke:github-api", version.ref = "githubApi" }
 jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jacksonCore" }
-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jacksonDatabind" }
-jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jacksonModuleKotlin" }
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jacksonCore" }
+jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jacksonCore" }
+junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junitJupiterApi" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junitJupiterApi" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junitJupiterApi" }
 ktlint-gradlePlugin = { group = "org.jlleitschuh.gradle", name = "ktlint-gradle", version.ref = "ktlint" }
 detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+platform-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatformLauncherVersion" }
 spotless-gradle = { group = "com.diffplug.spotless", name = "spotless-plugin-gradle", version.ref = "spotlessVersion" }
 detekt-gradlePlugin = { group = "io.gitlab.arturbosch.detekt", name = "detekt-gradle-plugin", version.ref = "detekt" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }


### PR DESCRIPTION
## 🎫 TICKET 
- [KMPPT-54](https://mifosforge.jira.com/browse/KMPPT-54)


**Key Changes**

- Implement `SecretsEnvParser` for parsing `secrets.env` files with heredoc support, matching the behavior of `keystore-manager.sh`.
- Add `EnvironmentOverrideHandler` for applying environment variable overrides to parsed secrets.
- Introduce unit tests to validate parsing functionality and edge cases.
- Update dependencies to include JUnit 5 for testing.
- Configure `build.gradle.kts` to support JUnit 5 test execution.

[KMPPT-54]: https://mifosforge.jira.com/browse/KMPPT-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ