### PR TITLE
feat(adoption): pin kmp-product-flavors 2.4.0-rc.0 — official adoption project

### DIFF
--- a/build-logic/convention/src/main/kotlin/KMPFlavorsConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KMPFlavorsConventionPlugin.kt
@@ -63,12 +63,23 @@ class KMPFlavorsConventionPlugin : Plugin<Project> {
             //    the plugin default ("BuildKonfig"). bridgeAgp* defaults are safe (idempotent
             //    in v1.1.5+) — no need to touch them.
             extensions.configure<KmpFlavorExtension> {
-                // v2.2+ — preserve v1.x active-variant-only semantics. The template''s
-                // AppVariant.kt reads BuildKonfig from commonMain; v2.2+ auto-enabling
-                // matrix mode (Phase 0A) moves BuildKonfig into per-flavor source sets,
-                // which commonMain can''t see. Explicit opt-out keeps the v1.x codegen
-                // + demonstrates the documented kmpFlavors.autoEnable.set(false) opt-out
-                // migration path described in CHANGELOG [2.2.0] + MATRIX_MODE.md.
+                // v2.4-rc.0 adoption: active-variant-only path preserved.
+                //
+                // Matrix mode (autoEnable=true → buildMatrix auto-flips on with our
+                // 2 flavors × 3 buildTypes × 6 targets shape) is **not** enabled
+                // here because the project's Compose Multiplatform Resources
+                // generator emits `expect` declarations in `commonMain` that have
+                // no matching `actual` once matrix-mode moves variant-scoped code
+                // into per-flavor source sets. This is a documented CMP × kmp-
+                // product-flavors limitation — see kmp-product-flavors `docs/
+                // REFERENCE.md` "Compatibility windows" + `MIGRATION_v1_to_v2.md`
+                // "Common pitfalls" → "Unresolved reference 'BuildKonfig' in
+                // commonMain".
+                //
+                // Once a workaround lands (e.g. CMP exposing a per-flavor resource
+                // generator hook, or kmp-product-flavors auto-skipping CMP-
+                // generated commonMain expect declarations), this opt-out can drop
+                // and matrix mode lights up automatically.
                 autoEnable.set(false)
                 buildConfigPackage.set(libs.findVersion("appPackage").get().requiredVersion)
                 enableBuildTypes.set(true)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kmpProductFlavors = "2.4.0-alpha.0"
+kmpProductFlavors = "2.4.0-rc.0"
 appPackage = "org.openmf.kmptemplate"
 # Android
 androidDesugarJdkLibs = "2.1.5"


### PR DESCRIPTION
## Summary

Two-line version bump + rationale comment cleanup. Positions `kmp-project-template` as the **official adoption testbed** for [`kmp-product-flavors`](https://github.com/MobileByteLabs/kmp-product-flavors) v2.4 GA.

This PR builds on PRs #149 (1.1.5 → 2.4.0-alpha.0 canary) and #144 (ci-equivalent-check.sh + iOS framework fix + dep-guard re-baseline) which both merged earlier today.

## What lands

### 1. `gradle/libs.versions.toml`

```diff
-kmpProductFlavors = "2.4.0-alpha.0"
+kmpProductFlavors = "2.4.0-rc.0"
```

The RC artifact was cut 2026-05-17 from the plugin's `development` branch. Maven Central + Gradle Plugin Portal both resolve the coordinate today.

### 2. `build-logic/convention/src/main/kotlin/KMPFlavorsConventionPlugin.kt`

Rewrote the `autoEnable.set(false)` rationale comment. The **original** comment referenced an `AppVariant.kt` file that doesn't exist in this template — stale boilerplate.

The **real** reason for keeping the v1.x active-variant-only path: Compose Multiplatform's resource generator emits `expect` declarations in `commonMain` that have no matching `actual` once matrix-mode moves variant-scoped code into per-flavor source sets.

Confirmed locally:

```
$ ./gradlew :cmp-shared:compileProdReleaseKotlinDesktop
e: ExpectResourceCollectors.kt:11 — Expected allDrawableResources has no actual declaration in module <commonMain> for JVM
```

The new comment documents the limitation + points at the upstream kmp-product-flavors docs (`docs/REFERENCE.md` "Compatibility windows" + `docs/MIGRATION_v1_to_v2.md` "Common pitfalls"). Once a workaround lands (CMP per-flavor resource generator hook OR kmp-product-flavors auto-skipping CMP-generated commonMain expects), the `autoEnable=false` opt-out can drop and matrix mode lights up automatically.

## Adoption status snapshot

`kmp-project-template` as the v2.4 testbed:

| Surface | State |
|---|---|
| Plugin pin | ✓ `2.4.0-rc.0` |
| Flavor + buildType DSL | ✓ `demo`/`prod` × `debug`/`staging`/`release` × 6 KMP targets |
| AGP bridge | ✓ `bridgeAgpProductFlavors` / `bridgeAgpBuildTypes` defaults active |
| Convention-plugin pattern | ✓ `KMPFlavorsConventionPlugin` applied via `build-logic/convention/` — the most-deployed downstream consumer shape |
| Matrix mode | ⏭ Follow-up — gated on CMP × per-flavor `expect`/`actual` limitation |
| Per-variant publishing | N/A — template is a starter, not a published library |

## Verification

- ✅ `./gradlew :cmp-shared:compileKotlinDesktop` green (49s local)
- ✅ Convention plugin compiles with the new comment rationale
- ✅ `libs.versions.toml` clean; no other version refs touched
- 🟡 Full CI run will exercise Static Analysis + Android + Desktop ×3 OSes + Web + iOS — same matrix that went green on PRs #144 / #149

## What this PR represents for kmp-product-flavors v2.4 GA

This adoption doubles as **one of the external adopter signals** for the [v2.4 GA gate](https://github.com/MobileByteLabs/kmp-product-flavors/discussions/92). Once `dev` here has soaked the `2.4.0-rc.0` pin for ≥1 calendar week with no regressions, a structured stability report will get filed via the [`v2.4-beta-stability-report.yml` issue template](https://github.com/MobileByteLabs/kmp-product-flavors/issues/new?template=v2.4-beta-stability-report.yml).

## Follow-up work

The matrix-mode adoption (full v2.4 feature surface) needs upstream work first:

1. Either kmp-product-flavors auto-skips CMP-generated `commonMain` expects when matrix mode moves them out, OR
2. CMP exposes a per-flavor resource generator hook that aligns with kmp-product-flavors' per-flavor source sets.

Tracked upstream once one of those paths becomes concrete; will file a follow-up issue here referencing the upstream resolution.

## Test plan

- [ ] All 7 PR Checks jobs green (Static Analysis, Android, Desktop ×3, Web, iOS)
- [ ] Dep-guard baseline still clean (no changes vs PR #144's re-baseline)
- [ ] Convention plugin smoke test: `./gradlew :cmp-shared:listFlavors` shows the same matrix as before
- [ ] No regressions in `cmp-android` build under the rc.0 pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)