### PR TITLE
fix(core/database): detekt MatchingDeclarationName on ChargeTypeConvertersInstalled

### DIFF
--- a/core/database/src/commonMain/kotlin/org/mifos/core/database/di/DatabaseModule.kt
+++ b/core/database/src/commonMain/kotlin/org/mifos/core/database/di/DatabaseModule.kt
@@ -24,7 +24,7 @@ import template.core.base.security.FieldEncryptor
  * encryptor cannot be passed in by constructor — it's injected post-construction through
  * the [ChargeTypeConverters.install] static method.
  */
-internal object ChargeTypeConvertersInstalled
+private object ChargeTypeConvertersInstalled
 
 /**
  * Koin module that provides the [AppDatabase] instance and all DAO singletons.


### PR DESCRIPTION
## Summary

Detekt is failing on `dev` (commit d85caea) with:

```
core/database/src/commonMain/kotlin/org/mifos/core/database/di/DatabaseModule.kt:27:17:
The file name 'DatabaseModule' does not match the name of the single top-level declaration
'ChargeTypeConvertersInstalled'. [MatchingDeclarationName]
```

> Failing run: https://github.com/openMF/kmp-project-template/actions/runs/26275219472/job/77337731846

Cause: the marker object added in #161 was declared `internal`. Since the `val DatabaseModule` and `expect val platformModule` in the same file are properties (not classes/objects/interfaces), `ChargeTypeConvertersInstalled` is the sole non-private top-level class/object/interface — which triggers `MatchingDeclarationName`.

## Fix

Change `internal object ChargeTypeConvertersInstalled` → `private object ChargeTypeConvertersInstalled`.

Two reasons private is correct here:

1. **Rule scope**: `MatchingDeclarationName` only triggers for non-private declarations. Making the marker private satisfies the rule without renaming files or adding suppressions.
2. **Intent**: the marker is referenced exactly once — in the same file's `single(createdAtStart = true) { ... ChargeTypeConvertersInstalled }`. It's a file-private side-effect token, not a public API. `private` expresses that accurately.

## Test plan

- [x] `./gradlew :cmp-shared:detekt :cmp-android:detekt :cmp-navigation:detekt :core:analytics:detekt` — all pass locally (the 4 modules that failed on dev)
- [x] `./gradlew :core:database:compileCommonMainKotlinMetadata` — compile still passes; Koin's singleton registration is unaffected by the visibility change (registration site is inside the same file as the declaration)
- [ ] CI re-runs detekt + downstream build jobs — should now go green

## Why this didn't catch in #161's review

I only ran `compileCommonMainKotlinMetadata` to verify #161, not the full `ci-prepush.sh`. The detekt rule would have surfaced this locally with the right invocation. Sorry for the noise — committing to running `./gradlew detekt` as a regular gate for any new top-level declaration going forward.

## Diff size

1 file, +1 / −1 (visibility keyword swap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code visibility adjustment to the database module for improved encapsulation.

---

**Note:** This release contains internal code improvements with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/kmp-project-template/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->