### PR TITLE
refactor(core-base/ui): unify BaseMutationViewModel on BaseViewModel MVI chain

### DIFF
--- a/core-base/ui/src/commonMain/kotlin/template/core/base/ui/viewmodel/BaseMutationViewModel.kt
+++ b/core-base/ui/src/commonMain/kotlin/template/core/base/ui/viewmodel/BaseMutationViewModel.kt
@@ -9,33 +9,36 @@
  */
 package template.core.base.ui.viewmodel
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import template.core.base.store.screen.ScreenState
 import template.core.base.store.submit.MutationUiState
 import template.core.base.store.submit.SubmitState
 import template.core.base.store.submit.submitHandler
 
 /**
- * Optional base class for edit-screen ViewModels that combine a read stream with a form submit.
+ * Base class for edit-screen ViewModels that combine a read stream with a form submit.
  *
- * Provides [uiState] (a [MutationUiState] combining screen + submit state), and three
- * no-argument handlers ([onSubmit], [onRetry], [onDismissResult]) that delegate to the
- * internal [submitHandler].
+ * Extends [BaseViewModel] with the MutationUiState/MutationAction shape baked in — submit
+ * lifecycle is driven through the inherited MVI action channel, so concurrent
+ * [MutationAction.Submit] / [MutationAction.Retry] / [MutationAction.Dismiss] are serialized.
  *
- * Subclasses override [performSubmit] to provide the actual network/repository call.
+ * The combined screen + submit state is exposed via the inherited [stateFlow]; the legacy
+ * [uiState] property is preserved as a get-only alias for backward compatibility.
+ *
+ * Subclasses override [performSubmit] to provide the actual network/repository call and
+ * populate [mutableScreenState] when the read-side data resolves.
  *
  * Usage:
  * ```kotlin
  * class EditClientViewModel(
  *     private val repo: ClientRepository,
  *     private val clientId: String,
- * ) : BaseMutationViewModel<ClientDetail, Unit, EditClientEvent>() {
+ * ) : BaseMutationViewModel<ClientDetail, Unit>() {
  *
  *     init {
  *         viewModelScope.launch {
@@ -50,38 +53,61 @@ import template.core.base.store.submit.submitHandler
  *     override suspend fun performSubmit(payload: ClientDetail): Unit =
  *         repo.updateClient(clientId, payload)
  * }
+ *
+ * // From the screen:
+ * viewModel.trySendAction(MutationAction.Submit(updatedClient))
+ * // — or the convenience shorthand —
+ * viewModel.onSubmit(updatedClient)
  * ```
  *
  * @param T Domain type loaded for display.
  * @param R Result type returned by the server on a successful submit.
  */
-abstract class BaseMutationViewModel<T, R> : ViewModel() {
+abstract class BaseMutationViewModel<T, R> :
+    BaseViewModel<MutationUiState<T, R>, Nothing, MutationAction<T>>(MutationUiState()) {
 
     private val submitHandler = viewModelScope.submitHandler<R>()
 
     protected val mutableScreenState: MutableStateFlow<ScreenState<T>> =
         MutableStateFlow(ScreenState.Loading)
 
-    val uiState: StateFlow<MutationUiState<T, R>> = combine(
-        mutableScreenState,
-        submitHandler.state,
-    ) { screen, submit ->
-        MutationUiState(screen = screen, submit = submit)
-    }.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5_000),
-        initialValue = MutationUiState(),
-    )
+    /**
+     * Backward-compat alias for the inherited [stateFlow]. Existing callers using
+     * `viewModel.uiState` keep working with no change.
+     */
+    val uiState: StateFlow<MutationUiState<T, R>> get() = stateFlow
+
+    init {
+        combine(mutableScreenState, submitHandler.state) { screen, submit ->
+            MutationUiState(screen = screen, submit = submit)
+        }.onEach { combined ->
+            updateState { combined }
+        }.launchIn(viewModelScope)
+    }
 
     /** Override to provide the network/repository call. Called with the current form payload. */
     protected abstract suspend fun performSubmit(payload: T): R
 
+    override fun handleAction(action: MutationAction<T>) {
+        when (action) {
+            is MutationAction.Submit -> submitHandler.submit { performSubmit(action.payload) }
+            MutationAction.Retry -> submitHandler.retry()
+            MutationAction.Dismiss -> submitHandler.reset()
+        }
+    }
+
     /** Trigger a form submission. No-op if already [SubmitState.Submitting]. */
-    fun onSubmit(payload: T) = submitHandler.submit { performSubmit(payload) }
+    fun onSubmit(payload: T) {
+        trySendAction(MutationAction.Submit(payload))
+    }
 
     /** Retry the last failed submission. */
-    fun onRetry() = submitHandler.retry()
+    fun onRetry() {
+        trySendAction(MutationAction.Retry)
+    }
 
     /** Dismiss the result overlay and return to [SubmitState.Idle]. */
-    fun onDismissResult() = submitHandler.reset()
+    fun onDismissResult() {
+        trySendAction(MutationAction.Dismiss)
+    }
 }

--- a/core-base/ui/src/commonMain/kotlin/template/core/base/ui/viewmodel/MutationAction.kt
+++ b/core-base/ui/src/commonMain/kotlin/template/core/base/ui/viewmodel/MutationAction.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package template.core.base.ui.viewmodel
+
+/**
+ * MVI actions emitted by mutation-flow screens (form edit, settings save, etc.).
+ *
+ * Consumed by [BaseMutationViewModel]'s inherited action channel — UI calls
+ * `viewModel.trySendAction(MutationAction.Submit(payload))` (or the convenience method
+ * `onSubmit(payload)`) and the channel serializes processing through `handleAction`.
+ *
+ * @param T Domain payload type submitted to the server / repository.
+ */
+sealed interface MutationAction<out T> {
+
+    /**
+     * User confirmed the form — submit [payload] via the subclass's
+     * [BaseMutationViewModel.performSubmit] implementation. While a submission is in flight,
+     * additional Submit actions queued through the channel are processed sequentially.
+     */
+    data class Submit<T>(val payload: T) : MutationAction<T>
+
+    /** Retry the last failed submission with the previously-submitted payload. */
+    data object Retry : MutationAction<Nothing>
+
+    /** Dismiss the result overlay and return the submit state to `SubmitState.Idle`. */
+    data object Dismiss : MutationAction<Nothing>
+}


### PR DESCRIPTION
## Summary

Part of epic [vm-mvi-and-framework-showcase](https://github.com/openMF/kmp-project-template/tree/dev/...). Sub-plan **01 of 5**: unify the ViewModel inheritance chain so all VMs descend from one MVI base.

Before: two independent ViewModel bases — `BaseViewModel<S, E, A>` (MVI) and `BaseMutationViewModel<T, R>` (direct methods, bypasses MVI). Concurrent Submit/Retry/Dismiss on the same VM weren't serialized.

After: `BaseMutationViewModel` extends `BaseViewModel<MutationUiState<T, R>, Nothing, MutationAction<T>>` — Submit/Retry/Dismiss are MVI actions processed through the inherited channel.

## What changed

| File | Change |
|---|---|
| `core-base/ui/.../viewmodel/MutationAction.kt` (new) | `sealed interface MutationAction<out T>` with `Submit<T>(payload) / Retry / Dismiss` variants |
| `core-base/ui/.../viewmodel/BaseMutationViewModel.kt` | Class signature now extends `BaseViewModel<...>` instead of raw `ViewModel`. `init { }` collects `combine(mutableScreenState, submitHandler.state)` and pushes the merged value into the inherited `stateFlow` via `updateState`. `handleAction` exhaustively dispatches to `submitHandler.submit/retry/reset`. `onSubmit/onRetry/onDismissResult` preserved as `trySendAction(...)` wrappers. `uiState` preserved as `get-only` alias for `stateFlow`. |

Diff: 2 files, +84 / −23.

## Backward compatibility

Zero in-template callers of `BaseMutationViewModel` exist (the class is pure scaffolding today), but if a fork has begun adopting it:

- `viewModel.uiState` still works — now a get-only alias for the inherited `stateFlow`
- `viewModel.onSubmit(payload)` still works — internally `trySendAction(MutationAction.Submit(payload))`
- `viewModel.onRetry()` still works — internally `trySendAction(MutationAction.Retry)`
- `viewModel.onDismissResult()` still works — internally `trySendAction(MutationAction.Dismiss)`
- `protected abstract suspend fun performSubmit(payload: T): R` unchanged
- `protected val mutableScreenState` unchanged

No source-level breakage.

## What this enables

Forks (and subsequent sub-plans 03 + 04) can now ship form-edit screens that:
- Serialize concurrent submit/retry through the action channel — no race conditions
- Observe a single state flow for UI rendering
- Use MVI-style action audit logging / testing patterns uniformly across read-screen and form-edit screens

## Test plan

- [x] `./gradlew :core-base:ui:compileCommonMainKotlinMetadata` — commonMain compiles across all KMP targets (Android, Desktop, iOS, JS, WasmJS metadata)
- [x] `./gradlew :cmp-shared:detekt :cmp-android:detekt :cmp-navigation:detekt :core:analytics:detekt` — detekt passes on the 4 modules that previously failed for MatchingDeclarationName (#162's regression class). New `MutationAction.kt` has matching filename, satisfies the rule.
- [x] `./gradlew check -p build-logic` — convention plugins compile
- [x] `./gradlew :core-base:ui:desktopTest` — existing test suite passes; public API surface (`onSubmit`/`onRetry`/`onDismissResult`/`uiState`) preserved
- [ ] CI: full Android + Desktop + iOS + Web builds — runs in this PR

## Risks documented in the sub-plan + addressed

- ✅ Hidden caller of `uiState` — preserved as alias; grep confirmed zero in-template callers
- ✅ Race between inherited `BaseViewModel.init { }` (action collector) and subclass `init { }` (combine collector) — both launch independent coroutines in `viewModelScope`; no ordering invariant; verified by compile + test run
- ✅ Detekt `MatchingDeclarationName` on new file — filename matches declaration
- N/A `eventFlow: Flow<Nothing>` exposed but never emits — type system clarifies; subclasses needing events can override `E` parameter

## Epic context

This is PR **1 of 5** in the [`vm-mvi-and-framework-showcase`](https://github.com/openMF/kmp-project-template/tree/dev/plan-layer) epic:
- ✅ 01: Unify BaseMutationViewModel on BaseViewModel (this PR)
- ⏳ 02: Migrate 7 existing VMs that "extend BaseViewModel but cheat" to proper MVI shape
- ⏳ 03: New feature/watchlist — canonical SubmitHandler showcase
- ⏳ 04: New feature/alerts — canonical DraftSubmitHandler showcase
- ⏳ 05: Refactor feature/home — multi-source combine dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)