### PR TITLE
feat(network): enable HTTP error validation in Ktor HttpClient

### DIFF
--- a/core-base/network/src/commonMain/kotlin/template/core/base/network/KtorHttpClient.kt
+++ b/core-base/network/src/commonMain/kotlin/template/core/base/network/KtorHttpClient.kt
@@ -159,4 +159,8 @@ fun setupDefaultHttpClient(
     install(ContentNegotiation) {
         json(jsonConfig)
     }
+
+    // Enable response validation to throw exceptions for non-2xx responses
+    // This allows proper error handling with ClientRequestException (4xx) and ServerResponseException (5xx)
+    expectSuccess = true
 }


### PR DESCRIPTION
## Summary
- Add `expectSuccess = true` to the default HttpClient configuration
- This enables Ktor's response validation which throws exceptions for non-2xx responses

## Changes
- `ClientRequestException` is thrown for 4xx responses
- `ServerResponseException` is thrown for 5xx responses

## Why
Without this setting, non-2xx responses are silently returned as successful responses, making proper error handling impossible. The response body would be attempted to be parsed as the success type, often leading to confusing deserialization errors instead of proper HTTP error handling.

## Test plan
- [x] Verify 4xx responses throw `ClientRequestException`
- [x] Verify 5xx responses throw `ServerResponseException`
- [x] Existing API calls continue to work for 2xx responses

🤖 Generated with [Claude Code](https://claude.ai/code)