### PR TITLE
Remove default value from Room value parameter

### DIFF
--- a/core-base/database/src/commonMain/kotlin/template/core/base/database/Room.kt
+++ b/core-base/database/src/commonMain/kotlin/template/core/base/database/Room.kt
@@ -506,7 +506,7 @@ expect annotation class TypeConverters(
      *
      * @return The list of classes that contains the converter methods.
      */
-    vararg val value: KClass<*> = [],
+    vararg val value: KClass<*>,
 
     /**
      * Configure whether Room can use various built in converters for common types. See


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Annotation parameter now requires explicit values; default empty parameter no longer supported. Update existing calls to supply required values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->