### PR TITLE
fix: unblock kover coverage gate (Gap #1 from source-coverage audit)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,6 +110,16 @@ subprojects {
             }
         }
     }
+
+    // Gradle 9+ defaults Test.failOnNoDiscoveredTests to true. AGP unit-test
+    // tasks (testDemoDebugUnitTest, testProdReleaseUnitTest, etc.) then fail
+    // on KMP `androidUnitTest` source sets that contain expect/actual TEST
+    // HELPERS but no @Test classes — those test classes legitimately live in
+    // `commonTest` or `desktopTest`. Disabling per-task unblocks the kover
+    // coverage gate without weakening real-test signal.
+    tasks.withType<org.gradle.api.tasks.testing.Test>().configureEach {
+        failOnNoDiscoveredTests = false
+    }
 }
 
 // Configuration for CMP module dependency graph

--- a/core/database/src/desktopTest/kotlin/org/mifos/core/database/AppDatabaseTest.kt
+++ b/core/database/src/desktopTest/kotlin/org/mifos/core/database/AppDatabaseTest.kt
@@ -48,9 +48,9 @@ class AppDatabaseTest {
 
     @Test
     fun databaseVersionIsCurrent() {
-        // Bumped to 4 in v3→v4 auto-migration that adds framework_fetched_at table.
-        // Update this when bumping AppDatabase.VERSION.
-        assertEquals(4, AppDatabase.VERSION)
+        // Bumped to 5 in the v4→v5 schema migration. Update this constant when
+        // bumping AppDatabase.VERSION so this guardrail stays meaningful.
+        assertEquals(5, AppDatabase.VERSION)
     }
 
     @Test

--- a/core/database/src/desktopTest/kotlin/org/mifos/core/database/currency/ChargeTypeConvertersTest.kt
+++ b/core/database/src/desktopTest/kotlin/org/mifos/core/database/currency/ChargeTypeConvertersTest.kt
@@ -9,7 +9,8 @@
  */
 package org.mifos.core.database.currency
 
-import org.mifos.core.database.infra.entity.SampleEntity
+import org.mifos.core.database.currency.converter.ChargeTypeConverters
+import org.mifos.core.database.sample.entity.SampleEntity
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull

--- a/core/database/src/desktopTest/kotlin/org/mifos/core/database/di/DatabaseModuleTest.kt
+++ b/core/database/src/desktopTest/kotlin/org/mifos/core/database/di/DatabaseModuleTest.kt
@@ -14,7 +14,7 @@ import org.koin.core.context.stopKoin
 import org.koin.test.KoinTest
 import org.koin.test.get
 import org.mifos.core.database.AppDatabase
-import org.mifos.core.database.infra.dao.SampleDao
+import org.mifos.core.database.sample.dao.SampleDao
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,4 +62,17 @@ compileSdk=36
 
 # v2.0 matrix mode opt-in — builds every variant in one Gradle invocation.
 # Comment-out (or set to false) to keep v1.x active-variant-only semantics.
-kmpFlavors.buildMatrix=true
+#
+# Disabled (2026-05-19) to unblock the kover coverage gate.
+# Matrix mode registers inactive-variant compilations whose defaultSourceSet
+# chain does NOT include the target's standard `<target>Main` source set, so
+# `expect val ... : Module` declarations in commonMain fail to resolve their
+# actuals (which live in desktopMain / iosMain / etc) when KMP compiles the
+# inactive variant. Reproducible on `:core:database`, `:core:data`, and any
+# of the ~30 expect declarations across `core/*`, `core-base/*`, `feature/*`.
+#
+# Flip back to `true` once kmp-product-flavors upstream-fixes the source-set
+# wiring (variant.defaultSourceSet.dependsOn(targetMain) for inactive-variant
+# compilations). Tracking: kmp-project-template Gap #1 in
+# docs/reports/source-coverage-260519.md → resolution pending the upstream PR.
+kmpFlavors.buildMatrix=false


### PR DESCRIPTION
## Summary

Five small fixes that together let `./gradlew koverXmlReport` succeed end-to-end across all 31 measurable modules. **None of the underlying breakage was introduced by this branch** — each was pre-existing on `dev` HEAD and surfaced once PR #153 wired up Kover for the first time. This is the "Gap #1" called out in `docs/reports/source-coverage-260519.md` (landed in PR #155).

## Baseline coverage numbers now available

```
:core-base:store          82.1%
:core-base:security       39.2%
:core:database            11.9%
:core-base:ui              7.5%
(every other module:       0.0%)
```

## What's changed

### `gradle.properties` — disable matrix mode

```diff
- kmpFlavors.buildMatrix=true
+ kmpFlavors.buildMatrix=false
```

**Why**: Matrix mode registers inactive-variant compilations (5 per non-Android target × 6 targets = up to 30 extra compilations per module) whose `defaultSourceSet` chain depends on `commonMain` + per-flavor source sets but NOT on the target's own `<target>Main`. KMP's expect/actual matcher therefore can't resolve actuals in `desktopMain` / `iosMain` / etc when compiling inactive variants. Breaks every module with `expect val ... : Module` in `commonMain` (~30 such declarations across `core/*`, `core-base/*`, `feature/*`; verified on `:core:database` and `:core:data`). Kover, which aggregates from every JVM compilation it finds, halts on those compile errors.

**This is upstream behavior** in `kmp-product-flavors`. The right fix is a plugin-side change that wires inactive-variant `defaultSourceSet` to `dependsOn(<target>Main)`. Follow-up PR planned against `MobileByteLabs/kmp-product-flavors`; once it lands and a version is shipped, this property flips back to `true` and matrix mode is restored. Documented per `kmp-product-flavors/docs/MATRIX_MODE.md`: *\"Setting `buildMatrix.set(false)` (or removing the opt-in entirely) restores v1.x behaviour byte-for-byte. No per-module consumer file needs to change.\"*

### `build.gradle.kts` — `Test.failOnNoDiscoveredTests = false`

```kotlin
tasks.withType<org.gradle.api.tasks.testing.Test>().configureEach {
    failOnNoDiscoveredTests = false
}
```

**Why**: Gradle 9 defaults this to `true`. AGP unit-test tasks then fail on KMP `androidUnitTest` source sets that hold expect/actual test HELPERS (e.g. `core/database/.../TestDatabaseModule.android.kt`, a Koin module imported by commonTest tests) but no `@Test` classes — those classes legitimately live in `commonTest` / `desktopTest`. Disabling per-task unblocks the AGP-driven test phase of `koverXmlReport` without weakening any real test signal: the only tasks affected are ones with zero discoverable tests by definition.

### Three drift-fix imports in `core/database` tests

PR #150 reorganized `core/database/src/commonMain/kotlin/.../` into domain sub-packages (`infra/`, `currency/converter/`, `sample/`, `sample/dao/`, `sample/entity/`) but three desktopTest files still imported pre-reorg paths:

- **`ChargeTypeConvertersTest.kt`**:
  - `+ import org.mifos.core.database.currency.converter.ChargeTypeConverters`
  - `- import org.mifos.core.database.infra.entity.SampleEntity`
  - `+ import org.mifos.core.database.sample.entity.SampleEntity`
- **`DatabaseModuleTest.kt`**:
  - `- import org.mifos.core.database.infra.dao.SampleDao`
  - `+ import org.mifos.core.database.sample.dao.SampleDao`
- **`AppDatabaseTest.kt`**: `assertEquals(4, AppDatabase.VERSION)` → `5` (schema bumped to 5 in the v4→v5 migration that landed alongside the reorg; the guardrail constant wasn't updated).

## Test plan

- [x] `./gradlew koverXmlReport` succeeds locally — 32 per-module `report.xml` files emitted
- [x] All 31 measurable modules pass the floor checker (default-floor=0)
- [x] No new test sources added; only stale import paths fixed
- [ ] CI run via the test-coverage workflow (waiting on PR #155 to merge first so the workflow file exists; this PR is order-independent — it can land before, after, or alongside #155)

## Follow-ups

Once this merges (and after PR #155 lands the gate workflow):

1. **Bump `:core-base:store` floor** in PR #155's `.kover-floor.yml`: `0` → `80` (actual is 82.1%; 80 leaves 2.1pp of fluctuation headroom). One-line PR.
2. **Upstream PR to `MobileByteLabs/kmp-product-flavors`**: wire inactive-variant `defaultSourceSet` to `dependsOn(<target>Main)` so matrix mode + expect/actual coexist correctly. Then flip `kmpFlavors.buildMatrix=true` back on here.
3. **Resume Phase 9 T32**: `feature/crypto/` test coverage (Pattern A + B exemplar).

## Reference

- `docs/reports/source-coverage-260519.md` (lands in PR #155) — original audit identifying this gap
- `plan-layer/active/PLAN-implement-universal.md` Phase 9 — the parent plan
- PR #153 — kover infrastructure (merged)
- PR #155 — audit + CI gate scaffold (in flight)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration to prevent failures when test suites are empty.
  * Reorganized internal test dependencies and imports.
  * Adjusted build system configuration for improved compatibility.
  * Updated database schema version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/kmp-project-template/pull/156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->