### PR TITLE
feat: Add KMP Product Flavors support

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -32,6 +32,8 @@ dependencies {
     compileOnly(libs.androidx.room.gradle.plugin)
     compileOnly(libs.firebase.crashlytics.gradlePlugin)
     compileOnly(libs.firebase.performance.gradlePlugin)
+    // KMP Product Flavors - for cross-platform flavor support
+    implementation(libs.kmpProductFlavors.gradlePlugin)
 }
 
 tasks {
@@ -89,6 +91,11 @@ gradlePlugin {
         register("kmpLibrary") {
             id = "org.convention.kmp.library"
             implementationClass = "KMPLibraryConventionPlugin"
+        }
+        register("kmpFlavors") {
+            id = "org.convention.kmp.flavors"
+            implementationClass = "KMPFlavorsConventionPlugin"
+            description = "Configures KMP Product Flavors for cross-platform flavor support"
         }
 
         register("kmpCoreBaseLibrary") {

--- a/build-logic/convention/src/main/kotlin/KMPFlavorsConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KMPFlavorsConventionPlugin.kt
@@ -1,0 +1,68 @@
+import com.mobilebytelabs.kmpflavors.KmpFlavorExtension
+import com.mobilebytelabs.kmpflavors.KmpFlavorPlugin
+import org.convention.KmpFlavors
+import org.convention.configureKmpFlavors
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+/**
+ * Convention plugin that applies and configures KMP Product Flavors plugin.
+ *
+ * This plugin provides cross-platform flavor support for Kotlin Multiplatform modules,
+ * allowing consistent flavor configuration across Android, iOS, Desktop, and Web targets.
+ *
+ * Usage:
+ * ```kotlin
+ * plugins {
+ *     id("org.convention.kmp.flavors")
+ * }
+ * ```
+ *
+ * This will configure:
+ * - Demo/Prod flavors aligned with Android application flavors
+ * - BuildConfig generation with flavor-specific constants
+ * - Proper source set wiring for all platforms
+ */
+class KMPFlavorsConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            // Apply the KMP Product Flavors plugin by class
+            pluginManager.apply(KmpFlavorPlugin::class.java)
+
+            // Configure flavors using centralized configuration
+            extensions.configure<KmpFlavorExtension> {
+                configureKmpFlavors(
+                    extension = this,
+                    dimensions = KmpFlavors.defaultDimensions,
+                    flavors = KmpFlavors.defaultFlavors,
+                    generateBuildConfig = true,
+                    buildConfigPackage = inferBuildConfigPackage(target),
+                )
+            }
+        }
+    }
+
+    /**
+     * Infers the BuildConfig package from the project's group or path.
+     */
+    private fun inferBuildConfigPackage(project: Project): String {
+        // Try to use the project's group if available
+        val group = project.group.toString()
+        if (group.isNotEmpty() && group != "unspecified") {
+            return "$group.${project.name.replace("-", ".")}"
+        }
+
+        // Fall back to path-based package name
+        val pathParts = project.path
+            .removePrefix(":")
+            .split(":")
+            .filter { it.isNotEmpty() }
+
+        return if (pathParts.isNotEmpty()) {
+            "org.mifos.${pathParts.joinToString(".") { it.replace("-", ".") }}"
+        } else {
+            "org.mifos.${project.name.replace("-", ".")}"
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/org/convention/KmpFlavors.kt
+++ b/build-logic/convention/src/main/kotlin/org/convention/KmpFlavors.kt
@@ -1,0 +1,195 @@
+package org.convention
+
+import com.mobilebytelabs.kmpflavors.FlavorConfig
+import com.mobilebytelabs.kmpflavors.KmpFlavorExtension
+import org.gradle.api.NamedDomainObjectContainer
+
+/**
+ * KMP Product Flavors configuration for kmp-project-template.
+ *
+ * This provides cross-platform flavor support that aligns with the existing
+ * Android application flavors (demo/prod).
+ *
+ * ## Flavor Dimensions
+ * - **contentType**: Demo vs Production content source
+ *
+ * ## Build Variants
+ * - demo: Uses local/mock data for development and testing
+ * - prod: Uses production backend services
+ *
+ * ## Usage in Modules
+ * ```kotlin
+ * plugins {
+ *     id("org.convention.kmp.flavors")
+ * }
+ * ```
+ */
+object KmpFlavors {
+
+    /**
+     * Flavor dimension definitions.
+     * Currently matches Android's contentType dimension.
+     */
+    enum class Dimension(val priority: Int) {
+        CONTENT_TYPE(0)
+    }
+
+    /**
+     * Available flavors aligned with Android application flavors.
+     */
+    enum class Flavor(
+        val dimension: Dimension,
+        val isDefault: Boolean = false,
+        val applicationIdSuffix: String? = null,
+        val bundleIdSuffix: String? = null,
+    ) {
+        DEMO(
+            dimension = Dimension.CONTENT_TYPE,
+            isDefault = true, // Demo is default for development
+            applicationIdSuffix = ".demo",
+            bundleIdSuffix = ".demo",
+        ),
+        PROD(
+            dimension = Dimension.CONTENT_TYPE,
+            isDefault = false,
+        );
+
+        val flavorName: String = name.lowercase()
+    }
+
+    /**
+     * Default dimension configurations for kmp-product-flavors.
+     */
+    val defaultDimensions: List<DimensionConfig>
+        get() = Dimension.values().map { dimension ->
+            DimensionConfig(
+                name = dimension.name.lowercase().replace("_", ""),
+                priority = dimension.priority,
+            )
+        }
+
+    /**
+     * Default flavor configurations for kmp-product-flavors.
+     */
+    val defaultFlavors: List<FlavorConfigData>
+        get() = Flavor.values().map { flavor ->
+            FlavorConfigData(
+                name = flavor.flavorName,
+                dimension = flavor.dimension.name.lowercase().replace("_", ""),
+                isDefault = flavor.isDefault,
+                applicationIdSuffix = flavor.applicationIdSuffix,
+                bundleIdSuffix = flavor.bundleIdSuffix,
+            )
+        }
+
+    /**
+     * Checks if a specific flavor is currently active.
+     */
+    fun isFlavorActive(flavor: Flavor, activeVariant: String): Boolean =
+        activeVariant.contains(flavor.flavorName, ignoreCase = true)
+
+    /**
+     * Gets the base URL for the current flavor.
+     */
+    fun getBaseUrl(flavor: Flavor): String = when (flavor) {
+        Flavor.DEMO -> "https://demo-api.mifos.org"
+        Flavor.PROD -> "https://api.mifos.org"
+    }
+
+    /**
+     * Gets the analytics enabled flag for the current flavor.
+     */
+    fun isAnalyticsEnabled(flavor: Flavor): Boolean = when (flavor) {
+        Flavor.DEMO -> false
+        Flavor.PROD -> true
+    }
+}
+
+/**
+ * Data class for dimension configuration.
+ */
+data class DimensionConfig(
+    val name: String,
+    val priority: Int,
+)
+
+/**
+ * Data class for flavor configuration.
+ */
+data class FlavorConfigData(
+    val name: String,
+    val dimension: String,
+    val isDefault: Boolean = false,
+    val applicationIdSuffix: String? = null,
+    val bundleIdSuffix: String? = null,
+    val buildConfigFields: Map<String, BuildConfigFieldData> = emptyMap(),
+)
+
+/**
+ * Data class for BuildConfig field.
+ */
+data class BuildConfigFieldData(
+    val type: String,
+    val value: String,
+)
+
+/**
+ * Extension function to configure KMP flavors using centralized configuration.
+ */
+fun configureKmpFlavors(
+    extension: KmpFlavorExtension,
+    dimensions: List<DimensionConfig>,
+    flavors: List<FlavorConfigData>,
+    generateBuildConfig: Boolean = true,
+    buildConfigPackage: String? = null,
+) {
+    extension.apply {
+        this.generateBuildConfig.set(generateBuildConfig)
+        buildConfigPackage?.let { this.buildConfigPackage.set(it) }
+
+        // Configure dimensions
+        flavorDimensions {
+            dimensions.forEach { dim ->
+                register(dim.name) {
+                    priority.set(dim.priority)
+                }
+            }
+        }
+
+        // Configure flavors
+        this.flavors {
+            flavors.forEach { flavorData ->
+                register(flavorData.name) {
+                    dimension.set(flavorData.dimension)
+                    isDefault.set(flavorData.isDefault)
+                    flavorData.applicationIdSuffix?.let { applicationIdSuffix.set(it) }
+                    flavorData.bundleIdSuffix?.let { bundleIdSuffix.set(it) }
+
+                    // Add standard BuildConfig fields
+                    addStandardBuildConfigFields(this, flavorData)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Adds standard BuildConfig fields to a flavor.
+ */
+private fun addStandardBuildConfigFields(
+    flavorConfig: FlavorConfig,
+    flavorData: FlavorConfigData,
+) {
+    val flavor = KmpFlavors.Flavor.values().find { it.flavorName == flavorData.name }
+    if (flavor != null) {
+        flavorConfig.apply {
+            buildConfigField("String", "BASE_URL", "\"${KmpFlavors.getBaseUrl(flavor)}\"")
+            buildConfigField("Boolean", "ANALYTICS_ENABLED", KmpFlavors.isAnalyticsEnabled(flavor).toString())
+        }
+    }
+
+    // Add any custom fields
+    flavorData.buildConfigFields.forEach { (name, field) ->
+        flavorConfig.buildConfigField(field.type, name, field.value)
+    }
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,5 +1,6 @@
 dependencyResolutionManagement {
     repositories {
+        mavenLocal() // For local development with kmp-product-flavors
         google()
         mavenCentral()
         gradlePluginPortal()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,6 +54,7 @@ spotlessVersion = "7.0.2"
 turbine = "1.2.1"
 twitter-detekt-compose = "0.0.26"
 moduleGraph = "2.9.0"
+kmpProductFlavors = "1.0.0"
 
 # Kotlin KMP Dependencies
 kotlin = "2.2.21"
@@ -251,6 +252,7 @@ kotlinx-serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 
 ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
+kmpProductFlavors-gradlePlugin = { group = "io.github.mobilebytelabs.kmpflavors", name = "flavor-plugin", version.ref = "kmpProductFlavors" }
 
 ktor-client-android = { group = "io.ktor", name = "ktor-client-android", version.ref = "ktorVersion" }
 ktor-client-auth = { group = "io.ktor", name = "ktor-client-auth", version.ref = "ktorVersion" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,7 @@
 pluginManagement {
     includeBuild("build-logic")
     repositories {
+        mavenLocal() // For local development with kmp-product-flavors
         google {
             content {
                 includeGroupByRegex("com\\.android.*")
@@ -16,6 +17,7 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode = RepositoriesMode.PREFER_PROJECT
     repositories {
+        mavenLocal() // For local development with kmp-product-flavors
         google {
             content {
                 includeGroupByRegex("com\\.android.*")


### PR DESCRIPTION
## Summary

Integrate [kmp-product-flavors](https://github.com/MobileByteLabs/kmp-product-flavors) (v1.0.0) for cross-platform flavor support that aligns with existing Android application flavors.

## Changes

- Add kmp-product-flavors v1.0.0 to version catalog
- Create `KMPFlavorsConventionPlugin` for easy integration
- Add `KmpFlavors.kt` with centralized flavor configuration
- Configure demo/prod flavors matching Android application
- Add mavenLocal() for local development support

## Features

- **Cross-platform flavor support** - Same flavor configuration across Android, iOS, Desktop, and Web
- **BuildConfig generation** - Flavor-specific constants accessible from shared code
- **Automatic source set wiring** - `commonDemo`, `commonProd`, `iosDemo`, etc.
- **Aligned with Android** - Uses same contentType dimension (demo/prod)

## Usage

Apply to any KMP module:
```kotlin
plugins {
    id("org.convention.kmp.flavors")
}
```

Build with specific flavor:
```bash
./gradlew build -PkmpFlavor=prod
./gradlew build -PkmpFlavor=demo
```

List available variants:
```bash
./gradlew listFlavors
```

## Generated BuildConfig

```kotlin
// Access from shared code
object FlavorConfig {
    const val VARIANT_NAME: String = "demo"
    const val IS_DEMO: Boolean = true
    const val IS_PROD: Boolean = false
    const val BASE_URL: String = "https://demo-api.mifos.org"
    const val ANALYTICS_ENABLED: Boolean = false
}
```

## Test plan

- [ ] Build project with `./gradlew build -PkmpFlavor=demo`
- [ ] Build project with `./gradlew build -PkmpFlavor=prod`
- [ ] Run `./gradlew listFlavors` to verify variant configuration
- [ ] Verify BuildConfig is generated in shared modules

---

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Kotlin Multiplatform Product Flavors support for cross-platform builds
  * Introduced DEMO and PROD flavor variants with environment-specific configurations
  * Enabled flavor-specific build configuration including base URLs and analytics toggles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->