### PR TITLE
refactor(core/database): lift ChargeTypeConverters.install to commonMain

### DIFF
--- a/core/database/src/androidMain/kotlin/org/mifos/core/database/di/DatabaseModule.android.kt
+++ b/core/database/src/androidMain/kotlin/org/mifos/core/database/di/DatabaseModule.android.kt
@@ -15,13 +15,10 @@ import org.koin.android.ext.koin.androidApplication
 import org.koin.core.module.Module
 import org.koin.dsl.module
 import org.mifos.core.database.AppDatabase
-import org.mifos.core.database.currency.converter.ChargeTypeConverters
 import template.core.base.database.AppDatabaseFactory
-import template.core.base.security.FieldEncryptor
 
 actual val platformModule: Module = module {
     single {
-        ChargeTypeConverters.install(get<FieldEncryptor>())
         AppDatabaseFactory(androidApplication())
             .createDatabase<AppDatabase>(
                 databaseName = AppDatabase.DATABASE_NAME,

--- a/core/database/src/commonMain/kotlin/org/mifos/core/database/di/DatabaseModule.kt
+++ b/core/database/src/commonMain/kotlin/org/mifos/core/database/di/DatabaseModule.kt
@@ -12,6 +12,19 @@ package org.mifos.core.database.di
 import org.koin.core.module.Module
 import org.koin.dsl.module
 import org.mifos.core.database.AppDatabase
+import org.mifos.core.database.currency.converter.ChargeTypeConverters
+import template.core.base.security.FieldEncryptor
+
+/**
+ * Marker singleton — its instantiation has the side effect of wiring [FieldEncryptor]
+ * into [ChargeTypeConverters] before any database access. Bound with `createdAtStart = true`
+ * so the install runs eagerly at Koin start, ahead of the first [AppDatabase] resolution.
+ *
+ * Room 3 KMP instantiates `@TypeConverters` classes via no-arg constructor, so the
+ * encryptor cannot be passed in by constructor — it's injected post-construction through
+ * the [ChargeTypeConverters.install] static method.
+ */
+internal object ChargeTypeConvertersInstalled
 
 /**
  * Koin module that provides the [AppDatabase] instance and all DAO singletons.
@@ -23,6 +36,10 @@ import org.mifos.core.database.AppDatabase
  */
 val DatabaseModule = module {
     includes(platformModule)
+    single(createdAtStart = true) {
+        ChargeTypeConverters.install(get<FieldEncryptor>())
+        ChargeTypeConvertersInstalled
+    }
     single { get<AppDatabase>().sampleDao }
     single { get<AppDatabase>().exchangeRatesDao }
     single { get<AppDatabase>().coinMarketDao }

--- a/core/database/src/desktopMain/kotlin/org/mifos/core/database/di/DatabaseModule.desktop.kt
+++ b/core/database/src/desktopMain/kotlin/org/mifos/core/database/di/DatabaseModule.desktop.kt
@@ -14,13 +14,10 @@ import kotlinx.coroutines.Dispatchers
 import org.koin.core.module.Module
 import org.koin.dsl.module
 import org.mifos.core.database.AppDatabase
-import org.mifos.core.database.currency.converter.ChargeTypeConverters
 import template.core.base.database.AppDatabaseFactory
-import template.core.base.security.FieldEncryptor
 
 actual val platformModule: Module = module {
     single {
-        ChargeTypeConverters.install(get<FieldEncryptor>())
         AppDatabaseFactory()
             .createDatabase<AppDatabase>(
                 databaseName = AppDatabase.DATABASE_NAME,

--- a/core/database/src/jsMain/kotlin/org/mifos/core/database/di/DatabaseModule.js.kt
+++ b/core/database/src/jsMain/kotlin/org/mifos/core/database/di/DatabaseModule.js.kt
@@ -13,13 +13,10 @@ import kotlinx.coroutines.Dispatchers
 import org.koin.core.module.Module
 import org.koin.dsl.module
 import org.mifos.core.database.AppDatabase
-import org.mifos.core.database.currency.converter.ChargeTypeConverters
 import template.core.base.database.AppDatabaseFactory
-import template.core.base.security.FieldEncryptor
 
 actual val platformModule: Module = module {
     single {
-        ChargeTypeConverters.install(get<FieldEncryptor>())
         AppDatabaseFactory()
             .createDatabase<AppDatabase>(
                 databaseName = AppDatabase.DATABASE_NAME,

--- a/core/database/src/nativeMain/kotlin/org/mifos/core/database/di/DatabaseModule.native.kt
+++ b/core/database/src/nativeMain/kotlin/org/mifos/core/database/di/DatabaseModule.native.kt
@@ -14,13 +14,10 @@ import kotlinx.coroutines.Dispatchers
 import org.koin.core.module.Module
 import org.koin.dsl.module
 import org.mifos.core.database.AppDatabase
-import org.mifos.core.database.currency.converter.ChargeTypeConverters
 import template.core.base.database.AppDatabaseFactory
-import template.core.base.security.FieldEncryptor
 
 actual val platformModule: Module = module {
     single {
-        ChargeTypeConverters.install(get<FieldEncryptor>())
         AppDatabaseFactory()
             .createDatabase<AppDatabase>(
                 databaseName = AppDatabase.DATABASE_NAME,

--- a/core/database/src/wasmJsMain/kotlin/org/mifos/core/database/di/DatabaseModule.wasmJs.kt
+++ b/core/database/src/wasmJsMain/kotlin/org/mifos/core/database/di/DatabaseModule.wasmJs.kt
@@ -13,13 +13,10 @@ import kotlinx.coroutines.Dispatchers
 import org.koin.core.module.Module
 import org.koin.dsl.module
 import org.mifos.core.database.AppDatabase
-import org.mifos.core.database.currency.converter.ChargeTypeConverters
 import template.core.base.database.AppDatabaseFactory
-import template.core.base.security.FieldEncryptor
 
 actual val platformModule: Module = module {
     single {
-        ChargeTypeConverters.install(get<FieldEncryptor>())
         AppDatabaseFactory()
             .createDatabase<AppDatabase>(
                 databaseName = AppDatabase.DATABASE_NAME,


### PR DESCRIPTION
## Summary

The `ChargeTypeConverters.install(get<FieldEncryptor>())` line was duplicated across all 5 platform DI modules (`androidMain`, `desktopMain`, `nativeMain`, `jsMain`, `wasmJsMain`). The line itself is platform-agnostic — it just resolves a Koin-provided `FieldEncryptor` (whose `expect` actuals ARE platform-specific) and calls a `commonMain` companion function.

This PR lifts the install to `commonMain` as a `createdAtStart = true` singleton bound to a marker object, eliminating the duplication.

## Why the install is needed at all

Room 3 KMP instantiates `@TypeConverters` classes via no-arg constructor, so `FieldEncryptor` cannot be passed by ctor. The static `companion.install(...)` is the documented post-construction injection pattern.

## What changed

| File | Change |
|---|---|
| `core/database/commonMain/DatabaseModule.kt` | Add `internal object ChargeTypeConvertersInstalled` marker + `single(createdAtStart = true) { ChargeTypeConverters.install(get<FieldEncryptor>()); ChargeTypeConvertersInstalled }` |
| `core/database/{android,desktop,native,js,wasmJs}Main/DatabaseModule.*.kt` | Drop the install line + unused `FieldEncryptor` / `ChargeTypeConverters` imports |

## Ordering guarantee

Before: install ran inside each platform's `single { AppDatabase ... }` factory lambda, just before `AppDatabaseFactory` was invoked.

After: install runs at Koin start (via `createdAtStart = true`) when `DatabaseModule` is loaded. `SecurityModule` (which provides `FieldEncryptor`) is loaded before `DatabaseModule` in `cmp-navigation/.../KoinModules.kt:allModules`, so the encryptor is resolvable when the install fires. The install completes before any consumer can resolve `AppDatabase`.

## Test plan

- [x] `./gradlew :core:database:compileCommonMainKotlinMetadata :core:data:compileCommonMainKotlinMetadata :cmp-navigation:compileCommonMainKotlinMetadata` — commonMain compiles for all touched modules (5 platforms × Kotlin metadata)
- [x] `grep -r "ChargeTypeConverters.install" --include="*.kt"` — only 1 callsite (commonMain DatabaseModule.kt)
- [ ] `./gradlew :cmp-android:build` — CI needs to verify (no `ANDROID_HOME` on dev machine where authored)
- [ ] Smoke test on Android device: encrypted fields still encrypt/decrypt correctly after logout/relogin
- [ ] Smoke test on iOS Apple Silicon simulator: same scenarios

## Diff size

6 files, +17 / −15 lines (net +2). Most of the addition is the marker-object KDoc explaining the install pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)