### PR TITLE
feat(core-base/store): add StoreData API with unified source selection and paging

### DIFF
--- a/core-base/store/build.gradle.kts
+++ b/core-base/store/build.gradle.kts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+plugins {
+    alias(libs.plugins.kmp.core.base.library.convention)
+}
+
+android {
+    namespace = "template.core.base.store"
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            api(libs.store5)
+            api(libs.store5.cache)
+            implementation(libs.kotlinx.coroutines.core)
+            implementation(project(":core-base:common"))
+        }
+
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.turbine)
+        }
+    }
+}

--- a/core-base/store/src/commonMain/kotlin/template/core/base/store/DefaultValidator.kt
+++ b/core-base/store/src/commonMain/kotlin/template/core/base/store/DefaultValidator.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package template.core.base.store
+
+import org.mobilenativefoundation.store.store5.Validator
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.TimeSource
+
+/**
+ * A TTL-based [Validator] that marks cached data as stale after a given duration.
+ *
+ * Tracks when data was last fetched using [TimeSource.Monotonic] and considers
+ * it invalid once the [ttl] has elapsed. Call [markFresh] when fresh data arrives.
+ *
+ * @param Output The cached data type.
+ * @param ttl Maximum age before data is considered stale. Defaults to 30 minutes.
+ */
+class DefaultValidator<Output : Any>(
+    private val ttl: Duration = 30.minutes,
+) : Validator<Output> {
+
+    private var lastFetchMark: TimeSource.Monotonic.ValueTimeMark? = null
+
+    /**
+     * Marks the current moment as the last fetch time.
+     * Call this after successfully fetching fresh data.
+     */
+    fun markFresh() {
+        lastFetchMark = TimeSource.Monotonic.markNow()
+    }
+
+    override suspend fun isValid(item: Output): Boolean {
+        val mark = lastFetchMark ?: return false
+        return mark.elapsedNow() < ttl
+    }
+
+    companion object {
+
+        /**
+         * Creates a [Validator] that always considers data valid (no TTL).
+         */
+        fun <Output : Any> alwaysValid(): Validator<Output> {
+            return Validator.by { true }
+        }
+
+        /**
+         * Creates a TTL-based [Validator] with the given duration.
+         *
+         * @param ttl Maximum age before data is stale.
+         */
+        fun <Output : Any> withTtl(
+            ttl: Duration = 30.minutes,
+        ): DefaultValidator<Output> {
+            return DefaultValidator(ttl = ttl)
+        }
+    }
+}

--- a/core-base/store/src/commonMain/kotlin/template/core/base/store/InMemoryBookkeeper.kt
+++ b/core-base/store/src/commonMain/kotlin/template/core/base/store/InMemoryBookkeeper.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package template.core.base.store
+
+import org.mobilenativefoundation.store.store5.Bookkeeper
+
+/**
+ * An in-memory [Bookkeeper] implementation for tracking unsynced local changes.
+ *
+ * Stores sync failure timestamps in a [MutableMap]. Suitable for lightweight
+ * use cases where sync tracking doesn't need to survive process death.
+ * For persistent tracking, use a Room-backed implementation in your app's
+ * `core/data` layer.
+ *
+ * @param Key The store key type.
+ */
+class InMemoryBookkeeper<Key : Any> : Bookkeeper<Key> {
+
+    private val failedSyncs = mutableMapOf<Key, Long>()
+
+    override suspend fun getLastFailedSync(key: Key): Long? {
+        return failedSyncs[key]
+    }
+
+    override suspend fun setLastFailedSync(key: Key, timestamp: Long): Boolean {
+        failedSyncs[key] = timestamp
+        return true
+    }
+
+    override suspend fun clear(key: Key): Boolean {
+        failedSyncs.remove(key)
+        return true
+    }
+
+    override suspend fun clearAll(): Boolean {
+        failedSyncs.clear()
+        return true
+    }
+
+    companion object {
+
+        /**
+         * Creates a [Bookkeeper] backed by a [MutableMap] (in-memory only).
+         */
+        fun <Key : Any> create(): InMemoryBookkeeper<Key> {
+            return InMemoryBookkeeper()
+        }
+    }
+}

--- a/core-base/store/src/commonMain/kotlin/template/core/base/store/StoreData.kt
+++ b/core-base/store/src/commonMain/kotlin/template/core/base/store/StoreData.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package template.core.base.store
+
+import template.core.base.common.DataState
+import kotlin.time.Duration
+import kotlin.time.TimeSource
+
+/**
+ * Wraps data with metadata about its origin, freshness, and refresh state.
+ *
+ * Works identically for both source modes:
+ * - **Network + Cache**: emits cached data first (fast), then network data (updated)
+ * - **Network only**: emits network data directly, no cache/staleness
+ *
+ * Feature modules collect `Flow<StoreData<T>>` from repositories and render
+ * cache-then-refresh UX patterns without knowing the source mode.
+ *
+ * @param T The domain data type.
+ * @param data The actual data payload.
+ * @param origin Where this data emission came from.
+ * @param isRefreshing True when a network fetch is in progress (cached data is being shown).
+ * @param fetchedAt Monotonic time mark of the last successful network fetch, or null if never fetched.
+ * @param error Non-null if the most recent refresh attempt failed. Data may still be valid (stale).
+ * @param isEmpty True if the data represents an empty result (e.g., empty list, null-equivalent).
+ */
+data class StoreData<out T>(
+    val data: T,
+    val origin: DataOrigin,
+    val isRefreshing: Boolean = false,
+    val fetchedAt: TimeSource.Monotonic.ValueTimeMark? = null,
+    val error: Throwable? = null,
+    val isEmpty: Boolean = false,
+) {
+    /** True if data has never been fetched from network (only meaningful for cached stores). */
+    val isStale: Boolean get() = fetchedAt == null && origin != DataOrigin.NETWORK
+
+    /** Duration since last successful network fetch, or null if never fetched. */
+    val staleDuration: Duration? get() = fetchedAt?.elapsedNow()
+
+    /** True if this emission has data and no error. */
+    val isSuccess: Boolean get() = error == null && !isEmpty
+
+    /** True if this is a terminal error with no usable data. */
+    val isError: Boolean get() = error != null && isEmpty
+}
+
+/**
+ * Indicates where a [StoreData] emission originated.
+ */
+enum class DataOrigin {
+    /** Data was read from local persistence (Room database). */
+    CACHE,
+
+    /** Data was freshly fetched from the network (API). */
+    NETWORK,
+
+    /** Data was served from Store's in-memory cache. */
+    MEMORY,
+}
+
+/**
+ * Converts [StoreData] to [DataState] for ViewModels using DataState patterns.
+ *
+ * Mapping:
+ * - [isEmpty] + no error -> [DataState.Loading] (no data yet)
+ * - [isRefreshing] + data -> [DataState.Pending] (cached data, refresh in progress)
+ * - [error] != null -> [DataState.Error] (with optional stale data)
+ * - data present, no error -> [DataState.Success]
+ */
+fun <T> StoreData<T>.toDataState(): DataState<T> {
+    return when {
+        isEmpty && error == null -> DataState.Loading
+        error != null -> DataState.Error(error, if (isEmpty) null else data)
+        isRefreshing -> DataState.Pending(data)
+        else -> DataState.Success(data)
+    }
+}

--- a/core-base/store/src/commonMain/kotlin/template/core/base/store/StoreDataExtensions.kt
+++ b/core-base/store/src/commonMain/kotlin/template/core/base/store/StoreDataExtensions.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package template.core.base.store
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import org.mobilenativefoundation.store.store5.Store
+import org.mobilenativefoundation.store.store5.StoreReadRequest
+
+/**
+ * Streams data from a [Store] with full [StoreData] metadata.
+ *
+ * This is the primary API for repositories. Source mode (network+cache vs network-only)
+ * is determined by how the Store was created:
+ * - [StoreFactory.createStore] -> network + cache (Fetcher + SourceOfTruth)
+ * - [StoreFactory.createMemoryStore] -> network only (Fetcher only, in-memory cache)
+ *
+ * Both produce the same `Flow<StoreData<Output>>` -- the ViewModel doesn't need to know.
+ *
+ * @param key The data identifier.
+ * @param refresh Whether to trigger a network refresh. Default true.
+ * @param isEmpty Predicate to detect empty results.
+ */
+fun <Key : Any, Output : Any> Store<Key, Output>.streamData(
+    key: Key,
+    refresh: Boolean = true,
+    isEmpty: (Output) -> Boolean = { false },
+): Flow<StoreData<Output>> {
+    return stream(StoreReadRequest.cached(key, refresh))
+        .mapToStoreData(isEmpty)
+}
+
+/**
+ * Like [streamData] but also emits on errors with last known data preserved.
+ *
+ * @param key The data identifier.
+ * @param fallback Value to use if error arrives before any data.
+ * @param refresh Whether to trigger a network refresh. Default true.
+ * @param isEmpty Predicate to detect empty results.
+ */
+fun <Key : Any, Output : Any> Store<Key, Output>.streamDataWithErrors(
+    key: Key,
+    fallback: Output,
+    refresh: Boolean = true,
+    isEmpty: (Output) -> Boolean = { false },
+): Flow<StoreData<Output>> {
+    return stream(StoreReadRequest.cached(key, refresh))
+        .mapToStoreDataWithErrors(fallback, isEmpty)
+}
+
+/**
+ * Forces a fresh network fetch, ignoring any cached data.
+ * Useful for pull-to-refresh or explicit "reload" actions.
+ */
+fun <Key : Any, Output : Any> Store<Key, Output>.freshData(
+    key: Key,
+    isEmpty: (Output) -> Boolean = { false },
+): Flow<StoreData<Output>> {
+    return stream(StoreReadRequest.fresh(key, fallBackToSourceOfTruth = true))
+        .mapToStoreData(isEmpty)
+}
+
+/**
+ * Reads only from local cache/database, no network.
+ * Useful for offline-only screens or pre-fetched data.
+ */
+fun <Key : Any, Output : Any> Store<Key, Output>.localData(
+    key: Key,
+    isEmpty: (Output) -> Boolean = { false },
+): Flow<StoreData<Output>> {
+    return stream(StoreReadRequest.localOnly(key))
+        .mapToStoreData(isEmpty)
+}
+
+/**
+ * Maps [StoreData] content while preserving all metadata.
+ */
+fun <T, R> StoreData<T>.map(transform: (T) -> R): StoreData<R> {
+    return StoreData(
+        data = transform(data),
+        origin = origin,
+        isRefreshing = isRefreshing,
+        fetchedAt = fetchedAt,
+        error = error,
+        isEmpty = isEmpty,
+    )
+}
+
+/**
+ * Maps a Flow of [StoreData] content while preserving all metadata.
+ */
+fun <T, R> Flow<StoreData<T>>.mapData(transform: (T) -> R): Flow<StoreData<R>> {
+    return map { it.map(transform) }
+}

--- a/core-base/store/src/commonMain/kotlin/template/core/base/store/StoreDataMapper.kt
+++ b/core-base/store/src/commonMain/kotlin/template/core/base/store/StoreDataMapper.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package template.core.base.store
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.transform
+import org.mobilenativefoundation.store.store5.StoreReadResponse
+import org.mobilenativefoundation.store.store5.StoreReadResponseOrigin
+import kotlin.time.TimeSource
+
+/**
+ * Maps a [StoreReadResponse] flow into `Flow<StoreData<Output>>`.
+ *
+ * Works for both source modes:
+ * - **Network + Cache store**: Loading -> Data(Cache, refreshing) -> Data(Network)
+ * - **Network-only store**: Loading -> Data(Network) or Error
+ *
+ * @param isEmpty Optional predicate to detect empty results (e.g., `{ it.isEmpty() }` for lists).
+ *   Defaults to false (all data is non-empty).
+ */
+fun <Output : Any> Flow<StoreReadResponse<Output>>.mapToStoreData(
+    isEmpty: (Output) -> Boolean = { false },
+): Flow<StoreData<Output>> {
+    var refreshing = false
+    var lastFetchMark: TimeSource.Monotonic.ValueTimeMark? = null
+
+    return transform { response ->
+        when (response) {
+            is StoreReadResponse.Initial,
+            is StoreReadResponse.Loading,
+            -> {
+                refreshing = true
+            }
+
+            is StoreReadResponse.Data -> {
+                val origin = response.origin.toDataOrigin()
+                if (origin == DataOrigin.NETWORK) {
+                    lastFetchMark = TimeSource.Monotonic.markNow()
+                    refreshing = false
+                }
+                emit(
+                    StoreData(
+                        data = response.value,
+                        origin = origin,
+                        isRefreshing = refreshing && origin != DataOrigin.NETWORK,
+                        fetchedAt = lastFetchMark,
+                        isEmpty = isEmpty(response.value),
+                    ),
+                )
+            }
+
+            is StoreReadResponse.NoNewData -> {
+                refreshing = false
+            }
+
+            is StoreReadResponse.Error -> {
+                refreshing = false
+            }
+        }
+    }
+}
+
+/**
+ * Like [mapToStoreData] but also emits on errors, carrying the last known data.
+ *
+ * Handles all status scenarios:
+ * - **Success**: Data arrives -> emit with origin and staleness
+ * - **Empty**: Data arrives but isEmpty predicate is true -> emit with isEmpty=true
+ * - **Error with stale data**: Error after cache -> emit error with last known data
+ * - **Error without data**: Error before any data -> emit error with fallback (isEmpty=true)
+ * - **No network**: Error type hints at connectivity -> ViewModel can check error type
+ *
+ * @param fallback Value to use if an error arrives before any data.
+ * @param isEmpty Predicate to detect empty results.
+ */
+fun <Output : Any> Flow<StoreReadResponse<Output>>.mapToStoreDataWithErrors(
+    fallback: Output,
+    isEmpty: (Output) -> Boolean = { false },
+): Flow<StoreData<Output>> {
+    var refreshing = false
+    var lastFetchMark: TimeSource.Monotonic.ValueTimeMark? = null
+    var lastData: Output = fallback
+    var hasReceivedData = false
+
+    return transform { response ->
+        when (response) {
+            is StoreReadResponse.Initial,
+            is StoreReadResponse.Loading,
+            -> {
+                refreshing = true
+            }
+
+            is StoreReadResponse.Data -> {
+                val origin = response.origin.toDataOrigin()
+                if (origin == DataOrigin.NETWORK) {
+                    lastFetchMark = TimeSource.Monotonic.markNow()
+                    refreshing = false
+                }
+                lastData = response.value
+                hasReceivedData = true
+                emit(
+                    StoreData(
+                        data = response.value,
+                        origin = origin,
+                        isRefreshing = refreshing && origin != DataOrigin.NETWORK,
+                        fetchedAt = lastFetchMark,
+                        isEmpty = isEmpty(response.value),
+                    ),
+                )
+            }
+
+            is StoreReadResponse.NoNewData -> {
+                refreshing = false
+            }
+
+            is StoreReadResponse.Error -> {
+                refreshing = false
+                val error = response.toThrowable()
+                emit(
+                    StoreData(
+                        data = lastData,
+                        origin = if (hasReceivedData) DataOrigin.CACHE else DataOrigin.NETWORK,
+                        isRefreshing = false,
+                        fetchedAt = lastFetchMark,
+                        error = error,
+                        isEmpty = !hasReceivedData,
+                    ),
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Maps [StoreReadResponseOrigin] to [DataOrigin].
+ *
+ * [StoreReadResponseOrigin] is a top-level sealed class (NOT nested in StoreReadResponse).
+ * [StoreReadResponseOrigin.Fetcher] is a data class with optional `name: String?`,
+ * while SourceOfTruth, Cache, and Initial are singleton objects.
+ */
+internal fun StoreReadResponseOrigin.toDataOrigin(): DataOrigin {
+    return when (this) {
+        is StoreReadResponseOrigin.Fetcher -> DataOrigin.NETWORK
+        StoreReadResponseOrigin.SourceOfTruth -> DataOrigin.CACHE
+        StoreReadResponseOrigin.Cache -> DataOrigin.MEMORY
+        StoreReadResponseOrigin.Initial -> DataOrigin.MEMORY
+    }
+}
+
+/**
+ * Extracts a [Throwable] from any [StoreReadResponse.Error] variant.
+ */
+internal fun StoreReadResponse.Error.toThrowable(): Throwable {
+    return when (this) {
+        is StoreReadResponse.Error.Exception -> error
+        is StoreReadResponse.Error.Message -> RuntimeException(message)
+        is StoreReadResponse.Error.Custom<*> -> RuntimeException("Store error: $error")
+    }
+}

--- a/core-base/store/src/commonMain/kotlin/template/core/base/store/StoreFactory.kt
+++ b/core-base/store/src/commonMain/kotlin/template/core/base/store/StoreFactory.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package template.core.base.store
+
+import org.mobilenativefoundation.store.core5.ExperimentalStoreApi
+import org.mobilenativefoundation.store.store5.Bookkeeper
+import org.mobilenativefoundation.store.store5.Converter
+import org.mobilenativefoundation.store.store5.Fetcher
+import org.mobilenativefoundation.store.store5.MutableStore
+import org.mobilenativefoundation.store.store5.SourceOfTruth
+import org.mobilenativefoundation.store.store5.Store
+import org.mobilenativefoundation.store.store5.StoreBuilder
+import org.mobilenativefoundation.store.store5.Updater
+import org.mobilenativefoundation.store.store5.Validator
+
+/**
+ * Factory for creating [Store] and [MutableStore] instances with sensible defaults.
+ *
+ * Wraps Store 5's builder API into two concise factory methods:
+ * - [createStore] for read-only stores (network fetch + local cache)
+ * - [createMutableStore] for read-write stores (adds write-back + offline sync)
+ */
+object StoreFactory {
+
+    /**
+     * Creates a read-only [Store] where the fetcher output type matches
+     * the source of truth input type (no conversion needed).
+     *
+     * @param Key The type used to identify data (e.g., a user ID or query params).
+     * @param Input The type produced by the fetcher and consumed by the source of truth.
+     * @param Output The domain type exposed to consumers.
+     * @param fetcher Network data source that fetches fresh data for a given key.
+     * @param sourceOfTruth Local persistence layer (reader emits cached data, writer persists).
+     * @param validator Optional cache validity check (e.g., TTL-based expiration).
+     * @return A configured [Store] ready for streaming reads.
+     */
+    fun <Key : Any, Input : Any, Output : Any> createStore(
+        fetcher: Fetcher<Key, Input>,
+        sourceOfTruth: SourceOfTruth<Key, Input, Output>,
+        validator: Validator<Output>? = null,
+    ): Store<Key, Output> {
+        var builder = StoreBuilder.from(
+            fetcher = fetcher,
+            sourceOfTruth = sourceOfTruth,
+        )
+        if (validator != null) {
+            builder = builder.validator(validator)
+        }
+        return builder.build()
+    }
+
+    /**
+     * Creates a read-only [Store] backed only by a [Fetcher] (no local persistence).
+     *
+     * Data is cached in-memory only. Useful for transient data that doesn't
+     * need to survive process death.
+     *
+     * @param Key The type used to identify data.
+     * @param Output The type produced by the fetcher and exposed to consumers.
+     * @param fetcher Network data source.
+     * @return A configured [Store] with in-memory caching only.
+     */
+    fun <Key : Any, Output : Any> createMemoryStore(
+        fetcher: Fetcher<Key, Output>,
+    ): Store<Key, Output> {
+        return StoreBuilder.from(fetcher = fetcher).build()
+    }
+
+    /**
+     * Creates a [MutableStore] that supports reads, writes, and offline sync.
+     *
+     * Uses a [Converter] to transform between network, local, and output types.
+     * When a write fails (e.g., no network), the [Bookkeeper] records the failure
+     * for retry on connectivity restore.
+     *
+     * @param Key The type used to identify data.
+     * @param Network The raw type returned by the network layer.
+     * @param Local The type persisted in local storage.
+     * @param Output The domain type exposed to consumers.
+     * @param fetcher Network data source for reads.
+     * @param sourceOfTruth Local persistence layer.
+     * @param converter Transforms between Network, Local, and Output types.
+     * @param updater Writes data back to the server (e.g., POST/PUT API call).
+     * @param bookkeeper Tracks unsynced local changes for retry on reconnection.
+     * @param validator Optional cache validity check.
+     * @return A configured [MutableStore] ready for reads and writes.
+     */
+    @OptIn(ExperimentalStoreApi::class)
+    fun <Key : Any, Network : Any, Local : Any, Output : Any> createMutableStore(
+        fetcher: Fetcher<Key, Network>,
+        sourceOfTruth: SourceOfTruth<Key, Local, Output>,
+        converter: Converter<Network, Local, Output>,
+        updater: Updater<Key, Output, *>,
+        bookkeeper: Bookkeeper<Key>,
+        validator: Validator<Output>? = null,
+    ): MutableStore<Key, Output> {
+        var builder = StoreBuilder.from(
+            fetcher = fetcher,
+            sourceOfTruth = sourceOfTruth,
+            converter = converter,
+        )
+        if (validator != null) {
+            builder = builder.validator(validator)
+        }
+        return builder
+            .toMutableStoreBuilder(converter)
+            .build(
+                updater = updater,
+                bookkeeper = bookkeeper,
+            )
+    }
+}

--- a/core-base/store/src/commonMain/kotlin/template/core/base/store/StorePagingSource.kt
+++ b/core-base/store/src/commonMain/kotlin/template/core/base/store/StorePagingSource.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package template.core.base.store
+
+import kotlinx.coroutines.flow.filterNot
+import kotlinx.coroutines.flow.first
+import org.mobilenativefoundation.store.store5.Store
+import org.mobilenativefoundation.store.store5.StoreReadRequest
+import org.mobilenativefoundation.store.store5.StoreReadResponse
+
+/**
+ * Key for paginated Store requests.
+ *
+ * Use this as the Store key type when the data source supports pagination.
+ * The Store will cache each page independently.
+ *
+ * @param page Zero-based page index.
+ * @param pageSize Number of items per page.
+ * @param query Optional search/filter query.
+ */
+data class PageKey(
+    val page: Int,
+    val pageSize: Int = DEFAULT_PAGE_SIZE,
+    val query: String? = null,
+) {
+    companion object {
+        const val DEFAULT_PAGE_SIZE = 20
+
+        /** First page with default size. */
+        fun first(pageSize: Int = DEFAULT_PAGE_SIZE, query: String? = null): PageKey =
+            PageKey(page = 0, pageSize = pageSize, query = query)
+    }
+
+    /** Next page key. */
+    fun next(): PageKey = copy(page = page + 1)
+
+    /** Offset for SQL LIMIT/OFFSET queries. */
+    val offset: Int get() = page * pageSize
+}
+
+/**
+ * Triggers a Store refresh for a specific page and suspends until data arrives.
+ *
+ * Use this inside a PagingSource.load() implementation to let Store handle
+ * caching while Paging handles the pagination UX.
+ *
+ * Usage in core/domain (where paging transformation lives):
+ * ```
+ * class ClientPagingSource(
+ *     private val store: Store<PageKey, List<Client>>,
+ * ) : PagingSource<Int, Client>() {
+ *
+ *     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Client> {
+ *         val page = params.key ?: 0
+ *         val pageKey = PageKey(page = page, pageSize = params.loadSize)
+ *         return store.loadPage(pageKey)
+ *     }
+ * }
+ * ```
+ *
+ * **Important:** Store's `stream()` returns an infinite Flow (never completes).
+ * This function uses `filterNot` + `first` to get the first Data or Error emission
+ * and then cancel the flow. Do NOT use `collect { return@collect }` -- `return@collect`
+ * only returns from the lambda, it does not cancel the flow.
+ *
+ * @param key The page key to load.
+ * @return Success with items and pagination keys, or Error.
+ */
+suspend fun <Value : Any> Store<PageKey, List<Value>>.loadPage(
+    key: PageKey,
+): StorePageResult<Value> {
+    val response = stream(StoreReadRequest.cached(key, refresh = true))
+        .filterNot {
+            it is StoreReadResponse.Loading ||
+                it is StoreReadResponse.NoNewData ||
+                it is StoreReadResponse.Initial
+        }
+        .first()
+
+    return when (response) {
+        is StoreReadResponse.Data -> {
+            val items = response.value
+            StorePageResult.Success(
+                items = items,
+                prevKey = if (key.page > 0) key.page - 1 else null,
+                nextKey = if (items.size >= key.pageSize) key.page + 1 else null,
+            )
+        }
+
+        is StoreReadResponse.Error -> StorePageResult.Error(response.toThrowable())
+
+        else -> StorePageResult.Error(RuntimeException("Unexpected store response: $response"))
+    }
+}
+
+/**
+ * Result of a paginated Store load, matching PagingSource.LoadResult shape.
+ *
+ * Consumer apps map this to `PagingSource.LoadResult` in their domain layer:
+ * ```
+ * when (result) {
+ *     is StorePageResult.Success -> LoadResult.Page(result.items, result.prevKey, result.nextKey)
+ *     is StorePageResult.Error -> LoadResult.Error(result.error)
+ * }
+ * ```
+ */
+sealed class StorePageResult<out T> {
+    data class Success<T>(
+        val items: List<T>,
+        val prevKey: Int?,
+        val nextKey: Int?,
+    ) : StorePageResult<T>()
+
+    data class Error(val error: Throwable) : StorePageResult<Nothing>()
+}

--- a/core-base/store/src/commonMain/kotlin/template/core/base/store/StoreResponseMapper.kt
+++ b/core-base/store/src/commonMain/kotlin/template/core/base/store/StoreResponseMapper.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package template.core.base.store
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterNot
+import kotlinx.coroutines.flow.map
+import org.mobilenativefoundation.store.store5.StoreReadResponse
+
+/**
+ * Extensions for mapping [StoreReadResponse] flows to simpler types.
+ *
+ * Repositories can use these to unwrap Store responses internally while
+ * keeping their public interface as `Flow<T>` or `Flow<Result<T>>`.
+ */
+
+/**
+ * Maps a [StoreReadResponse] flow to `Flow<Result<Output>>`.
+ *
+ * - [StoreReadResponse.Data] → [Result.success]
+ * - [StoreReadResponse.Error] → [Result.failure]
+ * - [StoreReadResponse.Loading] and [StoreReadResponse.NoNewData] are filtered out.
+ */
+fun <Output : Any> Flow<StoreReadResponse<Output>>.mapToResult(): Flow<Result<Output>> {
+    return filterNot { it is StoreReadResponse.Loading || it is StoreReadResponse.NoNewData }
+        .map { response ->
+            when (response) {
+                is StoreReadResponse.Data -> Result.success(response.value)
+
+                is StoreReadResponse.Error.Exception ->
+                    Result.failure(response.error)
+
+                is StoreReadResponse.Error.Message ->
+                    Result.failure(RuntimeException(response.message))
+
+                is StoreReadResponse.Error.Custom<*> ->
+                    Result.failure(RuntimeException("Store error: ${response.error}"))
+
+                else -> Result.failure(RuntimeException("Unexpected store response: $response"))
+            }
+        }
+}
+
+/**
+ * Maps a [StoreReadResponse] flow to `Flow<Output>`, emitting only data values.
+ *
+ * Loading, error, and no-data responses are silently filtered out.
+ * Use [mapToResult] when error handling is needed.
+ */
+fun <Output : Any> Flow<StoreReadResponse<Output>>.mapToData(): Flow<Output> {
+    return map { response ->
+        when (response) {
+            is StoreReadResponse.Data -> response.value
+            else -> null
+        }
+    }.filterNot { it == null }.map { it!! }
+}
+
+/**
+ * Returns the first [StoreReadResponse.Data] value or throws on error.
+ */
+suspend fun <Output : Any> StoreReadResponse<Output>.requireData(): Output {
+    return when (this) {
+        is StoreReadResponse.Data -> value
+        is StoreReadResponse.Error.Exception -> throw error
+        is StoreReadResponse.Error.Message -> error(message)
+        is StoreReadResponse.Error.Custom<*> -> error("Store error: $error")
+        else -> error("No data available: $this")
+    }
+}

--- a/core-base/store/src/commonMain/kotlin/template/core/base/store/di/StoreModule.kt
+++ b/core-base/store/src/commonMain/kotlin/template/core/base/store/di/StoreModule.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package template.core.base.store.di
+
+import org.koin.dsl.module
+
+/**
+ * Koin module providing base Store infrastructure.
+ *
+ * Consumer apps should include this module and add their own store bindings
+ * in their `core/data` DI module using [StoreFactory] to create store instances.
+ */
+val StoreModule = module {
+    // Base store module — intentionally minimal.
+    // StoreFactory is an object and doesn't need DI.
+    // Consumer apps wire their own Store<Key, Output> instances
+    // using their specific DAOs, API services, and converters.
+}

--- a/core-base/store/src/commonTest/kotlin/template/core/base/store/StoreDataMapperTest.kt
+++ b/core-base/store/src/commonTest/kotlin/template/core/base/store/StoreDataMapperTest.kt
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package template.core.base.store
+
+import app.cash.turbine.test
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.mobilenativefoundation.store.store5.StoreReadResponse
+import org.mobilenativefoundation.store.store5.StoreReadResponseOrigin
+import template.core.base.common.DataState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+// --- Network + Cache mode tests ---
+
+class StoreDataMapperCachedTest {
+
+    @Test
+    fun cacheDataEmitsWithCacheOrigin() = runTest {
+        val flow = flowOf(
+            StoreReadResponse.Data("cached", StoreReadResponseOrigin.SourceOfTruth),
+        )
+        flow.mapToStoreData().test {
+            val item = awaitItem()
+            assertEquals("cached", item.data)
+            assertEquals(DataOrigin.CACHE, item.origin)
+            assertFalse(item.isRefreshing)
+            assertTrue(item.isStale)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun loadingThenCacheSetsRefreshing() = runTest {
+        val flow = flowOf(
+            StoreReadResponse.Loading(StoreReadResponseOrigin.Fetcher()),
+            StoreReadResponse.Data("cached", StoreReadResponseOrigin.SourceOfTruth),
+        )
+        flow.mapToStoreData().test {
+            val item = awaitItem()
+            assertEquals("cached", item.data)
+            assertTrue(item.isRefreshing)
+            assertEquals(DataOrigin.CACHE, item.origin)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun cacheThenNetworkSequence() = runTest {
+        val flow = flowOf(
+            StoreReadResponse.Loading(StoreReadResponseOrigin.Fetcher()),
+            StoreReadResponse.Data("cached", StoreReadResponseOrigin.SourceOfTruth),
+            StoreReadResponse.Data("fresh", StoreReadResponseOrigin.Fetcher()),
+        )
+        flow.mapToStoreData().test {
+            val cached = awaitItem()
+            assertEquals("cached", cached.data)
+            assertTrue(cached.isRefreshing)
+            assertTrue(cached.isStale)
+
+            val fresh = awaitItem()
+            assertEquals("fresh", fresh.data)
+            assertFalse(fresh.isRefreshing)
+            assertFalse(fresh.isStale)
+            assertNotNull(fresh.fetchedAt)
+            assertEquals(DataOrigin.NETWORK, fresh.origin)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun errorAfterCacheKeepsLastData() = runTest {
+        val flow = flowOf(
+            StoreReadResponse.Data("cached", StoreReadResponseOrigin.SourceOfTruth),
+            StoreReadResponse.Error.Exception(
+                error = RuntimeException("timeout"),
+                origin = StoreReadResponseOrigin.Fetcher(),
+            ),
+        )
+        flow.mapToStoreDataWithErrors(fallback = "unused").test {
+            val cached = awaitItem()
+            assertEquals("cached", cached.data)
+            assertNull(cached.error)
+            assertTrue(cached.isSuccess)
+
+            val errored = awaitItem()
+            assertEquals("cached", errored.data)
+            assertNotNull(errored.error)
+            assertFalse(errored.isEmpty)
+            assertFalse(errored.isError)
+            awaitComplete()
+        }
+    }
+}
+
+// --- Network-only mode tests ---
+
+class StoreDataMapperNetworkOnlyTest {
+
+    @Test
+    fun networkOnlySuccessEmitsWithNetworkOrigin() = runTest {
+        val flow = flowOf(
+            StoreReadResponse.Loading(StoreReadResponseOrigin.Fetcher()),
+            StoreReadResponse.Data("fresh", StoreReadResponseOrigin.Fetcher()),
+        )
+        flow.mapToStoreData().test {
+            val item = awaitItem()
+            assertEquals("fresh", item.data)
+            assertEquals(DataOrigin.NETWORK, item.origin)
+            assertFalse(item.isRefreshing)
+            assertFalse(item.isStale)
+            assertNotNull(item.fetchedAt)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun networkOnlyErrorBeforeAnyData() = runTest {
+        val flow = flowOf(
+            StoreReadResponse.Loading(StoreReadResponseOrigin.Fetcher()),
+            StoreReadResponse.Error.Message(
+                message = "Network unavailable",
+                origin = StoreReadResponseOrigin.Fetcher(),
+            ),
+        )
+        flow.mapToStoreDataWithErrors(fallback = "none").test {
+            val item = awaitItem()
+            assertEquals("none", item.data)
+            assertTrue(item.isEmpty)
+            assertTrue(item.isError)
+            val error = assertNotNull(item.error)
+            assertEquals("Network unavailable", error.message)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun networkOnlyEmptyResult() = runTest {
+        val flow = flowOf(
+            StoreReadResponse.Data(emptyList<String>(), StoreReadResponseOrigin.Fetcher()),
+        )
+        flow.mapToStoreData(isEmpty = { it.isEmpty() }).test {
+            val item = awaitItem()
+            assertTrue(item.isEmpty)
+            assertTrue(item.data.isEmpty())
+            assertEquals(DataOrigin.NETWORK, item.origin)
+            awaitComplete()
+        }
+    }
+}
+
+// --- Shared behavior tests ---
+
+class StoreDataMapperSharedTest {
+
+    @Test
+    fun initialResponseProducesNoEmissions() = runTest {
+        flowOf(StoreReadResponse.Initial)
+            .mapToStoreData().test { awaitComplete() }
+    }
+
+    @Test
+    fun loadingAloneProducesNoEmissions() = runTest {
+        flowOf(StoreReadResponse.Loading(StoreReadResponseOrigin.Fetcher()))
+            .mapToStoreData().test { awaitComplete() }
+    }
+
+    @Test
+    fun noNewDataProducesNoEmissions() = runTest {
+        flowOf(StoreReadResponse.NoNewData(StoreReadResponseOrigin.Fetcher()))
+            .mapToStoreData().test { awaitComplete() }
+    }
+
+    @Test
+    fun memoryOriginMapsCorrectly() = runTest {
+        flowOf(StoreReadResponse.Data("memory", StoreReadResponseOrigin.Cache))
+            .mapToStoreData().test {
+                assertEquals(DataOrigin.MEMORY, awaitItem().origin)
+                awaitComplete()
+            }
+    }
+}
+
+// --- StoreData property tests ---
+
+class StoreDataTest {
+
+    @Test
+    fun isStaleWhenNeverFetched() {
+        val data = StoreData("test", DataOrigin.CACHE, fetchedAt = null)
+        assertTrue(data.isStale)
+        assertNull(data.staleDuration)
+    }
+
+    @Test
+    fun notStaleWhenFetched() {
+        val mark = kotlin.time.TimeSource.Monotonic.markNow()
+        val data = StoreData("test", DataOrigin.NETWORK, fetchedAt = mark)
+        assertFalse(data.isStale)
+        assertNotNull(data.staleDuration)
+    }
+
+    @Test
+    fun networkOriginNeverStale() {
+        val data = StoreData("test", DataOrigin.NETWORK, fetchedAt = null)
+        assertFalse(data.isStale)
+    }
+
+    @Test
+    fun isSuccessWhenNoErrorAndNotEmpty() {
+        val data = StoreData("test", DataOrigin.NETWORK)
+        assertTrue(data.isSuccess)
+        assertFalse(data.isError)
+    }
+
+    @Test
+    fun isErrorWhenErrorAndEmpty() {
+        val data = StoreData(
+            "",
+            DataOrigin.NETWORK,
+            error = RuntimeException("fail"),
+            isEmpty = true,
+        )
+        assertTrue(data.isError)
+        assertFalse(data.isSuccess)
+    }
+
+    @Test
+    fun mapPreservesMetadata() {
+        val mark = kotlin.time.TimeSource.Monotonic.markNow()
+        val original = StoreData(
+            "42",
+            DataOrigin.NETWORK,
+            isRefreshing = true,
+            fetchedAt = mark,
+        )
+        val mapped = original.map { it.toInt() }
+        assertEquals(42, mapped.data)
+        assertEquals(DataOrigin.NETWORK, mapped.origin)
+        assertTrue(mapped.isRefreshing)
+        assertEquals(mark, mapped.fetchedAt)
+    }
+}
+
+// --- DataState bridge tests ---
+
+class StoreDataBridgeTest {
+
+    @Test
+    fun toDataStateSuccess() {
+        val data = StoreData("test", DataOrigin.NETWORK)
+        assertTrue(data.toDataState() is DataState.Success)
+    }
+
+    @Test
+    fun toDataStatePendingWhenRefreshing() {
+        val data = StoreData("cached", DataOrigin.CACHE, isRefreshing = true)
+        val state = data.toDataState()
+        assertTrue(state is DataState.Pending)
+        assertEquals("cached", state.data)
+    }
+
+    @Test
+    fun toDataStateErrorWithData() {
+        val data = StoreData("stale", DataOrigin.CACHE, error = RuntimeException("fail"))
+        val state = data.toDataState()
+        assertTrue(state is DataState.Error)
+        assertEquals("stale", state.data)
+    }
+
+    @Test
+    fun toDataStateLoadingWhenEmpty() {
+        val data = StoreData("", DataOrigin.NETWORK, isEmpty = true)
+        assertTrue(data.toDataState() is DataState.Loading)
+    }
+
+    @Test
+    fun toDataStateErrorWithNoData() {
+        val data = StoreData(
+            "",
+            DataOrigin.NETWORK,
+            error = RuntimeException("fail"),
+            isEmpty = true,
+        )
+        val state = data.toDataState()
+        assertTrue(state is DataState.Error)
+        assertNull(state.data)
+    }
+}

--- a/docs/STORE_DATA_API.md
+++ b/docs/STORE_DATA_API.md
@@ -1,0 +1,497 @@
+# StoreData API — Unified Offline-First Data Layer
+
+> **Module:** `core-base/store` (synced to all consumer apps via sync-dirs.sh)
+> **Package:** `template.core.base.store`
+> **Store 5 Version:** 5.1.0-alpha08
+
+---
+
+## Overview
+
+The StoreData API provides a **unified interface** for feature modules to consume data from repositories without knowing whether the data comes from a network API, a local Room database, or an in-memory cache. It wraps [MobileNativeFoundation/Store 5](https://github.com/MobileNativeFoundation/Store) responses into a single `StoreData<T>` type that carries data + metadata about origin, staleness, refresh status, and errors.
+
+### Key Design Principles
+
+1. **ViewModel doesn't care about the source** — same API for network+cache and network-only stores
+2. **Cache-then-refresh UX** — show cached data instantly, update when network responds
+3. **Staleness awareness** — feature modules know how old their data is
+4. **Error recovery** — show stale data with an error indicator instead of a blank screen
+5. **Empty state detection** — distinguish "empty result" from "no data yet"
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Feature Module (ViewModel)                                  │
+│                                                              │
+│  collects Flow<StoreData<T>>  or  Flow<DataState<T>>        │
+│  (calls repository directly — no use case needed)            │
+│  (calls domain use case — only for paging/transformation)    │
+└──────────────────┬──────────────────────────────────────────┘
+                   │
+┌──────────────────▼──────────────────────────────────────────┐
+│  core/data (Repository)                                      │
+│                                                              │
+│  store.streamData(key)          → Flow<StoreData<T>>        │
+│  store.streamDataWithErrors(…)  → Flow<StoreData<T>>        │
+│  store.freshData(key)           → Flow<StoreData<T>>        │
+│  store.localData(key)           → Flow<StoreData<T>>        │
+└──────────────────┬──────────────────────────────────────────┘
+                   │
+┌──────────────────▼──────────────────────────────────────────┐
+│  core-base/store                                             │
+│                                                              │
+│  ┌─────────────────┐  ┌──────────────────┐                  │
+│  │ StoreData<T>     │  │ StoreDataMapper  │                  │
+│  │ DataOrigin       │  │ mapToStoreData() │                  │
+│  │ toDataState()    │  │ mapToStoreData   │                  │
+│  │ map()            │  │   WithErrors()   │                  │
+│  └─────────────────┘  └──────────────────┘                  │
+│                                                              │
+│  ┌─────────────────┐  ┌──────────────────┐                  │
+│  │ StoreFactory     │  │ PageKey          │                  │
+│  │ createStore()    │  │ StorePageResult  │                  │
+│  │ createMemory     │  │ loadPage()       │                  │
+│  │   Store()        │  │                  │                  │
+│  │ createMutable    │  │                  │                  │
+│  │   Store()        │  │                  │                  │
+│  └─────────────────┘  └──────────────────┘                  │
+└──────────────────┬──────────────────────────────────────────┘
+                   │
+        ┌──────────┴──────────┐
+        │                     │
+┌───────▼───────┐   ┌────────▼────────┐
+│ core/network  │   │ core/database   │
+│ (Ktor Fetcher)│   │ (Room 3 SOT)   │
+└───────────────┘   └─────────────────┘
+```
+
+---
+
+## Source Modes
+
+The same `StoreData<T>` type works for both modes. The difference is in how the Store is created — the consumer (ViewModel) never knows.
+
+### Mode 1: Network + Cache (offline-first)
+
+Store created with `StoreFactory.createStore(fetcher, sourceOfTruth)`.
+
+**Emission sequence:**
+```
+Initial → Loading(Fetcher) → Data(SourceOfTruth) → Data(Fetcher)
+```
+
+**StoreData mapping:**
+```
+Loading       → (no emission — sets refreshing flag)
+Data(SOT)     → StoreData(data, origin=CACHE, isRefreshing=true, isStale=true)
+Data(Fetcher) → StoreData(data, origin=NETWORK, isRefreshing=false, isStale=false)
+```
+
+**UX:** Data shows instantly from cache → subtle progress indicator → data updates silently.
+
+### Mode 2: Network Only (no database)
+
+Store created with `StoreFactory.createMemoryStore(fetcher)`.
+
+**Emission sequence:**
+```
+Initial → Loading(Fetcher) → Data(Fetcher)
+```
+
+**StoreData mapping:**
+```
+Loading       → (no emission — sets refreshing flag)
+Data(Fetcher) → StoreData(data, origin=NETWORK, isRefreshing=false, isStale=false)
+```
+
+**UX:** Loading spinner → data appears. No cache/staleness concept.
+
+---
+
+## API Reference
+
+### `StoreData<T>`
+
+The core data class that carries data + metadata.
+
+```kotlin
+data class StoreData<out T>(
+    val data: T,               // The actual payload
+    val origin: DataOrigin,    // CACHE, NETWORK, or MEMORY
+    val isRefreshing: Boolean, // Network fetch in progress?
+    val fetchedAt: TimeMark?,  // When last fetched from network
+    val error: Throwable?,     // Non-null if refresh failed
+    val isEmpty: Boolean,      // True if data is empty (empty list, etc.)
+)
+```
+
+**Computed properties:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `isStale` | `Boolean` | True if data has never been fetched from network (cache-only). Always false for `origin=NETWORK`. |
+| `staleDuration` | `Duration?` | Time elapsed since last network fetch. Null if never fetched. |
+| `isSuccess` | `Boolean` | True if no error and not empty. |
+| `isError` | `Boolean` | True if error exists and data is empty (terminal error). |
+
+### `DataOrigin`
+
+```kotlin
+enum class DataOrigin {
+    CACHE,    // From Room database (SourceOfTruth)
+    NETWORK,  // From API (Fetcher)
+    MEMORY,   // From Store's in-memory cache
+}
+```
+
+### Mapper Functions
+
+#### `mapToStoreData()`
+
+Maps `Flow<StoreReadResponse<T>>` → `Flow<StoreData<T>>`. Skips errors silently.
+
+```kotlin
+fun <T : Any> Flow<StoreReadResponse<T>>.mapToStoreData(
+    isEmpty: (T) -> Boolean = { false },
+): Flow<StoreData<T>>
+```
+
+#### `mapToStoreDataWithErrors()`
+
+Same as above but emits on errors too, carrying last known data.
+
+```kotlin
+fun <T : Any> Flow<StoreReadResponse<T>>.mapToStoreDataWithErrors(
+    fallback: T,                          // Used if error arrives before any data
+    isEmpty: (T) -> Boolean = { false },
+): Flow<StoreData<T>>
+```
+
+### Store Extensions
+
+One-liner convenience functions for repositories.
+
+```kotlin
+// Primary API — cache-first with optional refresh
+store.streamData(key, refresh = true, isEmpty = { it.isEmpty() })
+
+// Same but with error emissions
+store.streamDataWithErrors(key, fallback = emptyList(), isEmpty = { it.isEmpty() })
+
+// Force network fetch (pull-to-refresh)
+store.freshData(key, isEmpty = { it.isEmpty() })
+
+// Local only, no network
+store.localData(key, isEmpty = { it.isEmpty() })
+```
+
+### Transform Functions
+
+```kotlin
+// Transform data while preserving all metadata
+val mapped: StoreData<Int> = storeData.map { it.toInt() }
+
+// Transform a Flow of StoreData
+val flow: Flow<StoreData<Int>> = storeDataFlow.mapData { it.toInt() }
+```
+
+### DataState Bridge
+
+```kotlin
+// Convert to DataState for ViewModels using the existing pattern
+val dataState: DataState<T> = storeData.toDataState()
+```
+
+Mapping rules:
+
+| StoreData state | DataState |
+|----------------|-----------|
+| isEmpty + no error | `DataState.Loading` |
+| isRefreshing + data | `DataState.Pending(data)` |
+| error + no data | `DataState.Error(error, null)` |
+| error + stale data | `DataState.Error(error, data)` |
+| success | `DataState.Success(data)` |
+
+---
+
+## Paging Support
+
+For paginated lists, use `PageKey` as the Store key and `loadPage()` in a PagingSource.
+
+### `PageKey`
+
+```kotlin
+data class PageKey(
+    val page: Int,                          // Zero-based page index
+    val pageSize: Int = 20,                 // Items per page
+    val query: String? = null,              // Optional search filter
+) {
+    val offset: Int get() = page * pageSize // For SQL LIMIT/OFFSET
+    fun next(): PageKey                     // Next page
+}
+```
+
+### `loadPage()`
+
+Suspends until the first Data or Error response, then cancels the Store stream.
+
+```kotlin
+suspend fun <T : Any> Store<PageKey, List<T>>.loadPage(
+    key: PageKey,
+): StorePageResult<T>
+```
+
+> **Implementation note:** Store's `stream()` returns an **infinite Flow** that never completes.
+> `loadPage()` uses `filterNot { Loading/NoNewData/Initial }.first()` to get the first
+> meaningful response and cancel. Do NOT use `collect { return@collect }` — `return@collect`
+> only returns from the lambda, it does not cancel the flow.
+
+### PagingSource Integration (in core/domain)
+
+```kotlin
+class ClientPagingSource(
+    private val store: Store<PageKey, List<Client>>,
+) : PagingSource<Int, Client>() {
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Client> {
+        val page = params.key ?: 0
+        val pageKey = PageKey(page, params.loadSize)
+        return when (val result = store.loadPage(pageKey)) {
+            is StorePageResult.Success -> LoadResult.Page(
+                data = result.items,
+                prevKey = result.prevKey,
+                nextKey = result.nextKey,
+            )
+            is StorePageResult.Error -> LoadResult.Error(result.error)
+        }
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, Client>): Int? =
+        state.anchorPosition?.let { state.closestPageToPosition(it)?.prevKey?.plus(1) }
+}
+```
+
+---
+
+## Usage Patterns
+
+### Pattern 1: Network + Cache (most features)
+
+```kotlin
+// ── core/data ──
+class ClientRepository(
+    private val store: Store<ClientKey, List<Client>>,
+) : ClientRepositoryApi {
+    override fun getClients(key: ClientKey): Flow<StoreData<List<Client>>> =
+        store.streamDataWithErrors(key, fallback = emptyList(), isEmpty = { it.isEmpty() })
+}
+
+// ── feature/ (ViewModel calls repo directly) ──
+class ClientListViewModel(
+    private val repository: ClientRepositoryApi,
+) : ViewModel() {
+
+    val state: StateFlow<DataState<List<Client>>> = repository.getClients(ClientKey(0))
+        .mapData { clients -> clients.sortedBy { it.name } }
+        .map { it.toDataState() }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DataState.Loading)
+}
+```
+
+### Pattern 2: Network Only (transient data)
+
+```kotlin
+// ── core/data ──
+class ExchangeRateRepository(
+    private val store: Store<CurrencyKey, ExchangeRate>,  // createMemoryStore(fetcher)
+) : ExchangeRateRepositoryApi {
+    override fun getRate(key: CurrencyKey): Flow<StoreData<ExchangeRate>> =
+        store.streamDataWithErrors(key, fallback = ExchangeRate.EMPTY)
+}
+
+// ── feature/ (IDENTICAL ViewModel code — doesn't know it's network-only) ──
+class ExchangeViewModel(
+    private val repository: ExchangeRateRepositoryApi,
+) : ViewModel() {
+
+    val state = repository.getRate(CurrencyKey("USD"))
+        .map { it.toDataState() }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DataState.Loading)
+}
+```
+
+### Pattern 3: Paging (large lists via core/domain)
+
+```kotlin
+// ── core/domain (transformation needed — use case) ──
+class GetClientsPaginatedUseCase(
+    private val store: Store<PageKey, List<Client>>,
+) {
+    operator fun invoke(query: String? = null): Flow<PagingData<Client>> =
+        Pager(
+            config = PagingConfig(pageSize = PageKey.DEFAULT_PAGE_SIZE),
+            pagingSourceFactory = { ClientPagingSource(store) },
+        ).flow
+}
+
+// ── feature/ (ViewModel calls use case) ──
+class ClientListViewModel(
+    private val getClientsPaginated: GetClientsPaginatedUseCase,
+) : ViewModel() {
+    val pagingData = getClientsPaginated(query = null).cachedIn(viewModelScope)
+}
+```
+
+### Pattern 4: Using StoreData directly (rich UX)
+
+```kotlin
+// ── feature/ (use StoreData fields directly for rich UI) ──
+class ClientListViewModel(
+    private val repository: ClientRepositoryApi,
+) : ViewModel() {
+
+    data class UiState(
+        val clients: List<Client> = emptyList(),
+        val isLoading: Boolean = true,
+        val isRefreshing: Boolean = false,
+        val dataOrigin: DataOrigin? = null,
+        val isStale: Boolean = false,
+        val staleDuration: Duration? = null,
+        val error: String? = null,
+        val isEmpty: Boolean = false,
+    )
+
+    val state: StateFlow<UiState> = repository.getClients(ClientKey(0))
+        .map { storeData ->
+            UiState(
+                clients = storeData.data,
+                isLoading = false,
+                isRefreshing = storeData.isRefreshing,
+                dataOrigin = storeData.origin,
+                isStale = storeData.isStale,
+                staleDuration = storeData.staleDuration,
+                error = storeData.error?.message,
+                isEmpty = storeData.isEmpty,
+            )
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), UiState())
+}
+
+// ── Compose UI ──
+@Composable
+fun ClientListScreen(state: UiState) {
+    if (state.isRefreshing) LinearProgressIndicator(Modifier.fillMaxWidth())
+    if (state.isStale) InfoBanner("Data may be outdated")
+    state.staleDuration?.let { if (it > 30.minutes) InfoBanner("Updated ${it.inWholeMinutes}m ago") }
+    state.error?.let { Snackbar("Couldn't refresh: $it") }
+    if (state.isEmpty && !state.isLoading) EmptyState("No clients found")
+    LazyColumn { items(state.clients) { ClientItem(it) } }
+}
+```
+
+---
+
+## When to Use Domain Layer
+
+| Scenario | Layer | Why |
+|----------|-------|-----|
+| Simple data fetch | `core/data` → ViewModel | No transformation needed |
+| Sort/filter data | `core/data` → ViewModel (use `mapData`) | Simple transformation via extension |
+| Combine multiple repos | `core/domain` use case | Multiple data sources need merging |
+| Paging | `core/domain` use case | PagingSource is a transformation layer |
+| Complex business logic | `core/domain` use case | Validation, calculations, etc. |
+
+---
+
+## Module Structure
+
+```
+core-base/store/
+├── build.gradle.kts
+├── src/
+│   ├── commonMain/kotlin/template/core/base/store/
+│   │   ├── StoreFactory.kt            # Store/MutableStore creation (existing)
+│   │   ├── StoreResponseMapper.kt     # mapToResult/mapToData (existing)
+│   │   ├── DefaultValidator.kt        # TTL-based cache validation (existing)
+│   │   ├── InMemoryBookkeeper.kt      # Offline sync tracking (existing)
+│   │   ├── StoreData.kt              # StoreData<T> + DataOrigin + toDataState()
+│   │   ├── StoreDataMapper.kt        # mapToStoreData + mapToStoreDataWithErrors
+│   │   ├── StoreDataExtensions.kt    # streamData, freshData, localData, map
+│   │   ├── StorePagingSource.kt      # PageKey + loadPage + StorePageResult
+│   │   └── di/
+│   │       └── StoreModule.kt         # Koin module (existing)
+│   └── commonTest/kotlin/template/core/base/store/
+│       └── StoreDataMapperTest.kt     # 20+ test cases
+```
+
+---
+
+## UX Scenario Matrix
+
+| Scenario | Source Mode | StoreData State | UI Behavior |
+|----------|-----------|-----------------|-------------|
+| First load (no cache) | N+C | Loading → Data(Network) | Spinner → data |
+| Cached data + refresh | N+C | Data(Cache, refreshing) → Data(Network) | Data instantly + progress → updated |
+| Cache hit, no changes | N+C | Data(Cache) → NoNewData | Data shown, no indicator |
+| Network fails, has cache | N+C | Data(Cache) → Error(stale data) | Stale data + "Couldn't refresh" snackbar |
+| Network fails, no cache | N+C | Error(isEmpty=true) | Error screen + retry |
+| Network success | N-only | Loading → Data(Network) | Spinner → data |
+| Network fails | N-only | Loading → Error(isEmpty=true) | Error screen + retry |
+| Empty result | Both | Data(isEmpty=true) | Empty state UI |
+| TTL expired | N+C | Data(Cache, isStale) + refreshing | "Outdated" badge + auto-refresh |
+| Pull-to-refresh | Both | freshData() → Data(Network) | Refresh indicator → data |
+| Paginated list | N+C | PagingData via domain use case | Lazy list + page loading |
+
+---
+
+## Store 5 API Notes
+
+### StoreReadResponseOrigin (verified from bytecode)
+
+`StoreReadResponseOrigin` is a **standalone top-level sealed class** — NOT nested inside `StoreReadResponse`.
+
+```kotlin
+import org.mobilenativefoundation.store.store5.StoreReadResponseOrigin
+
+// Variants:
+StoreReadResponseOrigin.Fetcher()       // data class with optional name: String?
+StoreReadResponseOrigin.SourceOfTruth   // object
+StoreReadResponseOrigin.Cache           // object
+StoreReadResponseOrigin.Initial         // object
+```
+
+### Store.stream() is Infinite
+
+`Store.stream()` returns a **never-completing Flow**. It continues emitting updates as long as the collector is active. Use `.first()` when you need a single value (like in `loadPage()`).
+
+### StoreReadRequest Variants
+
+```kotlin
+StoreReadRequest.cached(key, refresh = true)              // Cache-first, optionally refresh
+StoreReadRequest.fresh(key, fallBackToSourceOfTruth = true)  // Force network
+StoreReadRequest.localOnly(key)                           // Cache/SOT only, no network
+StoreReadRequest.skipMemory(key, refresh = true)          // Bypass in-memory cache
+```
+
+---
+
+## Dependencies
+
+```kotlin
+// core-base/store/build.gradle.kts
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            api(libs.store5)                          // Store 5
+            api(libs.store5.cache)                    // Cache 5
+            implementation(libs.kotlinx.coroutines.core)
+            implementation(project(":core-base:common"))  // DataState bridge
+        }
+    }
+}
+```
+
+Consumer apps that need paging add `androidx.paging` to their own `libs.versions.toml` — it is NOT a dependency of `core-base/store`.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -107,6 +107,9 @@ desktopPackageVersion = "1.0.0"
 # Android Version
 androidPackageNamespace = "cmp.android.app"
 
+# Store 5
+store = "5.1.0-alpha08"
+
 #Room 3
 room = "3.0.0-alpha03"
 sqliteBundled = "2.6.2"
@@ -325,6 +328,9 @@ gitlive-firebase-performance = { module = "dev.gitlive:firebase-performance", ve
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 roborazzi = { group = "io.github.takahirom.roborazzi", name = "roborazzi", version.ref = "roborazzi" }
 roborazzi-accessibility-check = { group = "io.github.takahirom.roborazzi", name = "roborazzi-accessibility-check", version.ref = "roborazzi" }
+
+store5 = { group = "org.mobilenativefoundation.store", name = "store5", version.ref = "store" }
+store5-cache = { group = "org.mobilenativefoundation.store", name = "cache5", version.ref = "store" }
 
 aboutlibraries-core = { module = "com.mikepenz:aboutlibraries-core", version.ref = "aboutLibraries" }
 aboutlibraries-compose-core = { module = "com.mikepenz:aboutlibraries-compose", version.ref = "aboutLibraries" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -80,6 +80,7 @@ include(":core-base:database")
 include(":core-base:designsystem")
 include(":core-base:network")
 include(":core-base:platform")
+include(":core-base:store")
 include(":core-base:ui")
 
 check(JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {


### PR DESCRIPTION
## Summary

- Add `StoreData<T>` unified wrapper carrying data origin (CACHE/NETWORK/MEMORY), staleness tracking, refresh status, and error metadata
- Add `mapToStoreData()` / `mapToStoreDataWithErrors()` Flow transformers that work identically for both Network+Cache and Network-only Store modes
- Add Store convenience extensions: `streamData()`, `freshData()`, `localData()`, `streamDataWithErrors()` — the primary repository API
- Add `StoreData.map()` / `Flow<StoreData>.mapData()` for content transformation preserving all metadata
- Add `toDataState()` bridge for ViewModels migrating from existing DataState patterns
- Add `PageKey` + `loadPage()` + `StorePageResult` for paginated Store integration (used in core/domain PagingSource implementations)
- Add 20 test cases covering cached mode, network-only mode, shared behavior, property verification, and DataState bridge

## Design

- `StoreData<T>` is a data class (not sealed) — all emissions carry data, loading-without-data uses `DataState.Loading` before Store stream starts
- Source mode (Network+Cache vs Network-only) is determined by how the Store was created (`createStore` vs `createMemoryStore`) — same API surface for both
- `StoreReadResponseOrigin` (top-level sealed class in Store 5) is mapped to `DataOrigin` enum internally
- `isStale` is always `false` for `NETWORK` origin (network-only stores have no staleness concept)
- Paging utilities live in core-base/store but actual PagingSource implementations go in consumer app's core/domain layer
- Uses `kotlin.time.TimeSource.Monotonic` (not kotlinx-datetime) consistent with existing `DefaultValidator`

## Test plan

- [x] `StoreDataMapperCachedTest` — cache origin, loading+cache refreshing, cache-then-network sequence, error-after-cache
- [x] `StoreDataMapperNetworkOnlyTest` — network success, error-before-data, empty result detection
- [x] `StoreDataMapperSharedTest` — Initial/Loading/NoNewData produce no emissions, memory origin mapping
- [x] `StoreDataTest` — isStale, notStale, networkNeverStale, isSuccess, isError, map preserves metadata
- [x] `StoreDataBridgeTest` — toDataState for Success, Pending, Error+data, Loading, Error+noData
- [x] spotlessApply passes
- [x] detekt passes
- [x] desktopTest passes (all 20 tests green, zero warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a unified data layer abstraction for offline-first repositories with enhanced tracking of data origin, refresh status, staleness, and errors.
  * Added utility functions for common data-fetching patterns including cached, fresh, and local-only reads.
  * Added pagination support for paginated data sources.
  * Integrated Koin dependency injection module for store configuration.

* **Documentation**
  * Added comprehensive Store Data API documentation with usage examples and best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->