### PR TITLE
chore(deps): bump kmp-product-flavors 2.4.0 → 2.4.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kmpProductFlavors = "2.4.0"
+kmpProductFlavors = "2.4.2"
 appPackage = "org.openmf.kmptemplate"
 # Android
 androidDesugarJdkLibs = "2.1.5"


### PR DESCRIPTION
## Summary

Bumps `kmpProductFlavors = \"2.4.0\"` → `\"2.4.2\"` in `gradle/libs.versions.toml`. One-line dependency bump.

Upstream release: https://github.com/MobileByteLabs/kmp-product-flavors/releases/tag/v2.4.2

**Rebased onto current `dev`** (commit `59cfd88`, which now includes PR #156 with `buildMatrix=false` + the three drift fixes). Combined with this version bump, the Kover coverage gate now runs **end-to-end cleanly locally**.

## What v2.4.2 fixes

**Matrix mode + `expect`/`actual` in `commonMain`** ([MobileByteLabs/kmp-product-flavors#99](https://github.com/MobileByteLabs/kmp-product-flavors/issues/99), filed from this repo) — inactive-variant compilations now resolve `actual` declarations from the target's `<target>Main` source set (e.g. `desktopMain`, `iosMain`). Pre-fix, the variant's `defaultSourceSet` was wired only to per-flavor parents and never saw the target main, so KMP failed with *\"Expected `<name>` has no actual declaration in module `<commonMain>` for `<Target>`\"* on every inactive-variant compile on non-Android targets. This was the original Gap #1 documented in `docs/reports/source-coverage-260519.md` (PR #155).

**Verified locally**: `./gradlew :core:database:compileProdReleaseKotlinDesktop` (previously failing under v2.4.0) compiles cleanly under v2.4.2.

## End-to-end Kover gate verification

With v2.4.2 + #156 (`buildMatrix=false`) on this branch, `./gradlew koverXmlReport` succeeds and produces 32 per-module `report.xml` files:

```
✅ All 31 measurable modules meet their coverage floor.
   - core-base:store         82.1%
   - core-base:security      39.2%
   - core:database           11.9%
   - core-base:ui             7.5%
   - (everything else:        0.0%)
```

## Known follow-on issue ([kmp-product-flavors#102](https://github.com/MobileByteLabs/kmp-product-flavors/issues/102))

The v2.4.2 fix replays the target's `kotlin.srcDirs` into the variant `defaultSourceSet` correctly, but doesn't propagate the matching task-graph dependencies. With `buildMatrix=true`, Gradle 9's implicit-dependency validator blocks inactive-variant compile tasks that read KSP/Room/Wire generated sources:

```
Task ':<module>:compileDemoReleaseKotlinDesktop' uses output of
task ':<module>:kspKotlinDesktop' without declaring dependency.
```

I filed this as [MobileByteLabs/kmp-product-flavors#102](https://github.com/MobileByteLabs/kmp-product-flavors/issues/102) with reproducer + proposed fix. **Because #156 keeps `buildMatrix=false` for now, this PR does not surface that issue** — kover only runs the active variant (demoDebug), which doesn't hit the KSP task-dep gap.

When v2.4.3 (with the #102 fix) is released, a follow-up PR will flip `buildMatrix=true` back on and re-validate.

## Scope of this PR

Pure version-key bump in `gradle/libs.versions.toml`. One file, one line changed.

## Sequencing with related PRs

| PR | Status | What it does |
|---|---|---|
| [#155](https://github.com/openMF/kmp-project-template/pull/155) | ✅ Merged | Audit + CI gate scaffold |
| [#156](https://github.com/openMF/kmp-project-template/pull/156) | ✅ Merged | `buildMatrix=false` + 3 stale-import drift fixes |
| **This PR (#157)** | Open, rebased | v2.4.0 → v2.4.2 bump; verified end-to-end |
| Future | Pending [#102](https://github.com/MobileByteLabs/kmp-product-flavors/issues/102) fix → v2.4.3 | Bump version + flip `buildMatrix=true` |

## Test plan

- [x] Rebased cleanly onto current `dev` (no conflicts)
- [x] `./gradlew :core:database:compileProdReleaseKotlinDesktop` succeeds (previously failed with expect/actual under v2.4.0)
- [x] `./gradlew koverXmlReport` succeeds end-to-end with 32 per-module reports
- [x] Coverage gate (`scripts/check-coverage-floor.py` equivalent via `MobileByteLabs/mifos-x-actionhub-kover-coverage@v1`): all 31 measurable modules pass
- [ ] Confirmation via CI run

## Reference

- Upstream release notes: https://github.com/MobileByteLabs/kmp-product-flavors/releases/tag/v2.4.2
- Original issue (closed): [kmp-product-flavors#99](https://github.com/MobileByteLabs/kmp-product-flavors/issues/99)
- Follow-on issue (open): [kmp-product-flavors#102](https://github.com/MobileByteLabs/kmp-product-flavors/issues/102)
- Audit: `docs/reports/source-coverage-260519.md` (landed in PR #155)