### PR TITLE
feat(build-logic): add SecretsEnvUpdateTask and its test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ secrets/
 
 # Sync Log File
 *.log
+/build-logic/convention/secrets-backup/

--- a/build-logic/convention/src/main/kotlin/org/convention/keystore/SecretsEnvUpdateTask.kt
+++ b/build-logic/convention/src/main/kotlin/org/convention/keystore/SecretsEnvUpdateTask.kt
@@ -1,0 +1,595 @@
+package org.convention.keystore
+
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import java.io.File
+import java.util.Base64
+
+/**
+ * Gradle task for updating secrets.env file with base64-encoded keystores
+ *
+ * This task implements the functionality specified in KMPPT-57:
+ * - Updates secrets.env with base64-encoded keystore content
+ * - Maintains proper heredoc formatting for multiline values
+ * - Preserves existing environment variables
+ * - Handles file creation and updates seamlessly
+ * - Provides base64 encoding functionality
+ * - Implements multiline value formatting with proper heredoc syntax
+ * - Includes file merge logic for existing variables
+ * - Validates output format for GitHub CLI compatibility
+ */
+@DisableCachingByDefault(because = "Secrets file updates should always run")
+abstract class SecretsEnvUpdateTask : BaseKeystoreTask() {
+
+    @get:InputFile
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.ABSOLUTE)
+    abstract val originalKeystoreFile: RegularFileProperty
+
+    @get:InputFile
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.ABSOLUTE)
+    abstract val uploadKeystoreFile: RegularFileProperty
+
+    @get:OutputFile
+    abstract val secretsEnvFile: RegularFileProperty
+
+    @get:Input
+    @get:Optional
+    abstract val additionalSecrets: MapProperty<String, String>
+
+    @get:Input
+    @get:Optional
+    abstract val preserveComments: Property<Boolean>
+
+    @get:Input
+    @get:Optional
+    abstract val createBackup: Property<Boolean>
+
+    @get:Input
+    @get:Optional
+    abstract val validateOutput: Property<Boolean>
+
+    @get:Input
+    @get:Optional
+    abstract val base64LineLength: Property<Int>
+
+    @get:Input
+    @get:Optional
+    abstract val useHeredocFormat: Property<Boolean>
+
+    @get:Input
+    @get:Optional
+    abstract val heredocDelimiter: Property<String>
+
+    init {
+        description = "Updates secrets.env file with base64-encoded keystores and maintains proper formatting"
+
+        // Set default values
+        preserveComments.convention(true)
+        createBackup.convention(true)
+        validateOutput.convention(true)
+        base64LineLength.convention(76)
+        useHeredocFormat.convention(true)
+        heredocDelimiter.convention("EOF")
+        secretsEnvFile.convention(project.layout.projectDirectory.file("secrets.env"))
+        additionalSecrets.convention(emptyMap())
+    }
+
+    @TaskAction
+    fun updateSecretsEnv() {
+        logInfo("Starting secrets.env file update task")
+
+        val secretsFile = secretsEnvFile.asFile.get()
+        val config = secretsConfig.get()
+
+        try {
+            // Validate inputs first
+            validateInputs()
+
+            // Create backup if requested and file exists
+            if (createBackup.get() && secretsFile.exists()) {
+                createBackupFile(secretsFile, config)
+            }
+
+            // Parse existing secrets.env file if it exists
+            val existingSecrets = if (secretsFile.exists()) {
+                parseExistingSecretsFile(secretsFile, config)
+            } else {
+                logInfo("Creating new secrets.env file")
+                ParsedSecretsData()
+            }
+
+            // Encode available keystores to base64
+            val keystoreSecrets = encodeKeystoresToBase64()
+
+            // Merge all secrets
+            val mergedSecrets = mergeSecrets(existingSecrets, keystoreSecrets)
+
+            // Ensure output directory exists
+            secretsFile.parentFile?.mkdirs()
+
+            // Write updated secrets.env file
+            writeSecretsFile(secretsFile, mergedSecrets, config)
+
+            // Validate output if requested
+            if (validateOutput.get()) {
+                validateSecretsFile(secretsFile, config)
+            }
+
+            logInfo("Secrets.env file updated successfully")
+            printUpdateSummary(keystoreSecrets, mergedSecrets)
+
+        } catch (e: Exception) {
+            logError("Failed to update secrets.env file: ${e.message}")
+            throw e
+        }
+    }
+
+    /**
+     * Data class to hold parsed secrets file content
+     */
+    private data class ParsedSecretsData(
+        val simpleSecrets: MutableMap<String, String> = mutableMapOf(),
+        val multilineSecrets: MutableMap<String, String> = mutableMapOf(),
+        val comments: MutableList<String> = mutableListOf(),
+        val originalOrder: MutableList<String> = mutableListOf(), // Track order of keys
+    )
+
+    /**
+     * Validates task inputs before execution
+     */
+    private fun validateInputs() {
+        val originalFile = originalKeystoreFile.orNull?.asFile
+        val uploadFile = uploadKeystoreFile.orNull?.asFile
+
+        // Check if at least one keystore file is provided and exists
+        val hasValidOriginal = originalFile?.exists() == true
+        val hasValidUpload = uploadFile?.exists() == true
+
+        if (!hasValidOriginal && !hasValidUpload) {
+            logWarning("No valid keystore files found. Task will only process existing secrets and additional secrets.")
+        }
+
+        // Validate file readability
+        originalFile?.let { file ->
+            if (file.exists() && !file.canRead()) {
+                throw IllegalStateException("Cannot read original keystore file: ${file.absolutePath}")
+            }
+        }
+
+        uploadFile?.let { file ->
+            if (file.exists() && !file.canRead()) {
+                throw IllegalStateException("Cannot read upload keystore file: ${file.absolutePath}")
+            }
+        }
+
+        // Validate base64 line length
+        if (base64LineLength.get() < 0) {
+            throw IllegalArgumentException("Base64 line length cannot be negative")
+        }
+
+        // Validate heredoc delimiter
+        if (useHeredocFormat.get() && heredocDelimiter.get().isBlank()) {
+            throw IllegalArgumentException("Heredoc delimiter cannot be blank when heredoc format is enabled")
+        }
+    }
+
+    /**
+     * Creates a backup of the existing secrets file
+     */
+    private fun createBackupFile(secretsFile: File, config: SecretsConfig) {
+        try {
+            val timestamp = System.currentTimeMillis()
+            val backupFile = config.getBackupFile(timestamp.toString())
+
+            if (!ensureDirectoryExists(backupFile.parentFile)) {
+                throw IllegalStateException("Failed to create backup directory: ${backupFile.parentFile.absolutePath}")
+            }
+
+            secretsFile.copyTo(backupFile, overwrite = true)
+            logInfo("Created backup: ${backupFile.absolutePath}")
+        } catch (e: Exception) {
+            logWarning("Failed to create backup: ${e.message}")
+            // Continue execution even if backup fails, unless it's critical
+        }
+    }
+
+    /**
+     * Parses existing secrets.env file while preserving structure and comments
+     */
+    private fun parseExistingSecretsFile(secretsFile: File, config: SecretsConfig): ParsedSecretsData {
+        try {
+            val parser = SecretsEnvParser(config)
+            val parseResult = parser.parseFile(secretsFile)
+
+            if (!parseResult.isValid) {
+                logWarning("Issues parsing existing secrets file:")
+                parseResult.errors.forEach { error -> logWarning("  - $error") }
+                logWarning("Continuing with partial parsing...")
+            }
+
+            val parsedData = ParsedSecretsData()
+
+            // Add simple secrets
+            parseResult.secrets.forEach { (key, value) ->
+                parsedData.simpleSecrets[key] = value
+                parsedData.originalOrder.add(key)
+            }
+
+            // Add multiline secrets
+            parseResult.multilineSecrets.forEach { (key, value) ->
+                parsedData.multilineSecrets[key] = value
+                parsedData.originalOrder.add(key)
+            }
+
+            // Preserve comments if requested
+            if (preserveComments.get()) {
+                parsedData.comments.addAll(parseResult.comments)
+            }
+
+            logInfo("Parsed existing secrets file: ${parsedData.simpleSecrets.size} simple + ${parsedData.multilineSecrets.size} multiline secrets")
+            return parsedData
+
+        } catch (e: Exception) {
+            logError("Failed to parse existing secrets file: ${e.message}")
+            logWarning("Starting with empty secrets data")
+            return ParsedSecretsData()
+        }
+    }
+
+    /**
+     * Encodes available keystores to base64 format
+     */
+    private fun encodeKeystoresToBase64(): Map<String, String> {
+        val keystoreSecrets = mutableMapOf<String, String>()
+        val config = secretsConfig.get()
+
+        // Encode original keystore if provided and exists
+        originalKeystoreFile.orNull?.asFile?.let { file ->
+            when {
+                !file.exists() -> {
+                    logInfo("Original keystore file not found: ${file.absolutePath}")
+                }
+
+                file.length() == 0L -> {
+                    logWarning("Original keystore file is empty: ${file.absolutePath}")
+                }
+
+                file.length() > 50 * 1024 * 1024 -> { // 50MB limit
+                    logWarning("Original keystore file is very large (${file.length() / (1024 * 1024)}MB): ${file.absolutePath}")
+                    val base64Content = encodeFileToBase64(file)
+                    keystoreSecrets[config.originalKeystoreFileKey] = base64Content
+                    logInfo("Encoded ORIGINAL keystore: ${file.name}")
+                }
+
+                else -> {
+                    val base64Content = encodeFileToBase64(file)
+                    keystoreSecrets[config.originalKeystoreFileKey] = base64Content
+                    logInfo("Encoded ORIGINAL keystore: ${file.name}")
+                }
+            }
+        }
+
+        // Encode upload keystore if provided and exists
+        uploadKeystoreFile.orNull?.asFile?.let { file ->
+            when {
+                !file.exists() -> {
+                    logInfo("Upload keystore file not found: ${file.absolutePath}")
+                }
+
+                file.length() == 0L -> {
+                    logWarning("Upload keystore file is empty: ${file.absolutePath}")
+                }
+
+                file.length() > 50 * 1024 * 1024 -> { // 50MB limit
+                    logWarning("Upload keystore file is very large (${file.length() / (1024 * 1024)}MB): ${file.absolutePath}")
+                    val base64Content = encodeFileToBase64(file)
+                    keystoreSecrets[config.uploadKeystoreFileKey] = base64Content
+                    logInfo("Encoded UPLOAD keystore: ${file.name}")
+                }
+
+                else -> {
+                    val base64Content = encodeFileToBase64(file)
+                    keystoreSecrets[config.uploadKeystoreFileKey] = base64Content
+                    logInfo("Encoded UPLOAD keystore: ${file.name}")
+                }
+            }
+        }
+
+        return keystoreSecrets
+    }
+
+    /**
+     * Encodes a file to base64 with proper line wrapping and error handling
+     */
+    private fun encodeFileToBase64(file: File): String {
+        try {
+            val bytes = file.readBytes()
+            val base64String = Base64.getEncoder().encodeToString(bytes)
+
+            return if (base64LineLength.get() > 0) {
+                // Wrap lines to specified length for better readability
+                base64String.chunked(base64LineLength.get()).joinToString("\n")
+            } else {
+                base64String
+            }
+        } catch (e: Exception) {
+            logError("Failed to encode file to base64: ${file.absolutePath}")
+            throw IllegalStateException("Failed to encode keystore file: ${e.message}", e)
+        }
+    }
+
+    /**
+     * Merges existing secrets with new keystore secrets and additional secrets
+     */
+    private fun mergeSecrets(
+        existingSecrets: ParsedSecretsData,
+        keystoreSecrets: Map<String, String>,
+    ): ParsedSecretsData {
+        val mergedSecrets = ParsedSecretsData()
+
+        // Copy existing secrets (preserving order)
+        existingSecrets.originalOrder.forEach { key ->
+            when {
+                existingSecrets.simpleSecrets.containsKey(key) -> {
+                    mergedSecrets.simpleSecrets[key] = existingSecrets.simpleSecrets[key]!!
+                    mergedSecrets.originalOrder.add(key)
+                }
+
+                existingSecrets.multilineSecrets.containsKey(key) -> {
+                    mergedSecrets.multilineSecrets[key] = existingSecrets.multilineSecrets[key]!!
+                    mergedSecrets.originalOrder.add(key)
+                }
+            }
+        }
+
+        // Add or update keystore secrets (as multiline)
+        keystoreSecrets.forEach { (key, value) ->
+            if (mergedSecrets.originalOrder.contains(key)) {
+                // Update existing keystore secret
+                mergedSecrets.multilineSecrets[key] = value
+                // Remove from simple secrets if it was there before
+                mergedSecrets.simpleSecrets.remove(key)
+                logInfo("Updated existing keystore secret: $key")
+            } else {
+                // Add new keystore secret
+                mergedSecrets.multilineSecrets[key] = value
+                mergedSecrets.originalOrder.add(key)
+                logInfo("Added new keystore secret: $key")
+            }
+        }
+
+        // Add additional secrets
+        additionalSecrets.get().forEach { (key, value) ->
+            if (!mergedSecrets.originalOrder.contains(key)) {
+                mergedSecrets.simpleSecrets[key] = value
+                mergedSecrets.originalOrder.add(key)
+                logInfo("Added additional secret: $key")
+            } else {
+                logWarning("Additional secret '$key' conflicts with existing secret, skipping")
+            }
+        }
+
+        // Preserve comments
+        mergedSecrets.comments.addAll(existingSecrets.comments)
+
+        return mergedSecrets
+    }
+
+    /**
+     * Writes the merged secrets to the secrets.env file with proper formatting
+     */
+    private fun writeSecretsFile(secretsFile: File, secrets: ParsedSecretsData, config: SecretsConfig) {
+        try {
+            secretsFile.printWriter().use { writer ->
+                // Write header comment if it's a new file or no comments exist
+                if (!secretsFile.exists() || secrets.comments.isEmpty()) {
+                    writer.println("# GitHub Secrets Environment File")
+                    writer.println("# Generated by Gradle Keystore Management Plugin")
+                    writer.println("# Format: KEY=VALUE")
+                    writer.println("# Use <<EOF and EOF to denote multiline values")
+                    writer.println("# Run this command to format these secrets: dos2unix secrets.env")
+                    writer.println()
+                }
+
+                // Write preserved comments
+                if (preserveComments.get() && secrets.comments.isNotEmpty()) {
+                    secrets.comments.forEach { comment ->
+                        writer.println(comment)
+                    }
+                    writer.println()
+                }
+
+                // Write secrets in preserved order
+                secrets.originalOrder.forEach { key ->
+                    when {
+                        secrets.simpleSecrets.containsKey(key) -> {
+                            val value = secrets.simpleSecrets[key]!!
+                            writer.println("$key=${quoteValueIfNeeded(value)}")
+                        }
+
+                        secrets.multilineSecrets.containsKey(key) -> {
+                            val value = secrets.multilineSecrets[key]!!
+                            if (useHeredocFormat.get()) {
+                                writer.println("$key<<${heredocDelimiter.get()}")
+                                writer.println(value)
+                                writer.println(heredocDelimiter.get())
+                            } else {
+                                // Fallback to escaped format
+                                val escapedValue = value.replace("\n", "\\n").replace("\"", "\\\"")
+                                writer.println("$key=\"$escapedValue\"")
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            throw IllegalStateException("Failed to write secrets file: ${secretsFile.absolutePath}", e)
+        }
+    }
+
+    /**
+     * Quotes value if it contains spaces or special characters
+     */
+    private fun quoteValueIfNeeded(value: String): String {
+        return if (value.contains(" ") || value.contains("\t") || value.contains("\n") || value.contains("\"")) {
+            // Escape quotes in the value
+            val escapedValue = value.replace("\"", "\\\"")
+            "\"$escapedValue\""
+        } else {
+            value
+        }
+    }
+
+    /**
+     * Validates the generated secrets file for GitHub CLI compatibility
+     */
+    private fun validateSecretsFile(secretsFile: File, config: SecretsConfig) {
+        logInfo("Validating secrets.env file format...")
+
+        try {
+            val parser = SecretsEnvParser(config)
+            val parseResult = parser.parseFile(secretsFile)
+
+            if (parseResult.isValid) {
+                logInfo("✅ Secrets file validation passed")
+
+                // Additional GitHub CLI compatibility checks
+                val allSecrets = parseResult.allSecrets
+                val warnings = mutableListOf<String>()
+
+                // Check for potential GitHub CLI issues
+                allSecrets.forEach { (key, value) ->
+                    when {
+                        key.contains(" ") -> warnings.add("Key '$key' contains spaces")
+                        key.contains("-") -> warnings.add("Key '$key' contains hyphens (consider using underscores)")
+                        !key.matches(Regex("[A-Z_][A-Z0-9_]*")) -> warnings.add("Key '$key' doesn't follow UPPER_SNAKE_CASE convention")
+                        value.isEmpty() -> warnings.add("Key '$key' has empty value")
+                        key.length > 100 -> warnings.add("Key '$key' is very long (${key.length} chars)")
+                        value.length > 1024 * 1024 -> warnings.add("Value for '$key' is very large (${value.length / 1024}KB)")
+                    }
+                }
+
+                if (warnings.isNotEmpty()) {
+                    logWarning("GitHub CLI compatibility warnings:")
+                    warnings.forEach { warning -> logWarning("  - $warning") }
+                } else {
+                    logInfo("✅ No GitHub CLI compatibility issues found")
+                }
+
+            } else {
+                logError("❌ Secrets file validation failed:")
+                parseResult.errors.forEach { error -> logError("  - $error") }
+                throw IllegalStateException("Generated secrets.env file is invalid: ${parseResult.errors.joinToString("/")} ")
+            }
+        } catch (e: Exception) {
+            logError("Failed to validate secrets file: ${e.message}")
+            throw e
+        }
+    }
+
+    /**
+     * Prints a summary of the update operation
+     */
+    private fun printUpdateSummary(keystoreSecrets: Map<String, String>, finalSecrets: ParsedSecretsData) {
+        logInfo("")
+        logInfo("=".repeat(66))
+        logInfo("                    UPDATE SUMMARY")
+        logInfo("=".repeat(66))
+
+        if (keystoreSecrets.isNotEmpty()) {
+            logInfo("Keystore secrets added/updated:")
+            keystoreSecrets.forEach { (key, _) ->
+                logInfo("  ✅ $key")
+            }
+        } else {
+            logInfo("No keystore secrets processed")
+        }
+
+        val totalSecrets = finalSecrets.simpleSecrets.size + finalSecrets.multilineSecrets.size
+        logInfo("")
+        logInfo("Total secrets in file: $totalSecrets")
+        logInfo("  - Simple secrets: ${finalSecrets.simpleSecrets.size}")
+        logInfo("  - Multiline secrets: ${finalSecrets.multilineSecrets.size}")
+
+        if (preserveComments.get() && finalSecrets.comments.isNotEmpty()) {
+            logInfo("  - Comments preserved: ${finalSecrets.comments.size}")
+        }
+
+        logInfo("")
+        logInfo("File location: ${secretsEnvFile.asFile.get().absolutePath}")
+
+        if (createBackup.get()) {
+            logInfo("Backup directory: ${secretsConfig.get().backupDir.absolutePath}")
+        }
+
+        logInfo("")
+        logInfo("✅ Secrets.env file ready for GitHub CLI integration")
+    }
+
+    companion object {
+        /**
+         * Creates a task configured to update secrets from keystore generation task
+         */
+        fun createFromKeystoreGeneration(
+            task: SecretsEnvUpdateTask,
+            keystoreGenerationTask: KeystoreGenerationTask,
+            secretsConfig: SecretsConfig = SecretsConfig(),
+        ) {
+            // Set keystore files from generation task output
+            val originalKeystoreFile = keystoreGenerationTask.outputDirectory.file(
+                keystoreGenerationTask.originalConfig.map { it.originalKeystoreName },
+            )
+            val uploadKeystoreFile = keystoreGenerationTask.outputDirectory.file(
+                keystoreGenerationTask.uploadConfig.map { it.uploadKeystoreName },
+            )
+
+            task.originalKeystoreFile.set(originalKeystoreFile)
+            task.uploadKeystoreFile.set(uploadKeystoreFile)
+            task.secretsConfig.set(secretsConfig)
+
+            // Make this task depend on keystore generation
+            task.dependsOn(keystoreGenerationTask)
+        }
+
+        /**
+         * Creates a task with explicit keystore file paths
+         */
+        fun createWithKeystoreFiles(
+            task: SecretsEnvUpdateTask,
+            originalKeystoreFile: File?,
+            uploadKeystoreFile: File?,
+            secretsConfig: SecretsConfig = SecretsConfig(),
+        ) {
+            originalKeystoreFile?.let { file ->
+                task.originalKeystoreFile.set(file)
+            }
+            uploadKeystoreFile?.let { file ->
+                task.uploadKeystoreFile.set(file)
+            }
+            task.secretsConfig.set(secretsConfig)
+        }
+
+        /**
+         * Creates a task with additional environment secrets
+         */
+        fun createWithAdditionalSecrets(
+            task: SecretsEnvUpdateTask,
+            additionalSecrets: Map<String, String>,
+            secretsConfig: SecretsConfig = SecretsConfig(),
+        ) {
+            task.additionalSecrets.set(additionalSecrets)
+            task.secretsConfig.set(secretsConfig)
+        }
+    }
+}

--- a/build-logic/convention/src/test/kotlin/org/convention/keystore/SecretsEnvUpdateTaskTest.kt
+++ b/build-logic/convention/src/test/kotlin/org/convention/keystore/SecretsEnvUpdateTaskTest.kt
@@ -1,0 +1,450 @@
+package org.convention.keystore
+
+import org.gradle.internal.impldep.org.testng.Assert.assertEquals
+import org.gradle.internal.impldep.org.testng.Assert.assertTrue
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import java.util.Base64
+
+/**
+ * Test class for SecretsEnvUpdateTask
+ * 
+ * Tests various update scenarios as required by KMPPT-57:
+ * - secrets.env file creation and updates
+ * - Base64 encoding functionality  
+ * - Multiline value formatting with heredoc
+ * - File merge logic for existing variables
+ * - Output format validation for GitHub CLI compatibility
+ */
+class SecretsEnvUpdateTaskTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var project: org.gradle.api.Project
+    private lateinit var task: SecretsEnvUpdateTask
+    private lateinit var secretsFile: File
+    private lateinit var originalKeystoreFile: File
+    private lateinit var uploadKeystoreFile: File
+
+    @BeforeEach
+    fun setup() {
+        project = ProjectBuilder.builder()
+            .withProjectDir(tempDir.toFile())
+            .build()
+
+        task = project.tasks.create("testUpdateSecretsEnv", SecretsEnvUpdateTask::class.java)
+        
+        secretsFile = tempDir.resolve("secrets.env").toFile()
+        originalKeystoreFile = tempDir.resolve("original.keystore").toFile()
+        uploadKeystoreFile = tempDir.resolve("upload.keystore").toFile()
+
+        // Configure task
+        task.secretsEnvFile.set(secretsFile)
+        task.originalKeystoreFile.set(originalKeystoreFile)
+        task.uploadKeystoreFile.set(uploadKeystoreFile)
+        task.secretsConfig.set(SecretsConfig())
+    }
+
+    @Test
+    fun `test creates new secrets file when none exists`() {
+        // Arrange
+        createTestKeystoreFiles()
+
+        // Act
+        task.updateSecretsEnv()
+
+        // Assert
+        assertTrue(secretsFile.exists(), "Secrets file should be created")
+        val content = secretsFile.readText()
+        
+        assertTrue(content.contains("# GitHub Secrets Environment File"), "Should contain header comment")
+        assertTrue(content.contains("ORIGINAL_KEYSTORE_FILE<<EOF"), "Should contain original keystore heredoc")
+        assertTrue(content.contains("UPLOAD_KEYSTORE_FILE<<EOF"), "Should contain upload keystore heredoc")
+        assertTrue(content.contains("EOF"), "Should contain EOF delimiters")
+    }
+
+    @Test
+    fun `test updates existing secrets file preserving variables`() {
+        // Arrange
+        createTestKeystoreFiles()
+        createExistingSecretsFile()
+
+        // Act
+        task.updateSecretsEnv()
+
+        // Assert
+        val content = secretsFile.readText()
+        
+        // Check that existing variables are preserved
+        assertTrue(content.contains("EXISTING_SIMPLE_VAR=existing_value"), "Should preserve existing simple variable")
+        assertTrue(content.contains("ANOTHER_VAR=\"value with spaces\""), "Should preserve quoted variable")
+        
+        // Check that keystore variables are updated
+        assertTrue(content.contains("ORIGINAL_KEYSTORE_FILE<<EOF"), "Should update original keystore")
+        assertTrue(content.contains("UPLOAD_KEYSTORE_FILE<<EOF"), "Should update upload keystore")
+    }
+
+    @Test
+    fun `test preserves comments when updating file`() {
+        // Arrange
+        createTestKeystoreFiles()
+        createSecretsFileWithComments()
+        task.preserveComments.set(true)
+
+        // Act
+        task.updateSecretsEnv()
+
+        // Assert
+        val content = secretsFile.readText()
+        assertTrue(content.contains("# This is a custom comment"), "Should preserve custom comments")
+        assertTrue(content.contains("# Another important comment"), "Should preserve multiple comments")
+    }
+
+    @Test
+    fun `test base64 encoding produces valid output`() {
+        // Arrange
+        createTestKeystoreFiles()
+
+        // Act
+        task.updateSecretsEnv()
+
+        // Assert
+        val content = secretsFile.readText()
+        
+        // Extract base64 content
+        val originalB64 = extractBase64Content(content, "ORIGINAL_KEYSTORE_FILE")
+        val uploadB64 = extractBase64Content(content, "UPLOAD_KEYSTORE_FILE")
+
+        // Verify base64 is valid
+        assertTrue(isValidBase64(originalB64), "Original keystore base64 should be valid")
+        assertTrue(isValidBase64(uploadB64), "Upload keystore base64 should be valid")
+
+        // Verify decoded content matches original
+        val originalDecoded = Base64.getDecoder().decode(originalB64.replace("\n", ""))
+        val uploadDecoded = Base64.getDecoder().decode(uploadB64.replace("\n", ""))
+
+        assertEquals(originalKeystoreFile.readBytes().toList(), originalDecoded.toList(), 
+            "Decoded original keystore should match original file")
+        assertEquals(uploadKeystoreFile.readBytes().toList(), uploadDecoded.toList(), 
+            "Decoded upload keystore should match original file")
+    }
+
+    @Test
+    fun `test heredoc formatting is correct`() {
+        // Arrange
+        createTestKeystoreFiles()
+        task.useHeredocFormat.set(true)
+        task.heredocDelimiter.set("EOF")
+
+        // Act
+        task.updateSecretsEnv()
+
+        // Assert
+        val content = secretsFile.readText()
+        val lines = content.lines()
+
+        // Find heredoc blocks
+        val originalStart = lines.indexOfFirst { it == "ORIGINAL_KEYSTORE_FILE<<EOF" }
+        val uploadStart = lines.indexOfFirst { it == "UPLOAD_KEYSTORE_FILE<<EOF" }
+        
+        // Find the corresponding EOF markers after each start
+        val originalEnd = if (originalStart >= 0) {
+            lines.drop(originalStart + 1).indexOfFirst { it == "EOF" }.let { 
+                if (it >= 0) it + originalStart + 1 else -1 
+            }
+        } else -1
+        
+        val uploadEnd = if (uploadStart >= 0) {
+            lines.drop(uploadStart + 1).indexOfFirst { it == "EOF" }.let { 
+                if (it >= 0) it + uploadStart + 1 else -1 
+            }
+        } else -1
+
+        assertTrue(originalStart >= 0, "Should find original keystore heredoc start")
+        assertTrue(originalEnd > originalStart, "Should find original keystore heredoc end")
+        assertTrue(uploadStart >= 0, "Should find upload keystore heredoc start")
+        assertTrue(uploadEnd > uploadStart, "Should find upload keystore heredoc end")
+
+        // Verify content between heredoc markers is base64
+        val originalB64Lines = lines.subList(originalStart + 1, originalEnd)
+        assertTrue(originalB64Lines.isNotEmpty(), "Should have base64 content in original heredoc")
+        assertTrue(originalB64Lines.all { isValidBase64Line(it) }, "All lines in original heredoc should be valid base64")
+    }
+
+    @Test
+    fun `test line length wrapping for base64 content`() {
+        // Arrange
+        createTestKeystoreFiles()
+        task.base64LineLength.set(50) // Shorter line length for testing
+
+        // Act
+        task.updateSecretsEnv()
+
+        // Assert
+        val content = secretsFile.readText()
+        val originalB64 = extractBase64Content(content, "ORIGINAL_KEYSTORE_FILE")
+        val lines = originalB64.split("\n")
+
+        // Verify line length wrapping
+        lines.forEach { line ->
+            assertTrue(line.length <= 50, "Base64 lines should not exceed configured length: '${line}' (length: ${line.length})")
+        }
+    }
+
+    @Test
+    fun `test creates backup when enabled`() {
+        // Arrange
+        createTestKeystoreFiles()
+        createExistingSecretsFile()
+        task.createBackup.set(true)
+        
+        // Configure backup directory to be in temp directory
+        val customSecretsConfig = SecretsConfig(
+            backupDir = tempDir.resolve("secrets-backup").toFile()
+        )
+        task.secretsConfig.set(customSecretsConfig)
+
+        // Act
+        task.updateSecretsEnv()
+
+        // Assert
+        val backupDir = tempDir.resolve("secrets-backup").toFile()
+        assertTrue(backupDir.exists(), "Backup directory should be created")
+        assertTrue(backupDir.listFiles()?.any { it.name.startsWith("secrets.env.backup") } == true, 
+            "Backup file should be created")
+    }
+
+    @Test
+    fun `test validates output format for GitHub CLI compatibility`() {
+        // Arrange
+        createTestKeystoreFiles()
+        task.validateOutput.set(true)
+
+        // Act & Assert (should not throw exception)
+        task.updateSecretsEnv()
+
+        // Verify file can be parsed successfully
+        val parser = SecretsEnvParser(task.secretsConfig.get())
+        val parseResult = parser.parseFile(secretsFile)
+        assertTrue(parseResult.isValid, "Generated file should be valid: ${parseResult.errors}")
+    }
+
+    @Test
+    fun `test handles missing keystore files gracefully`() {
+        // Arrange - don't create keystore files, just set non-existent paths
+        task.originalKeystoreFile.set(File(tempDir.toFile(), "nonexistent.keystore"))
+        task.uploadKeystoreFile.set(File(tempDir.toFile(), "alsoNonexistent.keystore"))
+
+        // Act & Assert (should not throw exception)
+        task.updateSecretsEnv()
+
+        // Verify file is still created with proper content
+        assertTrue(secretsFile.exists(), "Secrets file should still be created")
+        val content = secretsFile.readText()
+        assertTrue(content.contains("# GitHub Secrets Environment File"), "Should contain header")
+        
+        // Should not contain any keystore secrets since files don't exist
+        assertTrue(!content.contains("ORIGINAL_KEYSTORE_FILE<<EOF"), "Should not contain original keystore")
+        assertTrue(!content.contains("UPLOAD_KEYSTORE_FILE<<EOF"), "Should not contain upload keystore")
+    }
+
+    @Test
+    fun `test additional secrets are included`() {
+        // Arrange
+        createTestKeystoreFiles()
+        val additionalSecrets = mapOf(
+            "CUSTOM_SECRET" to "custom_value",
+            "ANOTHER_SECRET" to "another_value"
+        )
+        task.additionalSecrets.set(additionalSecrets)
+
+        // Act
+        task.updateSecretsEnv()
+
+        // Assert
+        val content = secretsFile.readText()
+        assertTrue(content.contains("CUSTOM_SECRET=custom_value"), "Should include custom secret")
+        assertTrue(content.contains("ANOTHER_SECRET=another_value"), "Should include another secret")
+    }
+
+    @Test
+    fun `test multiline values use proper escaping when heredoc disabled`() {
+        // Arrange
+        createTestKeystoreFiles()
+        task.useHeredocFormat.set(false)
+        task.heredocDelimiter.set("EOF")
+        
+        // Verify the property is set correctly before execution
+        assertEquals(false, task.useHeredocFormat.get(), "useHeredocFormat should be false")
+
+        // Act
+        task.updateSecretsEnv()
+
+        // Assert
+        val content = secretsFile.readText()
+        
+        // Check for the specific patterns we expect when heredoc is disabled
+        val hasOriginalHeredoc = content.contains("ORIGINAL_KEYSTORE_FILE<<EOF")
+        val hasUploadHeredoc = content.contains("UPLOAD_KEYSTORE_FILE<<EOF")
+        val hasOriginalQuoted = content.contains("ORIGINAL_KEYSTORE_FILE=\"")
+        val hasUploadQuoted = content.contains("UPLOAD_KEYSTORE_FILE=\"")
+        
+        // Debug output if test fails
+        if (hasOriginalHeredoc || hasUploadHeredoc || !hasOriginalQuoted || !hasUploadQuoted) {
+            println("=== DEBUG: Unexpected content format ===")
+            println("Has original heredoc: $hasOriginalHeredoc (should be false)")
+            println("Has upload heredoc: $hasUploadHeredoc (should be false)")
+            println("Has original quoted: $hasOriginalQuoted (should be true)")
+            println("Has upload quoted: $hasUploadQuoted (should be true)")
+            println("Content:")
+            println(content)
+            println("=== END DEBUG ===")
+        }
+        
+        // Main assertions
+        assertTrue(!hasOriginalHeredoc, "Should not contain original keystore heredoc start")
+        assertTrue(!hasUploadHeredoc, "Should not contain upload keystore heredoc start")
+        assertTrue(hasOriginalQuoted, "Should use quoted format for original keystore")
+        assertTrue(hasUploadQuoted, "Should use quoted format for upload keystore")
+    }
+
+    @Test
+    fun `test handles large keystore files appropriately`() {
+        // Arrange - create a larger test file
+        val largeContent = "large keystore content ".repeat(1000)
+        originalKeystoreFile.writeBytes(largeContent.toByteArray())
+        uploadKeystoreFile.writeBytes("smaller content".toByteArray())
+
+        // Act
+        task.updateSecretsEnv()
+
+        // Assert - should still work but log warnings for large files
+        assertTrue(secretsFile.exists(), "Secrets file should be created")
+        val content = secretsFile.readText()
+        assertTrue(content.contains("ORIGINAL_KEYSTORE_FILE<<EOF"), "Should contain original keystore")
+        assertTrue(content.contains("UPLOAD_KEYSTORE_FILE<<EOF"), "Should contain upload keystore")
+    }
+
+    @Test
+    fun `test validation detects GitHub CLI compatibility issues`() {
+        // Arrange
+        createTestKeystoreFiles()
+        val problematicSecrets = mapOf(
+            "secret-with-dash" to "value1",
+            "secret with space" to "value2",
+            "lowercaseSecret" to "value3"
+        )
+        task.additionalSecrets.set(problematicSecrets)
+        task.validateOutput.set(true)
+
+        // Act & Assert - should complete but log warnings
+        task.updateSecretsEnv()
+        
+        // Verify file contains the problematic secrets
+        val content = secretsFile.readText()
+        assertTrue(content.contains("secret-with-dash=value1"), "Should include dash secret")
+        assertTrue(content.contains("secret with space"), "Should include space secret")
+        assertTrue(content.contains("lowercaseSecret=value3"), "Should include lowercase secret")
+    }
+
+    @Test
+    fun `test empty keystore files are handled gracefully`() {
+        // Arrange - create empty keystore files
+        originalKeystoreFile.writeBytes(byteArrayOf())
+        uploadKeystoreFile.writeBytes(byteArrayOf())
+
+        // Act
+        task.updateSecretsEnv()
+
+        // Assert - should create file but log warnings about empty files
+        assertTrue(secretsFile.exists(), "Secrets file should be created")
+        val content = secretsFile.readText()
+        assertTrue(content.contains("# GitHub Secrets Environment File"), "Should contain header")
+        
+        // Empty files should not produce keystore secrets
+        assertTrue(!content.contains("ORIGINAL_KEYSTORE_FILE<<EOF"), "Should not contain original keystore")
+        assertTrue(!content.contains("UPLOAD_KEYSTORE_FILE<<EOF"), "Should not contain upload keystore")
+    }
+
+    // Helper methods
+
+    private fun createTestKeystoreFiles() {
+        // Create dummy keystore files with some content
+        originalKeystoreFile.writeBytes("dummy original keystore content".toByteArray())
+        uploadKeystoreFile.writeBytes("dummy upload keystore content for testing".toByteArray())
+    }
+
+    private fun createExistingSecretsFile() {
+        secretsFile.writeText("""
+            # Existing secrets file
+            EXISTING_SIMPLE_VAR=existing_value
+            ANOTHER_VAR="value with spaces"
+            
+            ORIGINAL_KEYSTORE_FILE<<EOF
+            old_base64_content_here
+            EOF
+            
+            UPLOAD_KEYSTORE_FILE<<EOF
+            old_upload_content_here
+            EOF
+        """.trimIndent())
+    }
+
+    private fun createSecretsFileWithComments() {
+        secretsFile.writeText("""
+            # This is a custom comment
+            EXISTING_VAR=value
+            # Another important comment
+            
+            ORIGINAL_KEYSTORE_FILE<<EOF
+            old_content
+            EOF
+        """.trimIndent())
+    }
+
+    private fun extractBase64Content(content: String, key: String): String {
+        val lines = content.lines()
+        val startIndex = lines.indexOfFirst { it == "$key<<EOF" }
+        
+        if (startIndex >= 0) {
+            val endIndex = lines.drop(startIndex + 1).indexOfFirst { it == "EOF" }.let { 
+                if (it >= 0) it + startIndex + 1 else -1 
+            }
+            
+            if (endIndex > startIndex) {
+                return lines.subList(startIndex + 1, endIndex).joinToString("\n")
+            }
+        }
+        return ""
+    }
+
+    private fun isValidBase64(content: String): Boolean {
+        return try {
+            Base64.getDecoder().decode(content.replace("\n", ""))
+            true
+        } catch (e: IllegalArgumentException) {
+            false
+        }
+    }
+
+    private fun isValidBase64Line(line: String): Boolean {
+        return line.matches(Regex("[A-Za-z0-9+/=]*"))
+    }
+
+    @Test
+    fun `test task property configuration works correctly`() {
+        // Test that we can set and read task properties correctly
+        task.useHeredocFormat.set(false)
+        task.heredocDelimiter.set("CUSTOM_EOF")
+        task.base64LineLength.set(64)
+        
+        assertEquals(false, task.useHeredocFormat.get(), "Should be able to set useHeredocFormat to false")
+        assertEquals("CUSTOM_EOF", task.heredocDelimiter.get(), "Should be able to set custom delimiter")
+        assertEquals(64, task.base64LineLength.get(), "Should be able to set custom line length")
+    }
+}


### PR DESCRIPTION
## 🎫 TICKET
- [KMPPT-57](https://mifosforge.jira.com/browse/KMPPT-57)


### Key Changes
- Implement SecretsEnvUpdateTask to manage secrets.env file updates
  - Enables base64 encoding of keystore files and multiline value formatting
  - Supports merging existing secrets, preserving comments, and creating backups
  - Ensures GitHub CLI compatibility for generated secrets
- Add comprehensive test suite for SecretsEnvUpdateTask
  - Includes tests for file creation, update scenarios, backup functionality, and validation

[KMPPT-57]: https://mifosforge.jira.com/browse/KMPPT-57?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ