### PR TITLE
feat(ui): add launchIO helper to BaseViewModel for background operations

### DIFF
--- a/core-base/ui/src/commonMain/kotlin/template/core/base/ui/BaseViewModel.kt
+++ b/core-base/ui/src/commonMain/kotlin/template/core/base/ui/BaseViewModel.kt
@@ -11,6 +11,10 @@ package template.core.base.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.flow.Flow
@@ -96,5 +100,17 @@ abstract class BaseViewModel<S, E, A>(
      */
     protected fun sendEvent(event: E) {
         viewModelScope.launch { eventChannel.send(event) }
+    }
+
+    /**
+     * Launches a coroutine on [Dispatchers.IO] for network or database operations.
+     * Use this instead of `viewModelScope.launch` for any I/O-bound work to avoid
+     * blocking the main thread and causing UI freezes.
+     *
+     * @param block The suspending block to execute on the IO dispatcher.
+     * @return The [Job] representing the coroutine.
+     */
+    protected fun launchIO(block: suspend CoroutineScope.() -> Unit): Job {
+        return viewModelScope.launch(Dispatchers.IO, block = block)
     }
 }


### PR DESCRIPTION
## Summary

- Add `launchIO` helper function to `BaseViewModel` that launches coroutines on `Dispatchers.IO`
- Prevents UI freezing when performing network or database operations by ensuring they run on background threads

## Problem

When using `viewModelScope.launch { }` without specifying a dispatcher, coroutines run on `Dispatchers.Main` by default. This causes the UI to freeze while waiting for API responses, even if the repository layer uses `withContext(Dispatchers.IO)`, because the coroutine resumes on the Main thread.

## Solution

Add a `launchIO` helper function that all ViewModels inheriting from `BaseViewModel` can use:

```kotlin
protected fun launchIO(block: suspend CoroutineScope.() -> Unit): Job {
    return viewModelScope.launch(Dispatchers.IO, block = block)
}
```

## Usage

Replace:
```kotlin
viewModelScope.launch {
    val result = repository.makeApiCall()
    // UI frozen while waiting
}
```

With:
```kotlin
launchIO {
    val result = repository.makeApiCall()
    // Runs on IO thread, UI stays responsive
}
```

## Why This Works

- `StateFlow.update {}` is thread-safe and can be called from any thread
- Compose's `collectAsStateWithLifecycle()` automatically observes on Main thread
- Event channels handle cross-thread communication properly

## Test plan

- [ ] Build project successfully
- [ ] Verify existing ViewModels continue to work
- [ ] Update ViewModels to use `launchIO` for I/O operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal framework enhancements to improve asynchronous operation handling.

---

**Note:** This release contains no user-visible changes. Updates are limited to internal code improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->