### PR TITLE
feat: Integrate KMP Product Flavors v1.0.1

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -32,6 +32,8 @@ dependencies {
     compileOnly(libs.androidx.room.gradle.plugin)
     compileOnly(libs.firebase.crashlytics.gradlePlugin)
     compileOnly(libs.firebase.performance.gradlePlugin)
+    // KMP Product Flavors - for cross-platform flavor support
+    implementation(libs.kmpProductFlavors.gradlePlugin)
 }
 
 tasks {
@@ -89,6 +91,11 @@ gradlePlugin {
         register("kmpLibrary") {
             id = "org.convention.kmp.library"
             implementationClass = "KMPLibraryConventionPlugin"
+        }
+        register("kmpFlavors") {
+            id = "org.convention.kmp.flavors"
+            implementationClass = "KMPFlavorsConventionPlugin"
+            description = "Configures KMP Product Flavors for cross-platform flavor support"
         }
 
         register("kmpCoreBaseLibrary") {

--- a/build-logic/convention/src/main/kotlin/KMPCoreBaseLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KMPCoreBaseLibraryConventionPlugin.kt
@@ -11,6 +11,9 @@ import org.gradle.kotlin.dsl.dependencies
 
 /**
  * Plugin that applies the Android library and Kotlin multiplatform plugins and configures them.
+ *
+ * This plugin includes KMP Product Flavors support for cross-platform flavor configuration
+ * that aligns with Android application flavors (demo/prod).
  */
 class KMPCoreBaseLibraryConventionPlugin: Plugin<Project> {
     override fun apply(target: Project) {
@@ -19,6 +22,7 @@ class KMPCoreBaseLibraryConventionPlugin: Plugin<Project> {
                 apply("com.android.library")
                 apply("org.jetbrains.kotlin.multiplatform")
                 apply("org.convention.kmp.koin")
+                apply("org.convention.kmp.flavors") // KMP cross-platform flavors
                 apply("org.convention.detekt.plugin")
                 apply("org.jetbrains.kotlin.plugin.serialization")
                 apply("org.jetbrains.kotlin.plugin.parcelize")

--- a/build-logic/convention/src/main/kotlin/KMPFlavorsConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KMPFlavorsConventionPlugin.kt
@@ -1,0 +1,73 @@
+import com.mobilebytelabs.kmpflavors.KmpFlavorExtension
+import com.mobilebytelabs.kmpflavors.KmpFlavorPlugin
+import org.convention.KmpFlavors
+import org.convention.configureKmpFlavors
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+/**
+ * Convention plugin that applies and configures KMP Product Flavors plugin.
+ *
+ * This plugin provides cross-platform flavor support for Kotlin Multiplatform modules,
+ * allowing consistent flavor configuration across Android, iOS, Desktop, and Web targets.
+ *
+ * Usage:
+ * ```kotlin
+ * plugins {
+ *     id("org.convention.kmp.flavors")
+ * }
+ * ```
+ *
+ * This will configure:
+ * - Demo/Prod flavors aligned with Android application flavors
+ * - BuildConfig generation with flavor-specific constants
+ * - Proper source set wiring for all platforms
+ */
+class KMPFlavorsConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            // Apply the KMP Product Flavors plugin by class
+            pluginManager.apply(KmpFlavorPlugin::class.java)
+
+            // Configure flavors using centralized configuration
+            extensions.configure<KmpFlavorExtension> {
+                configureKmpFlavors(
+                    extension = this,
+                    dimensions = KmpFlavors.defaultDimensions,
+                    flavors = KmpFlavors.defaultFlavors,
+                    generateBuildConfig = true,
+                    buildConfigPackage = inferBuildConfigPackage(target),
+                )
+            }
+        }
+    }
+
+    /**
+     * Infers the BuildConfig package from the project's group or path.
+     * Ensures the package name is valid Kotlin (no hyphens).
+     */
+    private fun inferBuildConfigPackage(project: Project): String {
+        // Try to use the project's group if available
+        val group = project.group.toString()
+        if (group.isNotEmpty() && group != "unspecified") {
+            // Replace hyphens with dots to ensure valid Kotlin package name
+            val sanitizedGroup = group.replace("-", ".")
+            val sanitizedName = project.name.replace("-", ".")
+            return "$sanitizedGroup.$sanitizedName"
+        }
+
+        // Fall back to path-based package name
+        val pathParts = project.path
+            .removePrefix(":")
+            .split(":")
+            .filter { it.isNotEmpty() }
+
+        return if (pathParts.isNotEmpty()) {
+            // Replace hyphens with underscores to ensure valid Kotlin identifiers
+            "org.mifos.${pathParts.joinToString(".") { it.replace("-", "_") }}"
+        } else {
+            "org.mifos.${project.name.replace("-", "_")}"
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/KMPLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KMPLibraryConventionPlugin.kt
@@ -11,6 +11,9 @@ import org.gradle.kotlin.dsl.dependencies
 
 /**
  * Plugin that applies the Android library and Kotlin multiplatform plugins and configures them.
+ *
+ * This plugin now includes KMP Product Flavors support for cross-platform flavor configuration
+ * that aligns with Android application flavors (demo/prod).
  */
 class KMPLibraryConventionPlugin: Plugin<Project> {
     override fun apply(target: Project) {
@@ -19,6 +22,7 @@ class KMPLibraryConventionPlugin: Plugin<Project> {
                 apply("com.android.library")
                 apply("org.jetbrains.kotlin.multiplatform")
                 apply("org.convention.kmp.koin")
+                apply("org.convention.kmp.flavors") // KMP cross-platform flavors
                 apply("org.convention.detekt.plugin")
                 apply("org.convention.spotless.plugin")
                 apply("org.jetbrains.kotlin.plugin.serialization")

--- a/build-logic/convention/src/main/kotlin/org/convention/KmpFlavors.kt
+++ b/build-logic/convention/src/main/kotlin/org/convention/KmpFlavors.kt
@@ -1,0 +1,195 @@
+package org.convention
+
+import com.mobilebytelabs.kmpflavors.FlavorConfig
+import com.mobilebytelabs.kmpflavors.KmpFlavorExtension
+import org.gradle.api.NamedDomainObjectContainer
+
+/**
+ * KMP Product Flavors configuration for kmp-project-template.
+ *
+ * This provides cross-platform flavor support that aligns with the existing
+ * Android application flavors (demo/prod).
+ *
+ * ## Flavor Dimensions
+ * - **contentType**: Demo vs Production content source
+ *
+ * ## Build Variants
+ * - demo: Uses local/mock data for development and testing
+ * - prod: Uses production backend services
+ *
+ * ## Usage in Modules
+ * ```kotlin
+ * plugins {
+ *     id("org.convention.kmp.flavors")
+ * }
+ * ```
+ */
+object KmpFlavors {
+
+    /**
+     * Flavor dimension definitions.
+     * Currently matches Android's contentType dimension.
+     */
+    enum class Dimension(val priority: Int) {
+        CONTENT_TYPE(0)
+    }
+
+    /**
+     * Available flavors aligned with Android application flavors.
+     */
+    enum class Flavor(
+        val dimension: Dimension,
+        val isDefault: Boolean = false,
+        val applicationIdSuffix: String? = null,
+        val bundleIdSuffix: String? = null,
+    ) {
+        DEMO(
+            dimension = Dimension.CONTENT_TYPE,
+            isDefault = true, // Demo is default for development
+            applicationIdSuffix = ".demo",
+            bundleIdSuffix = ".demo",
+        ),
+        PROD(
+            dimension = Dimension.CONTENT_TYPE,
+            isDefault = false,
+        );
+
+        val flavorName: String = name.lowercase()
+    }
+
+    /**
+     * Default dimension configurations for kmp-product-flavors.
+     */
+    val defaultDimensions: List<DimensionConfig>
+        get() = Dimension.values().map { dimension ->
+            DimensionConfig(
+                name = dimension.name.lowercase().replace("_", ""),
+                priority = dimension.priority,
+            )
+        }
+
+    /**
+     * Default flavor configurations for kmp-product-flavors.
+     */
+    val defaultFlavors: List<FlavorConfigData>
+        get() = Flavor.values().map { flavor ->
+            FlavorConfigData(
+                name = flavor.flavorName,
+                dimension = flavor.dimension.name.lowercase().replace("_", ""),
+                isDefault = flavor.isDefault,
+                applicationIdSuffix = flavor.applicationIdSuffix,
+                bundleIdSuffix = flavor.bundleIdSuffix,
+            )
+        }
+
+    /**
+     * Checks if a specific flavor is currently active.
+     */
+    fun isFlavorActive(flavor: Flavor, activeVariant: String): Boolean =
+        activeVariant.contains(flavor.flavorName, ignoreCase = true)
+
+    /**
+     * Gets the base URL for the current flavor.
+     */
+    fun getBaseUrl(flavor: Flavor): String = when (flavor) {
+        Flavor.DEMO -> "https://demo-api.mifos.org"
+        Flavor.PROD -> "https://api.mifos.org"
+    }
+
+    /**
+     * Gets the analytics enabled flag for the current flavor.
+     */
+    fun isAnalyticsEnabled(flavor: Flavor): Boolean = when (flavor) {
+        Flavor.DEMO -> false
+        Flavor.PROD -> true
+    }
+}
+
+/**
+ * Data class for dimension configuration.
+ */
+data class DimensionConfig(
+    val name: String,
+    val priority: Int,
+)
+
+/**
+ * Data class for flavor configuration.
+ */
+data class FlavorConfigData(
+    val name: String,
+    val dimension: String,
+    val isDefault: Boolean = false,
+    val applicationIdSuffix: String? = null,
+    val bundleIdSuffix: String? = null,
+    val buildConfigFields: Map<String, BuildConfigFieldData> = emptyMap(),
+)
+
+/**
+ * Data class for BuildConfig field.
+ */
+data class BuildConfigFieldData(
+    val type: String,
+    val value: String,
+)
+
+/**
+ * Extension function to configure KMP flavors using centralized configuration.
+ */
+fun configureKmpFlavors(
+    extension: KmpFlavorExtension,
+    dimensions: List<DimensionConfig>,
+    flavors: List<FlavorConfigData>,
+    generateBuildConfig: Boolean = true,
+    buildConfigPackage: String? = null,
+) {
+    extension.apply {
+        this.generateBuildConfig.set(generateBuildConfig)
+        buildConfigPackage?.let { this.buildConfigPackage.set(it) }
+
+        // Configure dimensions
+        flavorDimensions {
+            dimensions.forEach { dim ->
+                register(dim.name) {
+                    priority.set(dim.priority)
+                }
+            }
+        }
+
+        // Configure flavors
+        this.flavors {
+            flavors.forEach { flavorData ->
+                register(flavorData.name) {
+                    dimension.set(flavorData.dimension)
+                    isDefault.set(flavorData.isDefault)
+                    flavorData.applicationIdSuffix?.let { applicationIdSuffix.set(it) }
+                    flavorData.bundleIdSuffix?.let { bundleIdSuffix.set(it) }
+
+                    // Add standard BuildConfig fields
+                    addStandardBuildConfigFields(this, flavorData)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Adds standard BuildConfig fields to a flavor.
+ */
+private fun addStandardBuildConfigFields(
+    flavorConfig: FlavorConfig,
+    flavorData: FlavorConfigData,
+) {
+    val flavor = KmpFlavors.Flavor.values().find { it.flavorName == flavorData.name }
+    if (flavor != null) {
+        flavorConfig.apply {
+            buildConfigField("String", "BASE_URL", "\"${KmpFlavors.getBaseUrl(flavor)}\"")
+            buildConfigField("Boolean", "ANALYTICS_ENABLED", KmpFlavors.isAnalyticsEnabled(flavor).toString())
+        }
+    }
+
+    // Add any custom fields
+    flavorData.buildConfigFields.forEach { (name, field) ->
+        flavorConfig.buildConfigField(field.type, name, field.value)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,6 +54,7 @@ spotlessVersion = "7.0.2"
 turbine = "1.2.1"
 twitter-detekt-compose = "0.0.26"
 moduleGraph = "2.9.0"
+kmpProductFlavors = "1.0.1"
 
 # Kotlin KMP Dependencies
 kotlin = "2.2.21"
@@ -251,6 +252,7 @@ kotlinx-serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 
 ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
+kmpProductFlavors-gradlePlugin = { group = "io.github.mobilebytelabs.kmpflavors", name = "flavor-plugin", version.ref = "kmpProductFlavors" }
 
 ktor-client-android = { group = "io.ktor", name = "ktor-client-android", version.ref = "ktorVersion" }
 ktor-client-auth = { group = "io.ktor", name = "ktor-client-auth", version.ref = "ktorVersion" }
@@ -367,6 +369,7 @@ aboutLibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "abo
 cmp-feature-convention = { id = "org.convention.cmp.feature", version = "unspecified" }
 kmp-koin-convention = { id = "org.convention.kmp.koin", version = "unspecified" }
 kmp-library-convention = { id = "org.convention.kmp.library", version = "unspecified" }
+kmp-flavors-convention = { id = "org.convention.kmp.flavors", version = "unspecified" }
 kmp-core-base-library-convention = { id = "org.convention.kmp.core.base.library", version = "unspecified" }
 
 android-application-firebase = { id = "org.convention.android.application.firebase" }


### PR DESCRIPTION
## Summary

Integrates [kmp-product-flavors](https://github.com/MobileByteLabs/kmp-product-flavors) v1.0.1 plugin for cross-platform flavor support in Kotlin Multiplatform projects.

### Changes

- **Convention Plugin**: `KMPFlavorsConventionPlugin.kt` - Wraps kmp-product-flavors plugin
- **Flavor Config**: `org/convention/KmpFlavors.kt` - Centralized flavor configuration (demo/prod)
- **Plugin Integration**: Applied in both `KMPLibraryConventionPlugin` and `KMPCoreBaseLibraryConventionPlugin`
- **Version Catalog**: Added `kmpProductFlavors = "1.0.1"` dependency
- **Bug Fix**: Fixed BuildConfig package name generation to handle project names with hyphens

### Features Enabled

- Multi-dimensional flavor support (demo/prod)
- BuildConfig generation per variant
- Flavor-specific source sets (`commonDemo/`, `commonProd/`, etc.)
- Proper source set dependency wiring (no warnings)

### v1.0.1 Fixes

- Fixed "Invalid Dependency on Default Compilation Source Set" warnings
- Platform flavor source sets now correctly depend only on `commonFlavor`
- Improved convention plugin integration documentation

## Test plan

- [ ] Verify build completes without flavor-related warnings
- [ ] Verify `./gradlew listFlavors` shows demo/prod variants
- [ ] Verify BuildConfig is generated with correct package names (no hyphens)

## Documentation

- [Wiki: Convention Plugin Integration](https://github.com/MobileByteLabs/kmp-product-flavors/wiki/Convention-Plugin-Integration)
- [Getting Started](https://github.com/MobileByteLabs/kmp-product-flavors/wiki/Getting-Started)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kotlin Multiplatform Product Flavors support enabling cross-platform flavor configuration management
  * Introduced configurable flavor dimensions and variants (DEMO/PROD) with per-flavor build configuration fields
  * Added support for flavor-specific application and bundle ID suffixes, base URL, and analytics settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->