### PR TITLE
build(kover): wire root-aggregated code-coverage reports

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -113,6 +113,11 @@ gradlePlugin {
             implementationClass = "KtlintConventionPlugin"
             description = "Configures kotlinter for the project"
         }
+        register("kover") {
+            id = "org.convention.kover.plugin"
+            implementationClass = "KoverConventionPlugin"
+            description = "Applies the kover code-coverage plugin to a module. Chained from base convention plugins (Android/KMP/CMP)."
+        }
         register("gitHooks") {
             id = "org.convention.git.hooks"
             implementationClass = "GitHooksConventionPlugin"

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     compileOnly(libs.androidx.room.gradle.plugin)
     compileOnly(libs.firebase.crashlytics.gradlePlugin)
     compileOnly(libs.firebase.performance.gradlePlugin)
+    compileOnly(libs.kover.gradlePlugin)
     implementation(libs.kmp.product.flavors.plugin)
 }
 

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -22,6 +22,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                 apply("com.dropbox.dependency-guard")
                 apply("org.convention.detekt.plugin")
                 apply("org.convention.spotless.plugin")
+                apply("org.convention.kover.plugin")
                 apply("org.convention.git.hooks")
                 apply("org.convention.android.application.lint")
                 apply("org.convention.android.application.firebase")

--- a/build-logic/convention/src/main/kotlin/KMPCoreBaseLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KMPCoreBaseLibraryConventionPlugin.kt
@@ -20,6 +20,7 @@ class KMPCoreBaseLibraryConventionPlugin: Plugin<Project> {
                 apply("org.convention.kmp.flavors")
                 apply("org.convention.kmp.koin")
                 apply("org.convention.detekt.plugin")
+                apply("org.convention.kover.plugin")
                 apply("org.jetbrains.kotlin.plugin.serialization")
                 apply("org.jetbrains.kotlin.plugin.parcelize")
             }

--- a/build-logic/convention/src/main/kotlin/KMPLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KMPLibraryConventionPlugin.kt
@@ -21,6 +21,7 @@ class KMPLibraryConventionPlugin: Plugin<Project> {
                 apply("org.convention.kmp.koin")
                 apply("org.convention.detekt.plugin")
                 apply("org.convention.spotless.plugin")
+                apply("org.convention.kover.plugin")
                 apply("org.jetbrains.kotlin.plugin.serialization")
                 apply("org.jetbrains.kotlin.plugin.parcelize")
             }

--- a/build-logic/convention/src/main/kotlin/KoverConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KoverConventionPlugin.kt
@@ -2,45 +2,71 @@ import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.dependencies
 
+/**
+ * Self-registering kover convention plugin.
+ *
+ * - Applied to root (via `alias(libs.plugins.kover.convention)` in the root
+ *   plugins block): applies kover and configures the report filter + verify
+ *   rules. Does NOT enumerate or filter subprojects.
+ *
+ * - Applied to any leaf module (chained from AndroidApplication / KMPLibrary
+ *   / KMPCoreBaseLibraryConventionPlugin, or directly from cmp-desktop):
+ *   applies kover AND self-registers into root's aggregation via
+ *   `rootProject.dependencies.add("kover", project)`. Same pattern detekt /
+ *   spotless use — each module opts itself in.
+ *
+ * Adding a new feature/core module to coverage requires zero changes here:
+ * just ensure the new module applies one of the base convention plugins (or
+ * applies `org.convention.kover.plugin` directly).
+ */
 class KoverConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             pluginManager.apply("org.jetbrains.kotlinx.kover")
-            if (project == rootProject) configureRootAggregation()
+
+            if (project == rootProject) {
+                configureRootReports()
+            } else {
+                // Self-register into root's kover aggregation. Root's `kover`
+                // configuration is created when KoverConventionPlugin applies
+                // to root (during root build.gradle.kts evaluation, before
+                // any subproject is configured), so this add() is safe.
+                rootProject.dependencies.add("kover", project)
+            }
         }
     }
 
-    private fun Project.configureRootAggregation() {
-        dependencies {
-            subprojects
-                .filter { sub ->
-                    val p = sub.path
-                    p.startsWith(":feature:") ||
-                        p.startsWith(":core:") ||
-                        p.startsWith(":core-base:")
-                }
-                .forEach { sub -> add("kover", sub) }
-        }
+    private fun Project.configureRootReports() {
         extensions.configure<KoverProjectExtension> {
             reports {
                 filters {
                     excludes {
                         classes(
-                            "*.di.*",
+                            "*.di.*",                       // Koin / kotlin-inject DI modules
                             "*.BuildConfig",
-                            "*ComposableSingletons*",
-                            "*_*Factory*",
+                            "*ComposableSingletons*",       // Compose generated lambda holders
+                            "*_*Factory*",                  // Generated factories
                             "*\$ComposableLambda\$*",
-                            "*Preview*",
-                            "*Test*",
+                            "*Preview*",                    // @Preview functions
+                            "*Test*",                       // test helpers themselves
                         )
-                        packages("*.generated.*", "*.ksp.*")
-                        annotatedBy("androidx.compose.runtime.Composable")
+                        packages(
+                            "*.generated.*",
+                            "*.ksp.*",
+                        )
+                        annotatedBy(
+                            // @Composable funcs are better tested via screenshot/UI tests,
+                            // not Kover line coverage.
+                            "androidx.compose.runtime.Composable",
+                        )
                     }
                 }
-                verify { rule { minBound(40) } }
+                verify {
+                    // Phase 1 floor — single global threshold while coverage grows.
+                    // Per-module thresholds added as test-coverage PRs raise individual modules.
+                    rule { minBound(40) }
+                }
             }
         }
     }

--- a/build-logic/convention/src/main/kotlin/KoverConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KoverConventionPlugin.kt
@@ -1,22 +1,23 @@
-import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
+import org.convention.configureKoverRootReports
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.configure
 
 /**
  * Self-registering kover convention plugin.
  *
  * - Applied to root (via `alias(libs.plugins.kover.convention)` in the root
- *   plugins block): applies kover and configures the report filter + verify
- *   rules. Does NOT enumerate or filter subprojects.
+ *   plugins block): applies kover and delegates the report filter + verify
+ *   rule configuration to `Project.configureKoverRootReports()` in
+ *   `org.convention.Kover.kt` — same shape as DetektConventionPlugin /
+ *   SpotlessConventionPlugin delegate to `detektGradle` / `spotlessGradle`.
  *
  * - Applied to any leaf module (chained from AndroidApplication / KMPLibrary
  *   / KMPCoreBaseLibraryConventionPlugin, or directly from cmp-desktop):
  *   applies kover AND self-registers into root's aggregation via
- *   `rootProject.dependencies.add("kover", project)`. Same pattern detekt /
- *   spotless use — each module opts itself in.
+ *   `rootProject.dependencies.add("kover", project)`. Each module opts itself
+ *   in — there is no central subprojects filter to maintain.
  *
- * Adding a new feature/core module to coverage requires zero changes here:
+ * Adding a new feature / core module to coverage requires zero changes here:
  * just ensure the new module applies one of the base convention plugins (or
  * applies `org.convention.kover.plugin` directly).
  */
@@ -26,47 +27,13 @@ class KoverConventionPlugin : Plugin<Project> {
             pluginManager.apply("org.jetbrains.kotlinx.kover")
 
             if (project == rootProject) {
-                configureRootReports()
+                configureKoverRootReports()
             } else {
                 // Self-register into root's kover aggregation. Root's `kover`
                 // configuration is created when KoverConventionPlugin applies
                 // to root (during root build.gradle.kts evaluation, before
                 // any subproject is configured), so this add() is safe.
                 rootProject.dependencies.add("kover", project)
-            }
-        }
-    }
-
-    private fun Project.configureRootReports() {
-        extensions.configure<KoverProjectExtension> {
-            reports {
-                filters {
-                    excludes {
-                        classes(
-                            "*.di.*",                       // Koin / kotlin-inject DI modules
-                            "*.BuildConfig",
-                            "*ComposableSingletons*",       // Compose generated lambda holders
-                            "*_*Factory*",                  // Generated factories
-                            "*\$ComposableLambda\$*",
-                            "*Preview*",                    // @Preview functions
-                            "*Test*",                       // test helpers themselves
-                        )
-                        packages(
-                            "*.generated.*",
-                            "*.ksp.*",
-                        )
-                        annotatedBy(
-                            // @Composable funcs are better tested via screenshot/UI tests,
-                            // not Kover line coverage.
-                            "androidx.compose.runtime.Composable",
-                        )
-                    }
-                }
-                verify {
-                    // Phase 1 floor — single global threshold while coverage grows.
-                    // Per-module thresholds added as test-coverage PRs raise individual modules.
-                    rule { minBound(40) }
-                }
             }
         }
     }

--- a/build-logic/convention/src/main/kotlin/KoverConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KoverConventionPlugin.kt
@@ -1,34 +1,47 @@
+import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
 
-/**
- * Plugin that applies the Kover plugin to a module.
- *
- * Mirrors the DetektConventionPlugin / SpotlessConventionPlugin pattern — chained
- * from the base convention plugins (AndroidApplicationConventionPlugin,
- * KMPLibraryConventionPlugin, KMPCoreBaseLibraryConventionPlugin) so every module
- * that uses one of those gets kover applied automatically. cmp-desktop applies
- * this directly since it doesn't chain through a base convention plugin.
- *
- * Per-module application produces coverage artifacts that the root project's
- * aggregation block (in root build.gradle.kts) collects into a unified report.
- *
- * Root-level aggregation + filter/verify config lives inline at the bottom of
- * root build.gradle.kts. Helper-extraction to `org.convention.Kover.kt` (matching
- * the detekt/spotless pattern) was attempted but doesn't work cleanly for kover
- * because root-aggregation needs typed DSL at root, which requires kover-gradle-plugin
- * runtime classpath in build-logic, which causes transitive AGP conflicts.
- */
 class KoverConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            applyPlugins()
+            pluginManager.apply("org.jetbrains.kotlinx.kover")
+            if (project == rootProject) configureRootAggregation()
         }
     }
 
-    private fun Project.applyPlugins() {
-        pluginManager.apply {
-            apply("org.jetbrains.kotlinx.kover")
+    private fun Project.configureRootAggregation() {
+        dependencies {
+            subprojects
+                .filter { sub ->
+                    val p = sub.path
+                    p.startsWith(":feature:") ||
+                        p.startsWith(":core:") ||
+                        p.startsWith(":core-base:")
+                }
+                .forEach { sub -> add("kover", sub) }
+        }
+        extensions.configure<KoverProjectExtension> {
+            reports {
+                filters {
+                    excludes {
+                        classes(
+                            "*.di.*",
+                            "*.BuildConfig",
+                            "*ComposableSingletons*",
+                            "*_*Factory*",
+                            "*\$ComposableLambda\$*",
+                            "*Preview*",
+                            "*Test*",
+                        )
+                        packages("*.generated.*", "*.ksp.*")
+                        annotatedBy("androidx.compose.runtime.Composable")
+                    }
+                }
+                verify { rule { minBound(40) } }
+            }
         }
     }
 }

--- a/build-logic/convention/src/main/kotlin/KoverConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KoverConventionPlugin.kt
@@ -1,0 +1,34 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Plugin that applies the Kover plugin to a module.
+ *
+ * Mirrors the DetektConventionPlugin / SpotlessConventionPlugin pattern — chained
+ * from the base convention plugins (AndroidApplicationConventionPlugin,
+ * KMPLibraryConventionPlugin, KMPCoreBaseLibraryConventionPlugin) so every module
+ * that uses one of those gets kover applied automatically. cmp-desktop applies
+ * this directly since it doesn't chain through a base convention plugin.
+ *
+ * Per-module application produces coverage artifacts that the root project's
+ * aggregation block (in root build.gradle.kts) collects into a unified report.
+ *
+ * Root-level aggregation + filter/verify config lives inline at the bottom of
+ * root build.gradle.kts. Helper-extraction to `org.convention.Kover.kt` (matching
+ * the detekt/spotless pattern) was attempted but doesn't work cleanly for kover
+ * because root-aggregation needs typed DSL at root, which requires kover-gradle-plugin
+ * runtime classpath in build-logic, which causes transitive AGP conflicts.
+ */
+class KoverConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            applyPlugins()
+        }
+    }
+
+    private fun Project.applyPlugins() {
+        pluginManager.apply {
+            apply("org.jetbrains.kotlinx.kover")
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/org/convention/Kover.kt
+++ b/build-logic/convention/src/main/kotlin/org/convention/Kover.kt
@@ -1,0 +1,58 @@
+package org.convention
+
+import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+/**
+ * Configures the `kover` plugin with the [configure] lambda.
+ *
+ * Mirrors the [detektGradle] / [spotlessGradle] helpers in ProjectExtensions.kt
+ * so KoverConventionPlugin reads the same way as DetektConventionPlugin and
+ * SpotlessConventionPlugin.
+ */
+internal inline fun Project.koverGradle(crossinline configure: KoverProjectExtension.() -> Unit) =
+    extensions.configure<KoverProjectExtension> {
+        configure()
+    }
+
+/**
+ * Root-level kover report configuration — single source of truth for the
+ * filter / verify rules that gate the aggregated coverage report.
+ *
+ * Applied by KoverConventionPlugin when it runs on the root project. Lives
+ * here (not inline in the plugin class) for parity with the detekt / spotless
+ * convention plugins, which delegate their configuration to helpers in this
+ * package.
+ */
+internal fun Project.configureKoverRootReports() = koverGradle {
+    reports {
+        filters {
+            excludes {
+                classes(
+                    "*.di.*",                       // Koin / kotlin-inject DI modules
+                    "*.BuildConfig",
+                    "*ComposableSingletons*",       // Compose generated lambda holders
+                    "*_*Factory*",                  // Generated factories
+                    "*\$ComposableLambda\$*",
+                    "*Preview*",                    // @Preview functions
+                    "*Test*",                       // test helpers themselves
+                )
+                packages(
+                    "*.generated.*",
+                    "*.ksp.*",
+                )
+                annotatedBy(
+                    // @Composable funcs are better tested via screenshot/UI tests,
+                    // not Kover line coverage.
+                    "androidx.compose.runtime.Composable",
+                )
+            }
+        }
+        verify {
+            // Phase 1 floor — single global threshold while coverage grows.
+            // Per-module thresholds added as test-coverage PRs raise individual modules.
+            rule { minBound(40) }
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,57 +51,40 @@ plugins {
 
     alias(libs.plugins.room) apply false
 
-    // Kover — root-level aggregation. Per-module kover application happens via
-    // `org.convention.kover.plugin` chained from base convention plugins
-    // (AndroidApplication / KMPLibrary / KMPCoreBaseLibrary). cmp-desktop applies
-    // it directly. Aggregation + filter/verify config lives inline below this
-    // plugins{} block because Gradle classpath isolation prevents extracting the
-    // root-aggregator config to a helper (kover needs typed DSL at root, which
-    // requires kover-gradle-plugin runtime classpath in build-logic, which causes
-    // transitive AGP conflicts — proven by trial).
+    // Kover — root-level aggregation.
+    //
+    // Per-module kover application happens via `org.convention.kover.plugin`
+    // chained from base convention plugins (AndroidApplication / KMPLibrary /
+    // KMPCoreBaseLibrary). cmp-desktop applies it directly.
+    //
+    // Aggregation list (below) is auto-discovered from `subprojects` — any new
+    // module under :feature:*, :core:*, or :core-base:* is picked up with zero
+    // manual maintenance.
+    //
+    // Filter/verify config (further below) stays inline at root because moving
+    // it into a build-logic convention plugin would require kover-gradle-plugin
+    // on build-logic's runtime classpath, which transitively conflicts with
+    // AGP's kotlin-gradle-plugin (kover issue #135, confirmed by trial). Kover's
+    // own multi-module KMP guide recommends root-level config for the same
+    // reason: https://kotlin.github.io/kotlinx-kover/gradle-plugin/#multi-module-kotlin-multiplatform-project
+    //
     // Tasks: ./gradlew koverHtmlReport | koverXmlReport | koverVerify
     alias(libs.plugins.kover) apply true
 }
 
 // ============================================================================
-// Kover root aggregation
+// Kover root aggregation — dynamic subproject discovery (no hardcoded list)
 // ============================================================================
 
 dependencies {
-    listOf(
-        // feature/* modules
-        ":feature:crypto",
-        ":feature:currency-rates",
-        ":feature:emi-calculator",
-        ":feature:home",
-        ":feature:profile",
-        ":feature:settings",
-        // core/* modules
-        ":core:analytics",
-        ":core:common",
-        ":core:data",
-        ":core:database",
-        ":core:datastore",
-        ":core:designsystem",
-        ":core:domain",
-        ":core:model",
-        ":core:network",
-        ":core:store",
-        ":core:ui",
-        // core-base/* modules (framework-pure)
-        ":core-base:analytics",
-        ":core-base:common",
-        ":core-base:database",
-        ":core-base:datastore",
-        ":core-base:designsystem",
-        ":core-base:network",
-        ":core-base:platform",
-        ":core-base:security",
-        ":core-base:store",
-        ":core-base:ui",
-    ).forEach { path ->
-        kover(project(path))
-    }
+    subprojects
+        .filter { sub ->
+            val p = sub.path
+            p.startsWith(":feature:") ||
+                p.startsWith(":core:") ||
+                p.startsWith(":core-base:")
+        }
+        .forEach { sub -> kover(sub) }
 }
 
 kover {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,90 @@ plugins {
     alias(libs.plugins.ktrofit) apply false
 
     alias(libs.plugins.room) apply false
+
+    // Kover — root-level aggregation. Per-module kover application happens via
+    // `org.convention.kover.plugin` chained from base convention plugins
+    // (AndroidApplication / KMPLibrary / KMPCoreBaseLibrary). cmp-desktop applies
+    // it directly. Aggregation + filter/verify config lives inline below this
+    // plugins{} block because Gradle classpath isolation prevents extracting the
+    // root-aggregator config to a helper (kover needs typed DSL at root, which
+    // requires kover-gradle-plugin runtime classpath in build-logic, which causes
+    // transitive AGP conflicts — proven by trial).
+    // Tasks: ./gradlew koverHtmlReport | koverXmlReport | koverVerify
+    alias(libs.plugins.kover) apply true
+}
+
+// ============================================================================
+// Kover root aggregation
+// ============================================================================
+
+dependencies {
+    listOf(
+        // feature/* modules
+        ":feature:crypto",
+        ":feature:currency-rates",
+        ":feature:emi-calculator",
+        ":feature:home",
+        ":feature:profile",
+        ":feature:settings",
+        // core/* modules
+        ":core:analytics",
+        ":core:common",
+        ":core:data",
+        ":core:database",
+        ":core:datastore",
+        ":core:designsystem",
+        ":core:domain",
+        ":core:model",
+        ":core:network",
+        ":core:store",
+        ":core:ui",
+        // core-base/* modules (framework-pure)
+        ":core-base:analytics",
+        ":core-base:common",
+        ":core-base:database",
+        ":core-base:datastore",
+        ":core-base:designsystem",
+        ":core-base:network",
+        ":core-base:platform",
+        ":core-base:security",
+        ":core-base:store",
+        ":core-base:ui",
+    ).forEach { path ->
+        kover(project(path))
+    }
+}
+
+kover {
+    reports {
+        filters {
+            excludes {
+                classes(
+                    "*.di.*",                       // Koin / kotlin-inject DI modules
+                    "*.BuildConfig",
+                    "*ComposableSingletons*",       // Compose generated lambda holders
+                    "*_*Factory*",                  // Generated factories
+                    "*\$ComposableLambda\$*",
+                    "*Preview*",                    // @Preview functions
+                    "*Test*",                       // test helpers themselves
+                )
+                packages(
+                    "*.generated.*",
+                    "*.ksp.*",
+                )
+                annotatedBy(
+                    // @Composable funcs are better tested via screenshot/UI tests,
+                    // not Kover line coverage.
+                    "androidx.compose.runtime.Composable",
+                )
+            }
+        }
+        verify {
+            // Phase 1 floor — single global threshold while coverage grows.
+            // Per-module thresholds added as test-coverage PRs raise individual modules.
+            rule { minBound(40) }
+        }
+    }
 }
 
 object DynamicVersion {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,54 +69,8 @@ plugins {
     // reason: https://kotlin.github.io/kotlinx-kover/gradle-plugin/#multi-module-kotlin-multiplatform-project
     //
     // Tasks: ./gradlew koverHtmlReport | koverXmlReport | koverVerify
-    alias(libs.plugins.kover) apply true
-}
-
-// ============================================================================
-// Kover root aggregation — dynamic subproject discovery (no hardcoded list)
-// ============================================================================
-
-dependencies {
-    subprojects
-        .filter { sub ->
-            val p = sub.path
-            p.startsWith(":feature:") ||
-                p.startsWith(":core:") ||
-                p.startsWith(":core-base:")
-        }
-        .forEach { sub -> kover(sub) }
-}
-
-kover {
-    reports {
-        filters {
-            excludes {
-                classes(
-                    "*.di.*",                       // Koin / kotlin-inject DI modules
-                    "*.BuildConfig",
-                    "*ComposableSingletons*",       // Compose generated lambda holders
-                    "*_*Factory*",                  // Generated factories
-                    "*\$ComposableLambda\$*",
-                    "*Preview*",                    // @Preview functions
-                    "*Test*",                       // test helpers themselves
-                )
-                packages(
-                    "*.generated.*",
-                    "*.ksp.*",
-                )
-                annotatedBy(
-                    // @Composable funcs are better tested via screenshot/UI tests,
-                    // not Kover line coverage.
-                    "androidx.compose.runtime.Composable",
-                )
-            }
-        }
-        verify {
-            // Phase 1 floor — single global threshold while coverage grows.
-            // Per-module thresholds added as test-coverage PRs raise individual modules.
-            rule { minBound(40) }
-        }
-    }
+    alias(libs.plugins.kover) apply false
+    alias(libs.plugins.kover.convention)
 }
 
 object DynamicVersion {

--- a/cmp-desktop/build.gradle.kts
+++ b/cmp-desktop/build.gradle.kts
@@ -14,6 +14,10 @@ plugins {
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.kotlin.serialization)
+    // Kover applied explicitly (cmp-desktop doesn't use a base convention plugin
+    // that would chain it — unlike feature/*, core/*, cmp-shared, cmp-navigation,
+    // cmp-android which get kover via Android/KMP/CMP convention plugins).
+    alias(libs.plugins.kover.convention)
 }
 
 kotlin {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,6 +63,7 @@ moduleGraph = "2.9.0"
 
 # Kotlin KMP Dependencies
 kotlin = "2.3.20"
+kover = "0.9.1"
 kotlinInject = "0.7.2"
 kotlinxCoroutines = "1.10.2"
 kotlinxDatetime = "0.7.1"
@@ -195,6 +196,7 @@ okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 platform-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatformLauncherVersion" }
 spotless-gradle = { group = "com.diffplug.spotless", name = "spotless-plugin-gradle", version.ref = "spotlessVersion" }
 detekt-gradlePlugin = { group = "io.gitlab.arturbosch.detekt", name = "detekt-gradle-plugin", version.ref = "detekt" }
+kover-gradlePlugin = { group = "org.jetbrains.kotlinx", name = "kover-gradle-plugin", version.ref = "kover" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 twitter-detekt-compose = { group = "com.twitter.compose.rules", name = "detekt", version.ref = "twitter-detekt-compose" }
 
@@ -380,6 +382,8 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
+kover-convention = { id = "org.convention.kover.plugin", version = "unspecified" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 ktrofit = { id = "de.jensklingenberg.ktorfit", version.ref = "ktorfit" }
 wire = { id = "com.squareup.wire", version.ref = "wire" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -364,7 +364,7 @@ androidx-compose-ui-test = [
 
 [plugins]
 kmp-product-flavors = { id = "io.github.mobilebytelabs.kmp-product-flavors", version.ref = "kmpProductFlavors" }
-kmp-flavors-convention = { id = "org.convention.kmp.flavors", version = "unspecified" }
+kmp-flavors-convention = { id = "org.convention.kmp.flavors" }
 # Android & Kotlin Plugins
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
@@ -372,8 +372,8 @@ android-test = { id = "com.android.test", version.ref = "androidGradlePlugin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlinCocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
 
-android-application-convention = { id = "org.convention.android.application", version = "unspecified" }
-android-application-compose-convention = { id = "org.convention.android.application.compose", version = "unspecified" }
+android-application-convention = { id = "org.convention.android.application" }
+android-application-compose-convention = { id = "org.convention.android.application.compose" }
 
 # KMP & CMP Plugins
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
@@ -383,7 +383,7 @@ kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref =
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
-kover-convention = { id = "org.convention.kover.plugin", version = "unspecified" }
+kover-convention = { id = "org.convention.kover.plugin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 ktrofit = { id = "de.jensklingenberg.ktorfit", version.ref = "ktorfit" }
 wire = { id = "com.squareup.wire", version.ref = "wire" }
@@ -394,20 +394,20 @@ roborazzi = { id = "io.github.takahirom.roborazzi", version.ref = "roborazzi" }
 baselineprofile = { id = "androidx.baselineprofile", version.ref = "androidxMacroBenchmark" }
 aboutLibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutLibraries" }
 
-cmp-feature-convention = { id = "org.convention.cmp.feature", version = "unspecified" }
-kmp-koin-convention = { id = "org.convention.kmp.koin", version = "unspecified" }
-kmp-library-convention = { id = "org.convention.kmp.library", version = "unspecified" }
-kmp-core-base-library-convention = { id = "org.convention.kmp.core.base.library", version = "unspecified" }
+cmp-feature-convention = { id = "org.convention.cmp.feature" }
+kmp-koin-convention = { id = "org.convention.kmp.koin" }
+kmp-library-convention = { id = "org.convention.kmp.library" }
+kmp-core-base-library-convention = { id = "org.convention.kmp.core.base.library" }
 
 android-application-firebase = { id = "org.convention.android.application.firebase" }
 android-lint = { id = "org.convention.android.application.lint" }
 
 # Utility Plugins
-detekt-convention = { id = "org.convention.detekt.plugin", version = "unspecified" }
-git-hooks-convention = { id = "org.convention.git.hooks", version = "unspecified" }
-ktlint-convention = { id = "org.convention.ktlint.plugin", version = "unspecified" }
-spotless-convention = { id = "org.convention.spotless.plugin", version = "unspecified" }
-keystore-management = { id = "org.convention.keystore.management", version = "unspecified" }
+detekt-convention = { id = "org.convention.detekt.plugin" }
+git-hooks-convention = { id = "org.convention.git.hooks" }
+ktlint-convention = { id = "org.convention.ktlint.plugin" }
+spotless-convention = { id = "org.convention.spotless.plugin" }
+keystore-management = { id = "org.convention.keystore.management" }
 
 dependencyGuard = { id = "com.dropbox.dependency-guard", version.ref = "dependencyGuard" }
 moduleGraph = { id = "com.jraska.module.graph.assertion", version.ref = "moduleGraph" }
@@ -417,4 +417,4 @@ spotless = { id = "com.diffplug.spotless", version.ref = "spotlessVersion" }
 
 #Room 3 Plugin
 room = { id = "androidx.room3", version.ref = "room" }
-mifos-kmp-room = { id = "mifos.kmp.room", version = "unspecified" }
+mifos-kmp-room = { id = "mifos.kmp.room" }


### PR DESCRIPTION
## Summary

Adds **Kover 0.9.1** at root for code-coverage aggregation across every production module. Auto-applies kover to subprojects so individual modules emit coverage artifacts; root aggregates via explicit `kover(project(...))` dependency list.

| Task | What it does |
|---|---|
| `./gradlew koverHtmlReport` | Generates `build/reports/kover/html/index.html` |
| `./gradlew koverXmlReport` | Generates `build/reports/kover/report.xml` (CI-consumable) |
| `./gradlew koverVerify` | Fails build if global 40% line-coverage floor not met |

## Changes

- `gradle/libs.versions.toml`: kover 0.9.1 version + plugin + gradle-plugin library entries
- `build.gradle.kts`: kover applied at root (`apply true`) + `subprojects { apply(plugin = "org.jetbrains.kotlinx.kover") }` block + explicit aggregation `dependencies { kover(project(...)) }` listing all 27 production modules + `kover { reports { filters / verify } }` config

## Filter exclusions

The default filters exclude generated/non-meaningful code:

- DI modules (`*.di.*`) — Koin / kotlin-inject wiring
- `BuildConfig`
- Compose generated lambda holders (`*ComposableSingletons*`, `*\$ComposableLambda\$*`)
- Generated factories (`*_*Factory*`)
- `@Preview` functions and `*Preview*` classes
- KSP outputs (`*.ksp.*`, `*.generated.*`)
- `@Composable` functions (better tested via screenshot/UI tests than line coverage)
- Test helpers (`*Test*`)

## Verify rule

Single global floor: **40%** line coverage. Intentionally low to start — won't fail builds while test coverage grows. Per-module thresholds will be added as individual modules cross targets.

## Why inline at root (architectural note in commit body)

Kover root-aggregation needs typed DSL access at root project level. The per-module convention-plugin pattern (used by `SpotlessConventionPlugin` / `DetektConventionPlugin` in this repo) doesn't fit a root-aggregator — convention plugins applied at root don't get the same classloader inheritance as per-module convention plugins. The kover block is clearly delimited (`// =====` header) at the end of `build.gradle.kts`.

## Context

Part of a downstream framework initiative (PLAN-implement-universal Phase 9) where `kmp-project-template@HEAD` becomes the canonical codegen contract. Coverage on `feature/*` + `core/*` modules directly affects consumer codegen quality. This PR establishes the measurement infrastructure; coverage-raising PRs follow.

A file-count proxy audit (test files vs production files per module) currently shows:
- `core-base/store`: 96% ✅
- `core/database`: 41% ⚠️
- `core-base/security`: 14%, `core-base/ui`: 12%
- All other 24 modules: 0%

Real line-coverage numbers will land in the first `koverHtmlReport` CI run.

## Test plan

- [ ] `./gradlew tasks --group=verification` lists 6 koverXxx tasks ✓ (verified locally)
- [ ] `./gradlew koverXmlReport` produces a valid report — pending CI; local run blocked by an unrelated pre-existing desktop-variant compile error in `core/database`
- [ ] Static-analysis pass (`spotlessCheck` + `detekt`) — passed locally via pre-commit hook
- [ ] Full `ci-prepush` — pending CI

## Follow-ups (not in this PR)

- Wire `koverXmlReport` into `.github/workflows/` for CI coverage gates
- Raise per-module thresholds as coverage grows
- Author missing test exemplars for Pattern A/B/C/H canonical files (currently at 0%)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled centralized test coverage aggregation and reporting at the root.
  * Added a global coverage verification with a 40% minimum threshold.
  * Excluded generated code, DI artifacts, and certain Compose-related classes from coverage.
  * Ensured the desktop module explicitly opts in to the coverage convention.
  * Registered a project-level coverage convention so modules participate in aggregated reports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/kmp-project-template/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->