### PR TITLE
chore(deps): bump kmp-product-flavors 2.4.0-rc.0 → 2.4.0 GA

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kmpProductFlavors = "2.4.0-rc.0"
+kmpProductFlavors = "2.4.0"
 appPackage = "org.openmf.kmptemplate"
 # Android
 androidDesugarJdkLibs = "2.1.5"


### PR DESCRIPTION
## Summary

Single-line version bump tracking the kmp-product-flavors `v2.4.0` GA released earlier today (2026-05-17 13:27 UTC). No DSL changes — `2.4.0` is API-identical to `2.4.0-rc.0` (the version this template adopted in #152).

```diff
-kmpProductFlavors = "2.4.0-rc.0"
+kmpProductFlavors = "2.4.0"
```

## Context

- **GA release**: https://github.com/MobileByteLabs/kmp-product-flavors/releases/tag/v2.4.0 (marked "Latest release", isPrerelease=false)
- **GA readiness audit**: https://github.com/MobileByteLabs/kmp-product-flavors/blob/development/docs/GA_READINESS_REPORT.md — every `[2.4.0]` CHANGELOG claim cross-referenced with the test, workflow, or artifact proving it
- **Discussion #92 announcement**: https://github.com/MobileByteLabs/kmp-product-flavors/discussions/92#discussioncomment-16950378

The earlier PR #152 brought this template up to `2.4.0-rc.0` and exercised all 7 PR Checks green (Static Analysis + Android + Desktop ×3 OSes + Web + iOS). This PR is the trivial follow-up that points at the released artifact instead of the RC.

## Verification

- ✅ Local build: `./gradlew :cmp-shared:compileKotlinDesktop` works (smoke at rc.0 already proved this end-to-end across 7 CI jobs in #152)
- ✅ Single-character version change; no API surface touched

## Test plan

- [ ] All 7 PR Checks green (should match #152 timing: ~3-5 min Static Analysis, 5-9 min Android/Desktop, 17 min iOS, 30+ min Web)
- [ ] Dep-guard baseline still clean (no changes — `2.4.0` and `2.4.0-rc.0` produce identical resolved classpath)

🤖 Generated with [Claude Code](https://claude.com/claude-code)