### PR TITLE
docs(store): align screen-archetype vocabulary with Compose API names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,10 +208,17 @@ see the **screen-type taxonomy table** in `core/store/README.md` — it maps eve
 common screen type to the right framework API. (`PagingScreenContent` is for
 infinite-scroll paginated lists only; detail pages use `ScreenContent`.)
 
-For **form submission and mutations**, use `SubmitHandler` (simple) or `DraftSubmitHandler`
+For **input screens** (form, wizard, quick-action, confirm, gesture — anything where
+the user submits a mutation), use `SubmitHandler` (simple) or `DraftSubmitHandler`
 (offline-resilient, persists payload across restarts). Wire the screen with
 `MutationScreenContent`. Control network vs. cache strategy per-request via `FetchPolicy`
 (`CACHE_ONLY` / `NETWORK_ONLY` / `CACHE_THEN_NETWORK`).
+
+> Screen-archetype vocabulary (used by `/kmp-feature` codegen via `ui.yaml.screens[].type`):
+> `screen-content` (→ `ScreenContent`), `paging-list` (→ `PagingScreenContent`),
+> `input` (→ `MutationScreenContent` + `SubmitHandler`/`DraftSubmitHandler`),
+> `custom` (bring-your-own), `pure-ui` (no Store). Names align 1:1 with the Compose
+> composable that wraps the screen body — see `core/store/README.md` taxonomy table.
 
 On **logout**, call `storeCacheManager.clearAll()` to wipe all Store caches and draft rows.
 On **app start**, call `storeCacheManager.pruneExpiredDrafts()` to remove SUBMITTED/FAILED

--- a/core/store/README.md
+++ b/core/store/README.md
@@ -25,21 +25,31 @@ the decision logic lives in `core-base/store`'s `DecisionEngine`, used by every 
 
 ## Which framework API for which screen type?
 
+Screen-archetype names align **1:1 with the Compose composable** that wraps the screen
+body — there is no translation between the authored intent in `ui.yaml` and the emitted
+code. Pick `screen-content` and `/kmp-feature` codegen emits `ScreenContent { … }`;
+pick `paging-list` and it emits `PagingScreenContent { items(…) }`; pick `input` and it
+emits `MutationScreenContent` + `SubmitHandler` (or `DraftSubmitHandler` when
+`offline_resilient: true`).
+
 `PagingScreenContent` is **not** a generic "all UI" wrapper — it's specifically for
 infinite-scroll paginated lists driven by `asPagingScreenStream`. Detail pages,
-non-paginated lists, forms, and dashboards each have their own canonical pattern:
+non-paginated lists, inputs, and dashboards each have their own canonical pattern:
 
-| Screen type | Framework API | Notes |
-|---|---|---|
-| **Detail (1 entity)** | `ScreenContent(state) { item -> ... }` | Single-key flow via `asScreenStream(key)`. CoinDetail uses this. |
-| **Detail (1 entity) + pull-to-refresh** | `RefreshableScreenContent(state, onRefresh) { item -> ... }` | Same as above wrapped in M3 `PullToRefreshBox`. Pull spinner appears while `state.freshness == UPDATING`. |
-| **Detail (dynamic key)** | `ScreenContent(state) { item -> ... }` | ViewModel uses `asScreenStream(keyFlow, ...)` overload. Re-streams when key changes. |
-| **Paginated list (infinite scroll)** | `PagingScreenContent { items(coins) { ... } }` | Auto LazyColumn + LoadMoreFooter + load-more trigger + **pull-to-refresh on by default** (`enablePullToRefresh = true`). CryptoWatchlist uses this. |
-| **Paginated list (custom layout)** | `PagingScreenContent(...) { items, _ -> /* your LazyColumn */ }` | Slot-only overload — you own the LazyColumn (sticky headers, sectioned lists, etc.). |
-| **Non-paginated list** | `ScreenContent(state) { list -> LazyColumn { items(list) { ... } } }` | `asScreenStream` returning `List<T>`. No load-more wiring. Wrap in `RefreshableScreenContent` for pull-to-refresh. |
-| **Form / pure UI (no remote data)** | none — regular Compose | No state stream needed. |
-| **Multi-source combined** | Manual `combine(s1.state, s2.state) { ... }` in ViewModel → expose `Flow<ScreenState<X>>` to screen | A `combineScreenStreams` framework helper is on the roadmap. Today: do it in the ViewModel. |
-| **Dashboard with several independent panels** | One `ScreenContent` per panel, each with its own `asScreenStream` | Each panel owns its loading/empty/error UX independently. |
+| Type (`ui.yaml`) | Sub-kind | Framework API | Notes |
+|---|---|---|---|
+| **`screen-content`** | `content_kind: detail` | `ScreenContent(state) { item -> ... }` | Single-key flow via `asScreenStream(key)`. CoinDetail uses this. |
+| **`screen-content`** | `content_kind: detail` + pull-to-refresh | `RefreshableScreenContent(state, onRefresh) { item -> ... }` | Same as above wrapped in M3 `PullToRefreshBox`. Pull spinner appears while `state.freshness == UPDATING`. |
+| **`screen-content`** | `content_kind: dynamic-key` | `ScreenContent(state) { item -> ... }` | ViewModel uses `asScreenStream(keyFlow, ...)` overload. Re-streams when key changes. |
+| **`paging-list`** | `list_kind: cursor` | `PagingScreenContent { items(coins) { ... } }` | Auto LazyColumn + LoadMoreFooter + load-more trigger + **pull-to-refresh on by default** (`enablePullToRefresh = true`). CryptoWatchlist uses this. |
+| **`paging-list`** | custom layout | `PagingScreenContent(...) { items, _ -> /* your LazyColumn */ }` | Slot-only overload — you own the LazyColumn (sticky headers, sectioned lists, etc.). |
+| **`screen-content`** | `content_kind: list` (non-paginated) | `ScreenContent(state) { list -> LazyColumn { items(list) { ... } } }` | `asScreenStream` returning `List<T>`. No load-more wiring. Wrap in `RefreshableScreenContent` for pull-to-refresh. |
+| **`input`** | `input_kind: form` | `MutationScreenContent(state, ...) { ... }` + `SubmitHandler` | User-write screen — form, wizard, quick-action, confirm, gesture. See "Mutation / Input Submission" section in `docs/claude/store-implementation.md`. |
+| **`input`** | `input_kind: form`, `offline_resilient: true` | `MutationScreenContent(...)` + `DraftSubmitHandler` | Draft-resilient submission — persists payload across app restarts via `SubmitOutbox`. CreateLoan example uses this. |
+| **`screen-content`** | `content_kind: dashboard` (multi-source combined) | Manual `combine(s1.state, s2.state) { ... }` in ViewModel → expose `Flow<ScreenState<X>>` to screen | A `combineScreenStreams` framework helper is on the roadmap. Today: do it in the ViewModel. |
+| **`screen-content`** | `content_kind: dashboard` (independent panels) | One `ScreenContent` per panel, each with its own `asScreenStream` | Each panel owns its loading/empty/error UX independently. |
+| **`pure-ui`** | — | none — regular Compose | No state stream needed. For static screens with no remote data. |
+| **`custom`** | — | bring-your-own composable + manual Store wiring | Escape hatch for atypical layouts. Use sparingly. |
 
 All variants share the same offline-first guarantees from `core-base/store`'s
 `DecisionEngine`. Branded visuals come from `appScreenStateDefaults()` in this module

--- a/docs/claude/store-implementation.md
+++ b/docs/claude/store-implementation.md
@@ -96,7 +96,13 @@ store.asScreenStream(StoreRequest.cached(key, refresh = policy == CACHE_THEN_NET
 
 ---
 
-## Mutation / Form Submission
+## Mutation / Input Submission
+
+> Screen-archetype name in `ui.yaml` (when used with `/kmp-feature` codegen): `type: input`.
+> The "form" terminology here refers to the *API parameter names* (e.g. `formKey`,
+> `observePendingByFormKey`) and shape of user input — the screen archetype itself is
+> called `input` (covers form / wizard / quick-action / confirm / gesture).
+
 
 ### Basic mutation (no draft persistence)
 ```kotlin


### PR DESCRIPTION
## Summary

Aligns the screen-archetype vocabulary in docs with the Compose composable names — zero translation between authored intent and emitted code.

| `ui.yaml.screens[].type` | Maps to | Covers (sub-kinds) |
|---|---|---|
| **`screen-content`** | `ScreenContent { … }` | detail, dashboard, search, static, dynamic-key |
| **`paging-list`** | `PagingScreenContent { items(…) }` | cursor, offset |
| **`input`** | `MutationScreenContent` + `SubmitHandler` / `DraftSubmitHandler` | form, wizard, quick-action, confirm, gesture |
| **`custom`** | bring-your-own composable | — |
| **`pure-ui`** | no Store, no data layer | static screens |

## Changes

- `core/store/README.md` — taxonomy table gains a `Type` + `Sub-kind` column; prior "Form / pure UI" row split into proper `input` and `pure-ui` rows; preface paragraph explains the 1:1 API-alignment principle.
- `docs/claude/store-implementation.md` — `## Mutation / Form Submission` → `## Mutation / Input Submission`; callout clarifies that API parameter names (`formKey`, `observePendingByFormKey`) remain unchanged — this is a vocabulary alignment for the *screen archetype* layer only.
- `CLAUDE.md` — customization-points section gains a vocabulary callout enumerating the canonical type set.

## What did NOT change

- Zero Kotlin source changes. `MutationScreenContent`, `SubmitHandler`, `DraftSubmitHandler`, `formKey`, `observePendingByFormKey` are already API-aligned and remain as-is. (`grep -r 'class Form\\|class Engagement' core-base/store core/store` → 0 results.)
- No `core-base/store` API surface change.

## Context

Part of upstream framework plan `kmp-pattern-aware-codegen` (mifos-x toolchain), which extends `/kmp-feature` codegen to read `ui.yaml.screens[].type` and emit the matching Compose composable directly. This PR makes the source-of-truth taxonomy doc agree with that vocabulary.

## Test plan

- [ ] Docs-only PR — `./ci-prepush.sh` should pass without changes (no source touched)
- [ ] Visual check of `core/store/README.md` table renders correctly on GitHub
- [ ] No broken internal links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated screen archetype taxonomy and framework API documentation with enhanced guidance on matching UI element types to framework composables.
  * Clarified input submission patterns, screen classification, and fetch policy configurations.
  * Refined terminology distinguishing between API parameter structures and screen presentation types, with expanded canonical examples for various screen patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/kmp-project-template/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->