### PR TITLE
feat(sync-dirs): add cmp-android + cmp-ios to syncable DIRS with branded-asset exclusions

### DIFF
--- a/.github/workflows/sync-dirs.yaml
+++ b/.github/workflows/sync-dirs.yaml
@@ -59,7 +59,9 @@ jobs:
 
           # Declare directories and files to sync
           DIRS=(
+            "cmp-android"
             "cmp-desktop"
+            "cmp-ios"
             "cmp-web"
             "cmp-shared"
             "core-base"
@@ -80,11 +82,15 @@ jobs:
           )
 
           # Define exclusions
+          # Consumer-branded assets and project-specific configs are preserved across syncs.
           declare -A EXCLUSIONS=(
+            ["cmp-android"]="src/main/res dependencies src/main/ic_launcher-playstore.png google-services.json"
+            ["cmp-ios"]="iosApp/Assets.xcassets"
             ["cmp-web"]="src/jsMain/resources src/wasmJsMain/resources"
             ["cmp-desktop"]="icons build.gradle.kts"
             ["fastlane-config"]="project_config.rb extract_config.rb"
             [".github"]="workflows/sync-dirs.yaml"
+            ["build-logic"]="convention/src/main/kotlin/local"
             ["root"]="secrets.env"
           )
 
@@ -272,16 +278,18 @@ jobs:
             Changes included in this sync:
 
             **Directories:**
+            - cmp-android (excluding src/main/res, dependencies, src/main/ic_launcher-playstore.png, google-services.json)
             - cmp-desktop (excluding icons, build.gradle.kts)
+            - cmp-ios (excluding iosApp/Assets.xcassets)
             - cmp-web (excluding src/jsMain/resources, src/wasmJsMain/resources)
             - cmp-shared
             - core-base
-            - build-logic
+            - build-logic (excluding convention/src/main/kotlin/local — consumer flavor extension point)
             - fastlane
             - fastlane-config (excluding project_config.rb, extract_config.rb)
             - scripts
             - config
-            - .github (excluding workflows/sync-dirs.yaml)
+            - .github (excluding workflows/sync-dirs.yaml — self-overwrite guard)
             - .run
 
             **Files:**

--- a/sync-dirs.sh
+++ b/sync-dirs.sh
@@ -23,7 +23,9 @@ LOG_FILE="sync-$(date +%d%m%Y-%H%M%S).log"
 
 # Directories and files to sync
 SYNC_DIRS=(
+    "cmp-android"
     "cmp-desktop"
+    "cmp-ios"
     "cmp-web"
     "cmp-shared"
     "core-base"
@@ -48,6 +50,11 @@ SYNC_FILES=(
 # type can be 'dir' or 'file'
 # Use "root" key for files in the root directory
 declare -A EXCLUSIONS=(
+    # Android — consumer-branded resources (drawables, strings, mipmaps), Firebase config,
+    # launcher icon, and the dependency-guard baseline directory are preserved across syncs.
+    ["cmp-android"]="src/main/res:dir dependencies:dir src/main/ic_launcher-playstore.png:file google-services.json:file"
+    # iOS — consumer-branded asset catalog (app icon, color palette) preserved across syncs.
+    ["cmp-ios"]="iosApp/Assets.xcassets:dir"
     ["cmp-web"]="src/jsMain/resources:dir src/wasmJsMain/resources:dir"
     ["cmp-desktop"]="icons:dir build.gradle.kts:file"
     ["fastlane-config"]="project_config.rb:file extract_config.rb:file"


### PR DESCRIPTION
## Summary

Add `cmp-android` and `cmp-ios` to the syncable `DIRS` list in both `.github/workflows/sync-dirs.yaml` and `sync-dirs.sh` (the two are intentionally kept in lockstep — they are the single source of truth for cross-consumer infrastructure sync). Branded-asset exclusions ensure consumer apps keep their own drawables, launcher icons, Firebase configs, and iOS asset catalogs across syncs.

## What changes

**DIRS additions** (synced from template → consumer on each run):
- `cmp-android` — Android module source tree
- `cmp-ios` — iOS module source tree

**EXCLUSIONS additions** (preserved on consumer side):
| Path | Reason |
|---|---|
| `cmp-android/src/main/res` | Consumer-branded drawables, strings, mipmaps |
| `cmp-android/dependencies` | Dependency-guard baseline directory (per-consumer) |
| `cmp-android/src/main/ic_launcher-playstore.png` | Consumer-branded launcher icon |
| `cmp-android/google-services.json` | Consumer's Firebase config |
| `cmp-ios/iosApp/Assets.xcassets` | Consumer-branded asset catalog (app icon, color palette) |
| `build-logic/convention/src/main/kotlin/local` | Consumer flavor extension point (formalized in workflow alongside script's existing exclusion) |

## Why

Downstream consumer apps (`mifos-x-field-officer-app`, `mifos-mobile`, `mifos-pay`, `mifos-x-group-banking`, `mifos-x-open-banking`, `reels-downloader-new`, …) need to receive Android/iOS source structure from the template (gradle config, Kotlin source layout, platform glue) while keeping their own branded resources. Previously the workflow synced only `cmp-desktop`/`cmp-web`/`cmp-shared`, forcing consumers to manually mirror Android/iOS structural changes.

This unblocks the upcoming `mifos-x-field-officer-app` Store5 migration epic, where field-officer needs to pull `core-base/store`, `core-base/ui`, `build-logic`, and platform sources in a single sync run.

## Test plan

- [ ] Workflow YAML lints (GitHub renders it without errors)
- [ ] `sync-dirs.sh --dry-run` from a fresh consumer clone — verify cmp-android + cmp-ios appear in "Items to sync" output with correct exclusions listed
- [ ] Trigger `workflow_dispatch` on a test consumer (e.g., field-officer's store5Migration branch) — verify resulting sync PR preserves consumer-branded res / Assets.xcassets / google-services.json
- [ ] Verify `temp_excluded/` directory created and cleaned up correctly during sync (no leftover artifacts)

## Related

- Will be consumed by the `mifos-x-field-officer-app` Store5 adoption epic