### PR TITLE
fix(home): correct month index for date calculations in TasksViewModel

### DIFF
--- a/feature/home/src/commonMain/kotlin/org/mifos/feature/home/tasks/TasksViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/org/mifos/feature/home/tasks/TasksViewModel.kt
@@ -160,12 +160,12 @@ class TasksViewModel(
      */
     private fun updateDaysInMonth() {
         val daysInCurrentMonth =
-            getDaysInMonth(year = selectedYear, month = selectedMonthIndex) // month is 1-based
+            getDaysInMonth(year = selectedYear, month = selectedMonthIndex + 1)
 
         val weekdaysAndDaysInSelectedMonth = mutableListOf<Pair<String, String>>()
 
         for (day in 1..daysInCurrentMonth) {
-            val date = LocalDate(selectedYear, selectedMonthIndex, day)
+            val date = LocalDate(selectedYear, selectedMonthIndex + 1, day)
             val weekday = shortWeekdayNames[date.dayOfWeek]
 
             weekdaysAndDaysInSelectedMonth.add(weekday!! to day.toString())


### PR DESCRIPTION
The `getDaysInMonth` and `LocalDate` constructors were using a 0-based month index (`selectedMonthIndex`), while they expect a 1-based month. This has been corrected by adding 1 to `selectedMonthIndex` in the calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed date calculation issue in the tasks feature to ensure accurate month and day handling, improving calendar reliability and preventing potential scheduling inconsistencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->