### PR TITLE
fix(cmp-shared): gate iOS framework optimized=true on RELEASE only

### DIFF
--- a/cmp-shared/build.gradle.kts
+++ b/cmp-shared/build.gradle.kts
@@ -8,6 +8,8 @@
  * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
  */
 
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
+
 plugins {
     alias(libs.plugins.kmp.library.convention)
     alias(libs.plugins.cmp.feature.convention)
@@ -23,7 +25,9 @@ kotlin {
         iosTarget.binaries.framework {
             baseName = "ComposeApp"
             isStatic = true
-            optimized = true
+            // KGP rejects debuggable=true + optimized=true on the same binary
+            // (kotlin:kgp:misconfiguration:incompatible-binary-configuration).
+            optimized = buildType == NativeBuildType.RELEASE
         }
     }
 


### PR DESCRIPTION
## Summary
Gate `optimized = true` on `NativeBuildType.RELEASE` for iOS framework binaries. The previous config set `optimized=true` unconditionally across all iOS frameworks, so the implicit `debugFramework` inherited optimization — which KGP rejects as a misconfiguration:

> w: ⚠️ Incompatible Binary Configuration
> Binary 'debugFramework' in project ':cmp-shared' has incompatible configuration: debuggable=true and optimized=true. Optimization significantly increases compile time and makes debugging difficult, which defeats the purpose of a debuggable build.
> Problem found: Incompatible Binary Configuration (id: `kotlin:kgp:misconfiguration:incompatible-binary-configuration`)

## Behavior change
- **Debug** iOS frameworks (`linkDebug*`): `optimized=false` — faster compile, debuggable.
- **Release** iOS frameworks (`linkRelease*`): `optimized=true` — unchanged from current behavior.

## Test plan
- [x] `./gradlew :cmp-shared:linkDebugFrameworkIosSimulatorArm64 --warning-mode all` → BUILD SUCCESSFUL, 0 incompatible-binary warnings (was 3 before).
- [ ] CI green on this PR.