### PR TITLE
refactor: migrate cheating VMs to proper MVI (CoinDetail, CryptoWatchlist, CurrencyRates, RateHistory)

### DIFF
--- a/feature/crypto/src/commonMain/kotlin/org/mifos/feature/crypto/ui/CoinDetailViewModel.kt
+++ b/feature/crypto/src/commonMain/kotlin/org/mifos/feature/crypto/ui/CoinDetailViewModel.kt
@@ -10,9 +10,9 @@
 package org.mifos.feature.crypto.ui
 
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import org.mifos.core.data.crypto.CryptoRepository
 import org.mifos.core.model.crypto.CoinDetail
 import template.core.base.store.screen.ScreenState
@@ -21,17 +21,33 @@ import template.core.base.ui.viewmodel.BaseViewModel
 class CoinDetailViewModel(
     cryptoRepository: CryptoRepository,
     coinId: String,
-) : BaseViewModel<Unit, Nothing, Nothing>(Unit) {
+) : BaseViewModel<ScreenState<CoinDetail>, Nothing, CoinDetailAction>(
+    initialState = ScreenState.Loading,
+) {
 
     private val stream = cryptoRepository.coinDetailStream(
         coinId = coinId,
         scope = viewModelScope,
     )
 
-    val screenState: StateFlow<ScreenState<CoinDetail>> = stream.state
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), ScreenState.Loading)
+    /** Backward-compat alias for the inherited [stateFlow]. */
+    val screenState: StateFlow<ScreenState<CoinDetail>> get() = stateFlow
 
-    fun onRetry() = stream.retry()
+    init {
+        stream.state
+            .onEach { newState -> updateState { newState } }
+            .launchIn(viewModelScope)
+    }
 
-    override fun handleAction(action: Nothing) {}
+    fun onRetry() {
+        trySendAction(CoinDetailAction.Retry)
+    }
+
+    override fun handleAction(action: CoinDetailAction) = when (action) {
+        CoinDetailAction.Retry -> stream.retry()
+    }
+}
+
+sealed interface CoinDetailAction {
+    data object Retry : CoinDetailAction
 }

--- a/feature/crypto/src/commonMain/kotlin/org/mifos/feature/crypto/ui/CryptoWatchlistViewModel.kt
+++ b/feature/crypto/src/commonMain/kotlin/org/mifos/feature/crypto/ui/CryptoWatchlistViewModel.kt
@@ -17,22 +17,34 @@ import template.core.base.ui.viewmodel.BaseViewModel
 
 class CryptoWatchlistViewModel(
     cryptoRepository: CryptoRepository,
-) : BaseViewModel<Unit, CryptoEvent, CryptoAction>(Unit) {
+) : BaseViewModel<Unit, Nothing, CryptoWatchlistAction>(Unit) {
 
     /**
      * Exposed for [template.core.base.ui.PagingScreenContent] which observes the stream
      * directly (state, hasMore, isLoadingMore, loadMoreError) and drives load-more.
+     * Paging state inherently spans multiple flows, so it stays as a field rather than
+     * being folded into the inherited [stateFlow].
      */
     val pagingStream: PagingScreenStream<CoinMarket> = cryptoRepository.coinMarketsStream(
         scope = viewModelScope,
         pageSize = 20,
     )
 
-    fun onRetry() = pagingStream.retry()
-    fun onRefresh() = pagingStream.refresh()
+    fun onRetry() {
+        trySendAction(CryptoWatchlistAction.Retry)
+    }
 
-    override fun handleAction(action: CryptoAction) {}
+    fun onRefresh() {
+        trySendAction(CryptoWatchlistAction.Refresh)
+    }
+
+    override fun handleAction(action: CryptoWatchlistAction) = when (action) {
+        CryptoWatchlistAction.Retry -> pagingStream.retry()
+        CryptoWatchlistAction.Refresh -> pagingStream.refresh()
+    }
 }
 
-sealed class CryptoAction
-sealed class CryptoEvent
+sealed interface CryptoWatchlistAction {
+    data object Retry : CryptoWatchlistAction
+    data object Refresh : CryptoWatchlistAction
+}

--- a/feature/currency-rates/src/commonMain/kotlin/org/mifos/feature/currencyrates/ui/CurrencyRatesViewModel.kt
+++ b/feature/currency-rates/src/commonMain/kotlin/org/mifos/feature/currencyrates/ui/CurrencyRatesViewModel.kt
@@ -21,7 +21,7 @@ import template.core.base.ui.viewmodel.BaseViewModel
 
 class CurrencyRatesViewModel(
     currencyRepository: CurrencyRepository,
-) : BaseViewModel<RatesLocalState, RatesEvent, RatesAction>(RatesLocalState()) {
+) : BaseViewModel<RatesLocalState, Nothing, RatesAction>(RatesLocalState()) {
 
     private val stream = currencyRepository.exchangeRatesStream(
         baseCurrency = "USD",
@@ -41,17 +41,26 @@ class CurrencyRatesViewModel(
         .emptyIfContent { it.rates.isEmpty() }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), ScreenState.Loading)
 
-    fun onRetry() = stream.retry()
-    fun onRefresh() = stream.refresh()
+    fun onRetry() {
+        trySendAction(RatesAction.Retry)
+    }
+
+    fun onRefresh() {
+        trySendAction(RatesAction.Refresh)
+    }
 
     override fun handleAction(action: RatesAction) = when (action) {
         is RatesAction.Search -> updateState { copy(searchQuery = action.query) }
+        RatesAction.Retry -> stream.retry()
+        RatesAction.Refresh -> stream.refresh()
     }
 }
 
 data class RatesLocalState(val searchQuery: String = "")
 data class RatesDisplay(val base: String, val date: String, val rates: Map<String, Double>)
-sealed class RatesAction {
-    data class Search(val query: String) : RatesAction()
+
+sealed interface RatesAction {
+    data class Search(val query: String) : RatesAction
+    data object Retry : RatesAction
+    data object Refresh : RatesAction
 }
-sealed class RatesEvent

--- a/feature/currency-rates/src/commonMain/kotlin/org/mifos/feature/currencyrates/ui/RateHistoryViewModel.kt
+++ b/feature/currency-rates/src/commonMain/kotlin/org/mifos/feature/currencyrates/ui/RateHistoryViewModel.kt
@@ -23,7 +23,7 @@ import template.core.base.ui.viewmodel.BaseViewModel
 
 class RateHistoryViewModel(
     currencyRepository: CurrencyRepository,
-) : BaseViewModel<HistoryLocalState, HistoryEvent, HistoryAction>(HistoryLocalState()) {
+) : BaseViewModel<HistoryLocalState, Nothing, HistoryAction>(HistoryLocalState()) {
 
     private val keyFlow = stateFlow.map { local ->
         RateHistoryKey(from = "USD", to = local.targetCurrency, days = local.periodDays)
@@ -37,17 +37,21 @@ class RateHistoryViewModel(
     val screenState: StateFlow<ScreenState<RateHistory>> = stream.state
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), ScreenState.Loading)
 
-    fun onRetry() = stream.retry()
+    fun onRetry() {
+        trySendAction(HistoryAction.Retry)
+    }
 
     override fun handleAction(action: HistoryAction) = when (action) {
         is HistoryAction.SelectCurrency -> updateState { copy(targetCurrency = action.code) }
         is HistoryAction.SelectPeriod -> updateState { copy(periodDays = action.days) }
+        HistoryAction.Retry -> stream.retry()
     }
 }
 
 data class HistoryLocalState(val targetCurrency: String = "INR", val periodDays: Int = 30)
-sealed class HistoryAction {
-    data class SelectCurrency(val code: String) : HistoryAction()
-    data class SelectPeriod(val days: Int) : HistoryAction()
+
+sealed interface HistoryAction {
+    data class SelectCurrency(val code: String) : HistoryAction
+    data class SelectPeriod(val days: Int) : HistoryAction
+    data object Retry : HistoryAction
 }
-sealed class HistoryEvent


### PR DESCRIPTION
## Summary

Part of epic **vm-mvi-and-framework-showcase**, sub-plan **02 of 5**.

Survey of the 8 existing ViewModels (Phase 1 of sub-plan 02) found that only **4 of 8** were actually "MVI cheaters" — the plan's initial assumption that all 8 cheated was wrong. This PR migrates the 4 that need it; the other 4 are already correct and untouched.

## Survey results

| VM | State source | Actions | `handleAction` | Status |
|---|---|---|---|---|
| `AppViewModel` | `mutableStateFlow.update {}` ✓ | 6 populated variants ✓ | Real body ✓ | **already proper — no change** |
| `AuthenticatedNavbarNavigationViewModel` | `Unit` (deliberate; offline derived separately) ✓ | Populated tab + internal variants ✓ | Real body + `sendEvent` ✓ | **already proper — no change** |
| `RootNavViewModel` | `mutableStateFlow.update {}` ✓ | `UserStateUpdateReceive` variant ✓ | Real body ✓ | **already proper — no change** |
| `EmiCalculatorViewModel` | `updateState {}` ✓ | 3 update variants ✓ | Real body ✓ | **already proper — no change** |
| `CurrencyRatesViewModel` | `stateFlow` ✓ + derived `screenState` | `Search` ✓; `onRetry`/`onRefresh` direct ❌ | Real body for Search, retry/refresh bypass | **migrated** — added `RatesAction.Retry/Refresh` |
| `RateHistoryViewModel` | `stateFlow` ✓ + derived `screenState` | `SelectCurrency`/`SelectPeriod` ✓; `onRetry` direct ❌ | Real body for selections, retry bypass | **migrated** — added `HistoryAction.Retry` |
| `CoinDetailViewModel` | Separate `screenState` field ❌ | Type params `<Unit, Nothing, Nothing>` ❌ | Empty (`Nothing`) ❌ | **migrated** — state into inherited `stateFlow`, added `CoinDetailAction.Retry` |
| `CryptoWatchlistViewModel` | `pagingStream` field (acceptable — paging is multi-flow) | Empty sealed `CryptoAction` ❌; `onRetry`/`onRefresh` direct ❌ | Empty ❌ | **migrated** — populated `CryptoWatchlistAction.Retry/Refresh`, deleted empty `CryptoEvent` |

## What changed

| File | Change |
|---|---|
| `feature/crypto/.../CoinDetailViewModel.kt` | Type params changed from `<Unit, Nothing, Nothing>` to `<ScreenState<CoinDetail>, Nothing, CoinDetailAction>`. `init {}` collects `stream.state` into inherited `stateFlow` via `updateState`. `screenState` preserved as get-only alias. `CoinDetailAction.Retry` populated. `handleAction` dispatches retry. |
| `feature/crypto/.../CryptoWatchlistViewModel.kt` | Renamed `CryptoAction` → `CryptoWatchlistAction` with populated `Retry`/`Refresh` variants. Deleted empty `CryptoEvent` (replaced with `Nothing` in type param). `handleAction` dispatches to pagingStream. |
| `feature/currency-rates/.../CurrencyRatesViewModel.kt` | Added `RatesAction.Retry`/`Refresh`. Deleted empty `RatesEvent` (replaced with `Nothing`). `handleAction` extended for retry/refresh. |
| `feature/currency-rates/.../RateHistoryViewModel.kt` | Added `HistoryAction.Retry`. Deleted empty `HistoryEvent` (replaced with `Nothing`). `handleAction` extended for retry. |

4 files, +66 / −25 LOC.

## Compose screens unchanged

All backward-compat preserved:
- `viewModel.screenState` still works (get-only alias for `stateFlow` in CoinDetail; the derived projection in Currency/RateHistory is unchanged)
- `viewModel.onRetry()` / `viewModel.onRefresh()` still work (now 1-line `trySendAction(...)` wrappers)
- `viewModel.pagingStream` still works (unchanged field)
- `viewModel::onRetry` references in screens (passed as callback) keep working

Zero changes to `*Screen.kt` files. Smoke test on Android/iOS sim verified by Phase 3 (next).

## Why the actions matter even though screens don't change

The race-safe property is the win:
- Before: user double-taps Retry while a Refresh is mid-flight → both methods run concurrently → `stream.retry()` and `stream.refresh()` race
- After: both calls go through the action channel → `handleAction` processes them sequentially → deterministic ordering

For paging streams in particular, this prevents `pagingStream.retry()` and `pagingStream.refresh()` from interleaving — important under flaky network conditions where users mash buttons.

## Test plan

- [x] `./gradlew :feature:crypto:compileCommonMainKotlinMetadata` — passes (multiplatform commonMain compile)
- [x] `./gradlew :feature:currency-rates:compileCommonMainKotlinMetadata` — passes
- [x] `./gradlew :cmp-shared:detekt :cmp-android:detekt :cmp-navigation:detekt :core:analytics:detekt` — all 4 modules pass
- [ ] CI: full Android + Desktop + iOS + Web builds
- [ ] Smoke test on Android device + iOS sim: retry/refresh on CoinDetail, CryptoWatchlist, CurrencyRates, RateHistory screens

## Epic context

This is PR **2 of 5** in the `vm-mvi-and-framework-showcase` epic:
- ✅ 01 ([#164](https://github.com/openMF/kmp-project-template/pull/164)): Unify BaseMutationViewModel on BaseViewModel
- ✅ **02 (this PR)**: Migrate cheating BaseViewModel consumers to proper MVI
- ⏳ 03: New feature/watchlist — canonical SubmitHandler showcase
- ⏳ 04: New feature/alerts — canonical DraftSubmitHandler showcase
- ⏳ 05: Refactor feature/home — multi-source combine dashboard

Independent of 01 — touches different files. 01 modifies `BaseMutationViewModel`, this PR modifies `BaseViewModel` consumers. Both can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)