### PR TITLE
feat(build-logic): add KeystoreGenerationTask and usage documentation

### DIFF
--- a/build-logic/convention/src/main/kotlin/org/convention/keystore/BaseKeystoreTask.kt
+++ b/build-logic/convention/src/main/kotlin/org/convention/keystore/BaseKeystoreTask.kt
@@ -2,15 +2,15 @@ package org.convention.keystore
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
+import org.gradle.work.DisableCachingByDefault
 import java.io.File
 
 /**
  * Base class for keystore management tasks following your existing convention patterns
  */
-@CacheableTask
+@DisableCachingByDefault(because = "Keystore generation is not a cacheable task")
 abstract class BaseKeystoreTask : DefaultTask() {
 
     @get:Input

--- a/build-logic/convention/src/main/kotlin/org/convention/keystore/KeystoreGenerationTask.kt
+++ b/build-logic/convention/src/main/kotlin/org/convention/keystore/KeystoreGenerationTask.kt
@@ -1,0 +1,353 @@
+package org.convention.keystore
+
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * Gradle task for generating Android keystores using keytool
+ * 
+ * This task replicates the functionality of the keystore-manager.sh script's
+ * generate_keystore and generate_keystores functions, providing native Gradle DSL
+ * support for cross-platform keystore generation.
+ */
+@DisableCachingByDefault(because = "Keystore generation is not a cacheable task")
+abstract class KeystoreGenerationTask : BaseKeystoreTask() {
+
+    @get:Input
+    @get:Optional
+    abstract val generateOriginal: Property<Boolean>
+
+    @get:Input
+    @get:Optional
+    abstract val generateUpload: Property<Boolean>
+
+    @get:Input
+    @get:Optional
+    abstract val originalConfig: Property<KeystoreConfig>
+
+    @get:Input
+    @get:Optional
+    abstract val uploadConfig: Property<KeystoreConfig>
+
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
+
+    init {
+        description = "Generates Android keystores (ORIGINAL and UPLOAD) using keytool"
+        
+        // Set default values
+        generateOriginal.convention(true)
+        generateUpload.convention(true)
+        outputDirectory.convention(project.layout.projectDirectory.dir("keystores"))
+        
+        // Set default keystore configurations
+        originalConfig.convention(KeystoreConfig.original())
+        uploadConfig.convention(KeystoreConfig.upload())
+    }
+
+    @TaskAction
+    fun generateKeystores() {
+        logInfo("Starting keystore generation task")
+
+        // Validate keytool availability
+        if (!checkKeytoolAvailable()) {
+            throw IllegalStateException("keytool is not available. Please ensure JDK is installed and keytool is in PATH.")
+        }
+
+        // Create keystores directory
+        val keystoreDir = outputDirectory.asFile.get()
+        if (!ensureDirectoryExists(keystoreDir)) {
+            throw IllegalStateException("Failed to create keystores directory: ${keystoreDir.absolutePath}")
+        }
+
+        var originalResult = true
+        var uploadResult = true
+
+        // Generate ORIGINAL keystore if requested
+        if (generateOriginal.get()) {
+            logInfo("=".repeat(66))
+            logInfo("Generating ORIGINAL keystore")
+            logInfo("=".repeat(66))
+            
+            val originalKeystoreConfig = originalConfig.get()
+            originalResult = generateKeystore(
+                environment = "ORIGINAL",
+                config = originalKeystoreConfig,
+                keystorePath = File(keystoreDir, originalKeystoreConfig.originalKeystoreName)
+            )
+        }
+
+        // Generate UPLOAD keystore if requested
+        if (generateUpload.get()) {
+            logInfo("=".repeat(66))
+            logInfo("Generating UPLOAD keystore")
+            logInfo("=".repeat(66))
+            
+            val uploadKeystoreConfig = uploadConfig.get()
+            uploadResult = generateKeystore(
+                environment = "UPLOAD",
+                config = uploadKeystoreConfig,
+                keystorePath = File(keystoreDir, uploadKeystoreConfig.uploadKeystoreName)
+            )
+        }
+
+        // Print summary
+        printSummary(originalResult, uploadResult, keystoreDir)
+
+        // Fail the task if any keystore generation failed
+        if (!originalResult || !uploadResult) {
+            throw IllegalStateException("One or more keystores failed to generate")
+        }
+    }
+
+    /**
+     * Generates a single keystore using keytool (matches script's generate_keystore function)
+     */
+    private fun generateKeystore(
+        environment: String,
+        config: KeystoreConfig,
+        keystorePath: File
+    ): Boolean {
+        try {
+            // Log keystore parameters
+            logKeystoreParameters(environment, config, keystorePath)
+
+            // Check if keystore already exists and handle overwrite behavior
+            if (keystorePath.exists()) {
+                if (config.overwriteExisting) {
+                    logInfo("Overwriting existing keystore file '${keystorePath.name}'")
+                } else {
+                    logInfo("Keystore file '${keystorePath.name}' already exists and OVERWRITE is not set to 'true'")
+                    logInfo("Using existing keystore")
+                    return true
+                }
+            }
+
+            // Build keytool command
+            val command = buildKeytoolCommand(config, keystorePath)
+            
+            // Execute keytool command
+            logInfo("Executing keytool command...")
+            val success = executeKeytoolCommand(command)
+
+            if (success && keystorePath.exists()) {
+                logInfo("")
+                logInfo("===== $environment Keystore created successfully! =====")
+                logInfo("Keystore location: ${keystorePath.absolutePath}")
+                logInfo("Keystore alias: ${config.keyAlias}")
+                logInfo("")
+                return true
+            } else {
+                logError("")
+                logError("Error: Failed to create $environment keystore. Please check the error messages above.")
+                return false
+            }
+
+        } catch (e: Exception) {
+            logError("Exception during $environment keystore generation: ${e.message}")
+            e.printStackTrace()
+            return false
+        }
+    }
+
+    /**
+     * Logs keystore generation parameters (matches script output format)
+     */
+    private fun logKeystoreParameters(environment: String, config: KeystoreConfig, keystorePath: File) {
+        logInfo("Generating keystore with the following parameters:")
+        logInfo("- Environment: $environment")
+        logInfo("- Keystore Name: ${keystorePath.absolutePath}")
+        logInfo("- Key Alias: ${config.keyAlias}")
+        logInfo("- Validity: ${config.validity} years")
+        logInfo("- Key Algorithm: ${config.keyAlgorithm}")
+        logInfo("- Key Size: ${config.keySize}")
+        logInfo("- Distinguished Name: ${config.distinguishedName}")
+    }
+
+    /**
+     * Builds the keytool command arguments (matches script's keytool invocation)
+     */
+    private fun buildKeytoolCommand(config: KeystoreConfig, keystorePath: File): List<String> {
+        return listOf(
+            "keytool",
+            "-genkey",
+            "-v",
+            "-keystore", keystorePath.absolutePath,
+            "-alias", config.keyAlias,
+            "-keyalg", config.keyAlgorithm,
+            "-keysize", config.keySize.toString(),
+            "-validity", (config.validity * 365).toString(), // Convert years to days
+            "-storepass", config.keystorePassword,
+            "-keypass", config.keyPassword,
+            "-dname", config.distinguishedName
+        )
+    }
+
+    /**
+     * Executes the keytool command with proper error handling
+     */
+    private fun executeKeytoolCommand(command: List<String>): Boolean {
+        return try {
+            logInfo("Command: ${command.joinToString(" ") { if (it.contains(" ")) "\"$it\"" else it }}")
+            
+            val processBuilder = ProcessBuilder(command)
+            processBuilder.redirectErrorStream(true)
+            
+            val process = processBuilder.start()
+            
+            // Capture output
+            val output = process.inputStream.bufferedReader().readText()
+            
+            // Wait for process to complete with timeout
+            val finished = process.waitFor(60, TimeUnit.SECONDS)
+            
+            if (!finished) {
+                logError("Keytool command timed out after 60 seconds")
+                process.destroyForcibly()
+                return false
+            }
+            
+            val exitCode = process.exitValue()
+            
+            if (exitCode == 0) {
+                logInfo("Keytool command completed successfully")
+                if (output.isNotBlank()) {
+                    logInfo("Keytool output:")
+                    output.lines().forEach { line ->
+                        if (line.isNotBlank()) {
+                            logInfo("  $line")
+                        }
+                    }
+                }
+                true
+            } else {
+                logError("Keytool command failed with exit code: $exitCode")
+                if (output.isNotBlank()) {
+                    logError("Keytool error output:")
+                    output.lines().forEach { line ->
+                        if (line.isNotBlank()) {
+                            logError("  $line")
+                        }
+                    }
+                }
+                false
+            }
+            
+        } catch (e: Exception) {
+            logError("Failed to execute keytool command: ${e.message}")
+            e.printStackTrace()
+            false
+        }
+    }
+
+    /**
+     * Prints summary of keystore generation results (matches script summary format)
+     */
+    private fun printSummary(originalResult: Boolean, uploadResult: Boolean, keystoreDir: File) {
+        logInfo("")
+        logInfo("=".repeat(66))
+        logInfo("                          SUMMARY")
+        logInfo("=".repeat(66))
+
+        if (generateOriginal.get()) {
+            val originalKeystorePath = File(keystoreDir, originalConfig.get().originalKeystoreName)
+            if (originalResult) {
+                logInfo("ORIGINAL keystore: SUCCESS - ${originalKeystorePath.absolutePath}")
+            } else {
+                logError("ORIGINAL keystore: FAILED")
+            }
+        }
+
+        if (generateUpload.get()) {
+            val uploadKeystorePath = File(keystoreDir, uploadConfig.get().uploadKeystoreName)
+            if (uploadResult) {
+                logInfo("UPLOAD keystore: SUCCESS - ${uploadKeystorePath.absolutePath}")
+            } else {
+                logError("UPLOAD keystore: FAILED")
+            }
+        }
+
+        logInfo("")
+        logInfo("IMPORTANT: Keep these keystore files and their passwords in a safe place.")
+        logInfo("If you lose them, you will not be able to update your application on the Play Store.")
+    }
+
+    companion object {
+        /**
+         * Creates a task with configurations loaded from secrets.env file
+         */
+        fun createWithSecretsConfig(
+            task: KeystoreGenerationTask,
+            secretsConfig: SecretsConfig = SecretsConfig()
+        ) {
+            // Parse secrets.env file if it exists
+            val parser = SecretsEnvParser(secretsConfig)
+            val parseResult = parser.parseFile()
+
+            if (parseResult.isValid) {
+                val secrets = parseResult.allSecrets
+
+                // Apply ORIGINAL keystore configuration from secrets
+                val originalKeystoreConfig = KeystoreConfig(
+                    keystorePassword = secrets[secretsConfig.originalKeystorePasswordKey] 
+                        ?: KeystoreConfig.original().keystorePassword,
+                    keyAlias = secrets[secretsConfig.originalKeystoreAliasKey] 
+                        ?: KeystoreConfig.original().keyAlias,
+                    keyPassword = secrets[secretsConfig.originalKeystoreAliasPasswordKey] 
+                        ?: KeystoreConfig.original().keyPassword,
+                    companyName = secrets["COMPANY_NAME"] ?: KeystoreConfig.original().companyName,
+                    department = secrets["DEPARTMENT"] ?: KeystoreConfig.original().department,
+                    organization = secrets["ORGANIZATION"] ?: KeystoreConfig.original().organization,
+                    city = secrets["CITY"] ?: KeystoreConfig.original().city,
+                    state = secrets["STATE"] ?: KeystoreConfig.original().state,
+                    country = secrets["COUNTRY"] ?: KeystoreConfig.original().country,
+                    keyAlgorithm = secrets["KEYALG"] ?: KeystoreConfig.original().keyAlgorithm,
+                    keySize = secrets["KEYSIZE"]?.toIntOrNull() ?: KeystoreConfig.original().keySize,
+                    validity = secrets["VALIDITY"]?.toIntOrNull() ?: KeystoreConfig.original().validity,
+                    originalKeystoreName = secrets["ORIGINAL_KEYSTORE_NAME"] 
+                        ?: KeystoreConfig.original().originalKeystoreName,
+                    overwriteExisting = secrets["OVERWRITE"]?.toBoolean() 
+                        ?: KeystoreConfig.original().overwriteExisting
+                )
+
+                // Apply UPLOAD keystore configuration from secrets
+                val uploadKeystoreConfig = KeystoreConfig(
+                    keystorePassword = secrets[secretsConfig.uploadKeystorePasswordKey] 
+                        ?: KeystoreConfig.upload().keystorePassword,
+                    keyAlias = secrets[secretsConfig.uploadKeystoreAliasKey] 
+                        ?: KeystoreConfig.upload().keyAlias,
+                    keyPassword = secrets[secretsConfig.uploadKeystoreAliasPasswordKey] 
+                        ?: KeystoreConfig.upload().keyPassword,
+                    companyName = secrets["COMPANY_NAME"] ?: KeystoreConfig.upload().companyName,
+                    department = secrets["DEPARTMENT"] ?: KeystoreConfig.upload().department,
+                    organization = secrets["ORGANIZATION"] ?: KeystoreConfig.upload().organization,
+                    city = secrets["CITY"] ?: KeystoreConfig.upload().city,
+                    state = secrets["STATE"] ?: KeystoreConfig.upload().state,
+                    country = secrets["COUNTRY"] ?: KeystoreConfig.upload().country,
+                    keyAlgorithm = secrets["KEYALG"] ?: KeystoreConfig.upload().keyAlgorithm,
+                    keySize = secrets["KEYSIZE"]?.toIntOrNull() ?: KeystoreConfig.upload().keySize,
+                    validity = secrets["VALIDITY"]?.toIntOrNull() ?: KeystoreConfig.upload().validity,
+                    uploadKeystoreName = secrets["UPLOAD_KEYSTORE_NAME"] 
+                        ?: KeystoreConfig.upload().uploadKeystoreName,
+                    overwriteExisting = secrets["OVERWRITE"]?.toBoolean() 
+                        ?: KeystoreConfig.upload().overwriteExisting
+                )
+
+                task.originalConfig.set(originalKeystoreConfig)
+                task.uploadConfig.set(uploadKeystoreConfig)
+
+                task.logger.lifecycle("[KEYSTORE] Loaded configuration from ${secretsConfig.secretsEnvFile.name}")
+            } else {
+                task.logger.warn("[KEYSTORE] Could not parse ${secretsConfig.secretsEnvFile.name}: ${parseResult.errors}")
+                task.logger.lifecycle("[KEYSTORE] Using default configurations")
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/test/kotlin/org/convention/keystore/KeystoreGenerationTaskTest.kt
+++ b/build-logic/convention/src/test/kotlin/org/convention/keystore/KeystoreGenerationTaskTest.kt
@@ -1,0 +1,306 @@
+package org.convention.keystore
+
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * Tests for KeystoreGenerationTask
+ */
+class KeystoreGenerationTaskTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private lateinit var project: Project
+    private lateinit var task: KeystoreGenerationTask
+
+    @BeforeEach
+    fun setup() {
+        project = ProjectBuilder.builder()
+            .withProjectDir(tempDir)
+            .build()
+
+        task = project.tasks.register("testGenerateKeystores", KeystoreGenerationTask::class.java).get()
+    }
+
+    @Test
+    fun `task is created with correct configuration`() {
+        // Verify task is configured correctly
+        assertEquals("keystore", task.group)
+        assertTrue(task.description.contains("Generates Android keystores"))
+        assertTrue(task.generateOriginal.get())
+        assertTrue(task.generateUpload.get())
+    }
+
+    @Test
+    fun `task has correct default configurations`() {
+        // Verify default configurations
+        val originalConfig = task.originalConfig.get()
+        val uploadConfig = task.uploadConfig.get()
+
+        // Check ORIGINAL keystore defaults
+        assertEquals("androiddebugkey", originalConfig.keyAlias)
+        assertEquals("original.keystore", originalConfig.originalKeystoreName)
+        assertEquals("Android Debug", originalConfig.companyName)
+
+        // Check UPLOAD keystore defaults
+        assertEquals("upload", uploadConfig.keyAlias)
+        assertEquals("upload.keystore", uploadConfig.uploadKeystoreName)
+        assertEquals("Android Release", uploadConfig.companyName)
+    }
+
+    @Test
+    fun `task creates correct output directory`() {
+        // Set a custom output directory
+        val outputDir = File(tempDir, "custom-keystores")
+        task.outputDirectory.set(outputDir)
+
+        assertEquals(outputDir, task.outputDirectory.asFile.get())
+    }
+
+    @Test
+    fun `task builds correct distinguished name from config`() {
+        val config = KeystoreConfig(
+            keystorePassword = "testpass",
+            keyAlias = "testalias",
+            keyPassword = "keypass",
+            keyAlgorithm = "RSA",
+            keySize = 2048,
+            validity = 25,
+            companyName = "Test Company",
+            department = "Test Dept",
+            organization = "Test Org",
+            city = "Test City",
+            state = "Test State",
+            country = "US"
+        )
+
+        task.originalConfig.set(config)
+        
+        // Verify distinguished name construction
+        val expectedDN = "CN=Test Company, OU=Test Dept, O=Test Org, L=Test City, ST=Test State, C=US"
+        assertEquals(expectedDN, config.distinguishedName)
+        assertEquals(config, task.originalConfig.get())
+    }
+
+    @Test
+    fun `configuration loading from secrets works correctly`() {
+        // Create a test secrets.env file
+        val secretsFile = File(tempDir, "secrets.env")
+        secretsFile.writeText("""
+            # Test secrets file
+            ORIGINAL_KEYSTORE_FILE_PASSWORD=original_password
+            ORIGINAL_KEYSTORE_ALIAS=original_alias
+            ORIGINAL_KEYSTORE_ALIAS_PASSWORD=original_alias_password
+            
+            UPLOAD_KEYSTORE_FILE_PASSWORD=upload_password
+            UPLOAD_KEYSTORE_ALIAS=upload_alias
+            UPLOAD_KEYSTORE_ALIAS_PASSWORD=upload_alias_password
+            
+            COMPANY_NAME=Test Company From Secrets
+            DEPARTMENT=Test Department
+            ORGANIZATION=Test Organization
+            CITY=Test City
+            STATE=Test State
+            COUNTRY=TS
+            
+            KEYALG=RSA
+            KEYSIZE=4096
+            VALIDITY=30
+            OVERWRITE=true
+        """.trimIndent())
+
+        // Create SecretsConfig pointing to our test file
+        val secretsConfig = SecretsConfig(secretsEnvFile = secretsFile)
+
+        // Apply configuration from secrets
+        KeystoreGenerationTask.createWithSecretsConfig(task, secretsConfig)
+
+        // Verify configurations were loaded
+        val originalConfig = task.originalConfig.get()
+        val uploadConfig = task.uploadConfig.get()
+
+        // Check ORIGINAL keystore configuration
+        assertEquals("original_password", originalConfig.keystorePassword)
+        assertEquals("original_alias", originalConfig.keyAlias)
+        assertEquals("original_alias_password", originalConfig.keyPassword)
+        assertEquals("Test Company From Secrets", originalConfig.companyName)
+        assertEquals("Test Department", originalConfig.department)
+        assertEquals("Test Organization", originalConfig.organization)
+        assertEquals("Test City", originalConfig.city)
+        assertEquals("Test State", originalConfig.state)
+        assertEquals("TS", originalConfig.country)
+        assertEquals("RSA", originalConfig.keyAlgorithm)
+        assertEquals(4096, originalConfig.keySize)
+        assertEquals(30, originalConfig.validity)
+        assertTrue(originalConfig.overwriteExisting)
+
+        // Check UPLOAD keystore configuration
+        assertEquals("upload_password", uploadConfig.keystorePassword)
+        assertEquals("upload_alias", uploadConfig.keyAlias)
+        assertEquals("upload_alias_password", uploadConfig.keyPassword)
+        assertEquals("Test Company From Secrets", uploadConfig.companyName)
+        assertEquals("Test Department", uploadConfig.department)
+        assertEquals("Test Organization", uploadConfig.organization)
+        assertEquals("Test City", uploadConfig.city)
+        assertEquals("Test State", uploadConfig.state)
+        assertEquals("TS", uploadConfig.country)
+        assertEquals("RSA", uploadConfig.keyAlgorithm)
+        assertEquals(4096, uploadConfig.keySize)
+        assertEquals(30, uploadConfig.validity)
+        assertTrue(uploadConfig.overwriteExisting)
+    }
+
+    @Test
+    fun `task handles missing secrets file gracefully`() {
+        // Create SecretsConfig pointing to non-existent file
+        val secretsConfig = SecretsConfig(secretsEnvFile = File(tempDir, "nonexistent.env"))
+
+        // Apply configuration from secrets (should not throw)
+        assertDoesNotThrow {
+            KeystoreGenerationTask.createWithSecretsConfig(task, secretsConfig)
+        }
+
+        // Should use default configurations
+        val originalConfig = task.originalConfig.get()
+        val uploadConfig = task.uploadConfig.get()
+
+        assertEquals("Android Debug", originalConfig.companyName)
+        assertEquals("Android Release", uploadConfig.companyName)
+    }
+
+    @Test
+    fun `task configuration can be overridden programmatically`() {
+        // Create custom configurations
+        val customOriginalConfig = KeystoreConfig(
+            keystorePassword = "custom_original_pass",
+            keyAlias = "custom_original_alias",
+            keyPassword = "custom_original_key_pass",
+            companyName = "Custom Original Company",
+            keySize = 4096,
+            validity = 50
+        )
+
+        val customUploadConfig = KeystoreConfig(
+            keystorePassword = "custom_upload_pass",
+            keyAlias = "custom_upload_alias",
+            keyPassword = "custom_upload_key_pass",
+            companyName = "Custom Upload Company",
+            keySize = 4096,
+            validity = 50
+        )
+
+        // Apply custom configurations
+        task.originalConfig.set(customOriginalConfig)
+        task.uploadConfig.set(customUploadConfig)
+
+        // Verify configurations were applied
+        val appliedOriginalConfig = task.originalConfig.get()
+        val appliedUploadConfig = task.uploadConfig.get()
+
+        assertEquals("custom_original_pass", appliedOriginalConfig.keystorePassword)
+        assertEquals("custom_original_alias", appliedOriginalConfig.keyAlias)
+        assertEquals("Custom Original Company", appliedOriginalConfig.companyName)
+        assertEquals(4096, appliedOriginalConfig.keySize)
+        assertEquals(50, appliedOriginalConfig.validity)
+
+        assertEquals("custom_upload_pass", appliedUploadConfig.keystorePassword)
+        assertEquals("custom_upload_alias", appliedUploadConfig.keyAlias)
+        assertEquals("Custom Upload Company", appliedUploadConfig.companyName)
+        assertEquals(4096, appliedUploadConfig.keySize)
+        assertEquals(50, appliedUploadConfig.validity)
+    }
+
+    @Test
+    fun `individual keystore generation flags work correctly`() {
+        // Test generating only ORIGINAL keystore
+        task.generateOriginal.set(true)
+        task.generateUpload.set(false)
+
+        assertTrue(task.generateOriginal.get())
+        assertFalse(task.generateUpload.get())
+
+        // Test generating only UPLOAD keystore
+        task.generateOriginal.set(false)
+        task.generateUpload.set(true)
+
+        assertFalse(task.generateOriginal.get())
+        assertTrue(task.generateUpload.get())
+
+        // Test generating both keystores
+        task.generateOriginal.set(true)
+        task.generateUpload.set(true)
+
+        assertTrue(task.generateOriginal.get())
+        assertTrue(task.generateUpload.get())
+    }
+
+    @Test
+    fun `task validates keystore configurations`() {
+        // Test with valid configuration
+        val validConfig = KeystoreConfig(
+            keystorePassword = "validpassword",
+            keyAlias = "validalias",
+            keyPassword = "validkeypass",
+            keySize = 2048,
+            validity = 25,
+            country = "US"
+        )
+
+        val validationErrors = validConfig.validate()
+        assertTrue(validationErrors.isEmpty(), "Valid configuration should have no errors")
+
+        // Test with invalid configuration
+        val invalidConfig = KeystoreConfig(
+            keystorePassword = "", // Invalid: blank password
+            keyAlias = "", // Invalid: blank alias
+            keyPassword = "", // Invalid: blank key password
+            keySize = 512, // Invalid: too small key size
+            validity = -1, // Invalid: negative validity
+            country = "USA" // Invalid: country code too long
+        )
+
+        val invalidErrors = invalidConfig.validate()
+        assertFalse(invalidErrors.isEmpty(), "Invalid configuration should have errors")
+        assertTrue(invalidErrors.any { it.contains("password cannot be blank") })
+        assertTrue(invalidErrors.any { it.contains("alias cannot be blank") })
+        assertTrue(invalidErrors.any { it.contains("Key size must be at least 1024") })
+        assertTrue(invalidErrors.any { it.contains("Validity period must be positive") })
+        assertTrue(invalidErrors.any { it.contains("Country code must be exactly 2 characters") })
+    }
+
+    @Test
+    fun `distinguished name is formatted correctly`() {
+        val config = KeystoreConfig(
+            companyName = "Test Company",
+            department = "Engineering",
+            organization = "Test Org",
+            city = "San Francisco",
+            state = "California",
+            country = "US"
+        )
+
+        val expectedDN = "CN=Test Company, OU=Engineering, O=Test Org, L=San Francisco, ST=California, C=US"
+        assertEquals(expectedDN, config.distinguishedName)
+    }
+
+    @Test
+    fun `keystore file paths are constructed correctly`() {
+        val config = KeystoreConfig(
+            keystoreDir = File(tempDir, "test-keystores"),
+            originalKeystoreName = "debug.keystore",
+            uploadKeystoreName = "release.keystore"
+        )
+
+        val expectedOriginalPath = File(File(tempDir, "test-keystores"), "debug.keystore")
+        val expectedUploadPath = File(File(tempDir, "test-keystores"), "release.keystore")
+
+        assertEquals(expectedOriginalPath, config.originalKeystorePath)
+        assertEquals(expectedUploadPath, config.uploadKeystorePath)
+    }
+}

--- a/cmp-android/build.gradle.kts
+++ b/cmp-android/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     alias(libs.plugins.baselineprofile)
     alias(libs.plugins.roborazzi)
     alias(libs.plugins.aboutLibraries)
+    alias(libs.plugins.keystore.management)
     id("com.google.devtools.ksp")
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -378,6 +378,7 @@ detekt-convention = { id = "org.convention.detekt.plugin", version = "unspecifie
 git-hooks-convention = { id = "org.convention.git.hooks", version = "unspecified" }
 ktlint-convention = { id = "org.convention.ktlint.plugin", version = "unspecified" }
 spotless-convention = { id = "org.convention.spotless.plugin", version = "unspecified" }
+keystore-management = { id = "org.convention.keystore.management", version = "unspecified" }
 
 dependencyGuard = { id = "com.dropbox.dependency-guard", version.ref = "dependencyGuard" }
 moduleGraph = { id = "com.jraska.module.graph.assertion", version.ref = "moduleGraph" }


### PR DESCRIPTION
## 🎫 TICKET  
- [KMPPT-55](https://mifosforge.jira.com/browse/KMPPT-55)

Key changes:
- Introduced `KeystoreGenerationTask` for generating Android keystores via Gradle.
- Added support for keystore generation configurations using Gradle DSL and `secrets.env`.
- Added test cases for `KeystoreGenerationTask` to verify behavior and configuration loading.

[KMPPT-55]: https://mifosforge.jira.com/browse/KMPPT-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ