### PR TITLE
chore(canary): bump kmp-product-flavors 1.1.5 → 2.4.0-alpha.0

### DIFF
--- a/build-logic/convention/src/main/kotlin/KMPFlavorsConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KMPFlavorsConventionPlugin.kt
@@ -63,6 +63,13 @@ class KMPFlavorsConventionPlugin : Plugin<Project> {
             //    the plugin default ("BuildKonfig"). bridgeAgp* defaults are safe (idempotent
             //    in v1.1.5+) — no need to touch them.
             extensions.configure<KmpFlavorExtension> {
+                // v2.2+ — preserve v1.x active-variant-only semantics. The template''s
+                // AppVariant.kt reads BuildKonfig from commonMain; v2.2+ auto-enabling
+                // matrix mode (Phase 0A) moves BuildKonfig into per-flavor source sets,
+                // which commonMain can''t see. Explicit opt-out keeps the v1.x codegen
+                // + demonstrates the documented kmpFlavors.autoEnable.set(false) opt-out
+                // migration path described in CHANGELOG [2.2.0] + MATRIX_MODE.md.
+                autoEnable.set(false)
                 buildConfigPackage.set(libs.findVersion("appPackage").get().requiredVersion)
                 enableBuildTypes.set(true)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kmpProductFlavors = "1.1.5"
+kmpProductFlavors = "2.4.0-alpha.0"
 appPackage = "org.openmf.kmptemplate"
 # Android
 androidDesugarJdkLibs = "2.1.5"


### PR DESCRIPTION
## Summary

v2.4 plan Phase 6C — adoption canary against `openMF/kmp-project-template`. First canary PR after a 3-major-version gap (template at `1.1.5`; v2.0, v2.1, v2.2-alpha, v2.4-alpha have shipped since).

## Two changes bundled

1. **`gradle/libs.versions.toml`**: `kmpProductFlavors = "1.1.5"` → `"2.4.0-alpha.0"`.
2. **`build-logic/convention/src/main/kotlin/KMPFlavorsConventionPlugin.kt`**: adds `kmpFlavors.autoEnable.set(false)` as the first DSL call inside `extensions.configure<KmpFlavorExtension> { }`.

## Why `autoEnable.set(false)`

v2.2 Phase 0A auto-enables matrix mode when the project's target × flavor shape clears the heuristic threshold. This template trips it (6 non-Android targets × 2 flavors × 3 buildTypes = 36 variants). Auto-enabled matrix mode moves `BuildKonfig` codegen out of `commonMain` into per-flavor source sets — but `AppVariant.kt` reads `BuildKonfig` from `commonMain`, breaking the build.

`autoEnable.set(false)` preserves v1.x active-variant-only semantics, which is what the existing `AppVariant.kt` expects. Documented v1.x → v2.x migration path in [`MATRIX_MODE.md`](https://github.com/MobileByteLabs/kmp-product-flavors/blob/development/docs/MATRIX_MODE.md) + [`CHANGELOG [2.2.0]`](https://github.com/MobileByteLabs/kmp-product-flavors/blob/development/CHANGELOG.md).

## Plugin scope (since v1.1.5)

- [v2.0.0](https://github.com/MobileByteLabs/kmp-product-flavors/releases/tag/v2.0.0) — per-variant Kotlin compilation matrix.
- [v2.1.0](https://github.com/MobileByteLabs/kmp-product-flavors/releases/tag/v2.1.0) — AGP-parity completion.
- [v2.2.0-alpha.0/1](https://github.com/MobileByteLabs/kmp-product-flavors/releases/tag/v2.2.0-alpha.1) — fully-automatic defaults + native publishing (XCFramework, SPM, npm).
- [v2.4.0-alpha.0](https://github.com/MobileByteLabs/kmp-product-flavors/releases/tag/v2.4.0-alpha.0) — variant-conditional dep excludes, cache namespacing impl, Compose hot-reload Option-B workaround.

For consumers using only the v1.x DSL surface, `autoEnable.set(false)` keeps behaviour byte-identical. The bump should be drop-in.

## Test plan

- [ ] CI green across all `cmp-*` modules.
- [ ] No regression in active variant (`demoBankADebug` by default).
- [ ] Watch for KMPF-V14 (CMP version < 1.7.0) — bump CMP if flagged.

## Maintainer note

Opened as a manual canary because the kmp-product-flavors repo's `PAT_CANARY_PR` secret for automated cross-org PR creation isn't provisioned. Once provisioned, the [`Auto-canary against kmp-project-template`](https://github.com/MobileByteLabs/kmp-product-flavors/actions/workflows/auto-canary.yml) workflow will run automatically on every release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated KMP Product Flavors plugin dependency to v2.4.0-alpha.0 (from v1.1.5)
  * Updated KMP flavor configuration settings to align with new plugin version behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/kmp-project-template/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->