### PR TITLE
feat(watchlist): add Personal Watchlist feature — canonical SubmitHandler showcase

### DIFF
--- a/cmp-navigation/build.gradle.kts
+++ b/cmp-navigation/build.gradle.kts
@@ -35,6 +35,7 @@ kotlin {
             implementation(projects.feature.emiCalculator)
             implementation(projects.feature.profile)
             implementation(projects.feature.settings)
+            implementation(projects.feature.watchlist)
 
             //put your multiplatform dependencies here
             implementation(compose.material3)

--- a/cmp-navigation/src/commonMain/kotlin/cmp/navigation/authenticated/AuthenticatedNavigation.kt
+++ b/cmp-navigation/src/commonMain/kotlin/cmp/navigation/authenticated/AuthenticatedNavigation.kt
@@ -18,6 +18,7 @@ import androidx.navigation.navigation
 import cmp.navigation.authenticatednavbar.AuthenticatedNavbarRoute
 import cmp.navigation.authenticatednavbar.authenticatedNavbarGraph
 import kotlinx.serialization.Serializable
+import org.mifos.feature.crypto.navigation.CoinDetailRoute
 import org.mifos.feature.crypto.navigation.cryptoGraph
 import org.mifos.feature.crypto.navigation.navigateToCrypto
 import org.mifos.feature.currencyrates.navigation.currencyRatesGraph
@@ -28,6 +29,7 @@ import org.mifos.feature.emicalculator.navigation.navigateToEmiCalculator
 import org.mifos.feature.settings.navigateToSettings
 import org.mifos.feature.settings.notificationDestination
 import org.mifos.feature.settings.settingsDestination
+import org.mifos.feature.watchlist.navigation.personalWatchlistDestination
 
 @Serializable
 internal data object AuthenticatedGraphRoute
@@ -62,5 +64,11 @@ internal fun NavGraphBuilder.authenticatedGraph(
         cryptoGraph(navController)
         currencyRatesGraph(navController)
         emiCalculatorDestination(onBackClick = navController::popBackStack)
+
+        // Personal watchlist (local-only — SubmitHandler showcase target)
+        personalWatchlistDestination(
+            onBackClick = navController::popBackStack,
+            onCoinClick = { coinId -> navController.navigate(CoinDetailRoute(coinId)) },
+        )
     }
 }

--- a/cmp-navigation/src/commonMain/kotlin/cmp/navigation/di/KoinModules.kt
+++ b/cmp-navigation/src/commonMain/kotlin/cmp/navigation/di/KoinModules.kt
@@ -23,6 +23,7 @@ import org.mifos.feature.currencyrates.di.CurrencyRatesModule
 import org.mifos.feature.emicalculator.di.EmiCalculatorModule
 import org.mifos.feature.home.di.HomeModule
 import org.mifos.feature.settings.SettingsModule
+import org.mifos.feature.watchlist.di.WatchlistModule
 import template.core.base.analytics.di.analyticsModule
 import template.core.base.common.di.CommonModule
 import template.core.base.platform.di.platformModule
@@ -52,6 +53,7 @@ object KoinModules {
             EmiCalculatorModule,
             HomeModule,
             SettingsModule,
+            WatchlistModule,
         )
     }
 

--- a/core/data/src/commonMain/kotlin/org/mifos/core/data/di/RepositoryModule.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/core/data/di/RepositoryModule.kt
@@ -24,6 +24,8 @@ import org.mifos.core.data.user.UserDataRepository
 import org.mifos.core.data.user.UserLogoutManager
 import org.mifos.core.data.user.impl.UserDataRepositoryImpl
 import org.mifos.core.data.user.impl.UserLogoutManagerImpl
+import org.mifos.core.data.watchlist.WatchlistRepository
+import org.mifos.core.data.watchlist.impl.WatchlistRepositoryImpl
 import org.mifos.core.database.AppDatabase
 import org.mifos.core.database.di.DatabaseModule
 import org.mifos.core.datastore.di.DatastoreModule
@@ -44,6 +46,10 @@ val DataModule = module {
 
     // Framework DraftDao — backing store for SubmitOutbox / DraftSubmitHandler
     single { get<AppDatabase>().draftDao }
+
+    // Personal watchlist — local-only persistence for the SubmitHandler showcase.
+    single { get<AppDatabase>().watchlistDao }
+    single<WatchlistRepository> { WatchlistRepositoryImpl(get()) }
 
     single<UserLogoutManager> { UserLogoutManagerImpl(get(), get(), get()) }
 

--- a/core/data/src/commonMain/kotlin/org/mifos/core/data/watchlist/WatchlistRepository.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/core/data/watchlist/WatchlistRepository.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package org.mifos.core.data.watchlist
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * User's personal watchlist of coins — purely local persistence, no remote sync.
+ *
+ * Demonstrates the "input simple" archetype: writes go through
+ * [org.mifos.core.data.watchlist.WatchlistRepository.add] /
+ * [org.mifos.core.data.watchlist.WatchlistRepository.remove], driven from
+ * `AddToWatchlistViewModel` via `SubmitHandler` (the canonical simple-mutation
+ * pattern). Reads are reactive [Flow]s straight from the DAO.
+ */
+interface WatchlistRepository {
+
+    /** Observe the full watchlist (newest-added first). Reactive — emits on every change. */
+    fun watchlist(): Flow<List<WatchlistItem>>
+
+    /** Reactive in-membership check. Used by the star toggle to render filled/outline. */
+    fun contains(coinId: String): Flow<Boolean>
+
+    /** Add a coin. Idempotent — re-adds touch the addedAtMs timestamp to "now". */
+    suspend fun add(coinId: String)
+
+    /** Remove a coin. Idempotent — no-op if not present. */
+    suspend fun remove(coinId: String)
+}
+
+/**
+ * UI-facing projection of a watchlist row.
+ *
+ * @property coinId CoinGecko identifier (look up details via CryptoRepository).
+ * @property addedAtMs Epoch millis when the user added the coin.
+ */
+data class WatchlistItem(
+    val coinId: String,
+    val addedAtMs: Long,
+)

--- a/core/data/src/commonMain/kotlin/org/mifos/core/data/watchlist/impl/WatchlistRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/core/data/watchlist/impl/WatchlistRepositoryImpl.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package org.mifos.core.data.watchlist.impl
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlin.time.Clock
+import org.mifos.core.data.watchlist.WatchlistItem
+import org.mifos.core.data.watchlist.WatchlistRepository
+import org.mifos.core.database.watchlist.dao.WatchlistDao
+import org.mifos.core.database.watchlist.entity.WatchlistEntity
+
+internal class WatchlistRepositoryImpl(
+    private val dao: WatchlistDao,
+) : WatchlistRepository {
+
+    override fun watchlist(): Flow<List<WatchlistItem>> =
+        dao.observeAll().map { rows ->
+            rows.map { WatchlistItem(coinId = it.coinId, addedAtMs = it.addedAtMs) }
+        }
+
+    override fun contains(coinId: String): Flow<Boolean> = dao.observeContains(coinId)
+
+    override suspend fun add(coinId: String) {
+        dao.insert(WatchlistEntity(coinId = coinId, addedAtMs = Clock.System.now().toEpochMilliseconds()))
+    }
+
+    override suspend fun remove(coinId: String) {
+        dao.delete(coinId)
+    }
+}

--- a/core/database/src/commonMain/kotlin/org/mifos/core/database/AppDatabase.kt
+++ b/core/database/src/commonMain/kotlin/org/mifos/core/database/AppDatabase.kt
@@ -33,6 +33,8 @@ import org.mifos.core.database.infra.entity.DraftEntity
 import org.mifos.core.database.infra.entity.FetchedAtEntity
 import org.mifos.core.database.sample.dao.SampleDao
 import org.mifos.core.database.sample.entity.SampleEntity
+import org.mifos.core.database.watchlist.dao.WatchlistDao
+import org.mifos.core.database.watchlist.entity.WatchlistEntity
 
 /**
  * KSP-generated constructor bridge for [AppDatabase].
@@ -70,6 +72,7 @@ expect object AppDatabaseConstructor : RoomDatabaseConstructor<AppDatabase> {
         BookkeeperEntity::class,
         FetchedAtEntity::class,
         DraftEntity::class,
+        WatchlistEntity::class,
     ],
     version = AppDatabase.VERSION,
     exportSchema = true,
@@ -78,6 +81,8 @@ expect object AppDatabaseConstructor : RoomDatabaseConstructor<AppDatabase> {
         AutoMigration(from = 3, to = 4),
         // v4 → v5: adds `framework_submit_drafts` for offline-first form submission outbox.
         AutoMigration(from = 4, to = 5),
+        // v5 → v6: adds `personal_watchlist` for the user's private watchlist.
+        AutoMigration(from = 5, to = 6),
     ],
 )
 @TypeConverters(ChargeTypeConverters::class, FintechTypeConverters::class)
@@ -92,9 +97,10 @@ abstract class AppDatabase : RoomDatabase() {
     abstract val bookkeeperDao: BookkeeperDao
     abstract val fetchedAtDao: FetchedAtDao
     abstract val draftDao: DraftDao
+    abstract val watchlistDao: WatchlistDao
 
     companion object {
-        const val VERSION = 5
+        const val VERSION = 6
         const val DATABASE_NAME = "mifos_database.db"
     }
 }

--- a/core/database/src/commonMain/kotlin/org/mifos/core/database/watchlist/dao/WatchlistDao.kt
+++ b/core/database/src/commonMain/kotlin/org/mifos/core/database/watchlist/dao/WatchlistDao.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package org.mifos.core.database.watchlist.dao
+
+import androidx.room3.Dao
+import androidx.room3.Insert
+import androidx.room3.OnConflictStrategy
+import androidx.room3.Query
+import kotlinx.coroutines.flow.Flow
+import org.mifos.core.database.watchlist.entity.WatchlistEntity
+
+/**
+ * Data-access object for the `personal_watchlist` table.
+ *
+ * Reads are reactive [Flow]s; writes are `suspend`. Standard Room 3 KMP shape.
+ */
+@Dao
+interface WatchlistDao {
+
+    /** Observe the full watchlist, ordered by addition time (newest first). */
+    @Query("SELECT * FROM personal_watchlist ORDER BY addedAtMs DESC")
+    fun observeAll(): Flow<List<WatchlistEntity>>
+
+    /** Reactive in-membership check for a given coin — emits whenever the watchlist changes. */
+    @Query("SELECT EXISTS(SELECT 1 FROM personal_watchlist WHERE coinId = :coinId)")
+    fun observeContains(coinId: String): Flow<Boolean>
+
+    /** Add a coin to the watchlist. If already present, replaces the row (no-op effectively). */
+    @Insert(entity = WatchlistEntity::class, onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(entry: WatchlistEntity)
+
+    /** Remove a coin from the watchlist. No-op if absent. */
+    @Query("DELETE FROM personal_watchlist WHERE coinId = :coinId")
+    suspend fun delete(coinId: String)
+}

--- a/core/database/src/commonMain/kotlin/org/mifos/core/database/watchlist/entity/WatchlistEntity.kt
+++ b/core/database/src/commonMain/kotlin/org/mifos/core/database/watchlist/entity/WatchlistEntity.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package org.mifos.core.database.watchlist.entity
+
+import androidx.room3.Entity
+import androidx.room3.PrimaryKey
+
+/**
+ * Persistent row representing a coin in the user's personal watchlist.
+ *
+ * Local-only: no Store5 caching layer, no remote sync. The user's watchlist
+ * is a private device-local list of coin identifiers; full coin metadata
+ * (name, symbol, price, etc.) is resolved on-demand via the existing
+ * `coinDetailStream` / `coinMarketsStream` from CryptoRepository.
+ *
+ * @property coinId CoinGecko coin identifier (e.g., "bitcoin", "ethereum"). Primary key.
+ * @property addedAtMs Epoch millis when the coin was added — used for default sort order.
+ */
+@Entity(tableName = "personal_watchlist")
+data class WatchlistEntity(
+    @PrimaryKey
+    val coinId: String,
+    val addedAtMs: Long,
+)

--- a/feature/crypto/src/commonMain/kotlin/org/mifos/feature/crypto/ui/CoinDetailScreen.kt
+++ b/feature/crypto/src/commonMain/kotlin/org/mifos/feature/crypto/ui/CoinDetailScreen.kt
@@ -35,6 +35,7 @@ import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 import org.mifos.core.common.formatDecimal
 import org.mifos.core.common.formatGrouped
+import org.mifos.feature.watchlist.ui.AddToWatchlistButton
 import template.core.base.ui.screen.ScreenContent
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -56,6 +57,9 @@ fun CoinDetailScreen(
                     IconButton(onClick = onBackClick) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
+                },
+                actions = {
+                    AddToWatchlistButton(coinId = coinId)
                 },
             )
         },

--- a/feature/watchlist/build.gradle.kts
+++ b/feature/watchlist/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Mifos Initiative
+ * Copyright 2026 Mifos Initiative
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -12,7 +12,7 @@ plugins {
 }
 
 android {
-    namespace = "org.mifos.feature.crypto"
+    namespace = "org.mifos.feature.watchlist"
 }
 
 kotlin {
@@ -20,10 +20,8 @@ kotlin {
         commonMain.dependencies {
             implementation(projects.core.common)
             implementation(projects.core.domain)
-            // KptScaffold + rememberKptPullToRefreshState bridge live in core/ui
             implementation(projects.core.ui)
-            // CoinDetailScreen embeds AddToWatchlistButton from feature/watchlist
-            implementation(projects.feature.watchlist)
+            implementation(projects.core.data)
 
             implementation(compose.ui)
             implementation(compose.material3)

--- a/feature/watchlist/src/commonMain/kotlin/org/mifos/feature/watchlist/di/WatchlistModule.kt
+++ b/feature/watchlist/src/commonMain/kotlin/org/mifos/feature/watchlist/di/WatchlistModule.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package org.mifos.feature.watchlist.di
+
+import org.koin.core.module.dsl.viewModel
+import org.koin.dsl.module
+import org.mifos.feature.watchlist.ui.AddToWatchlistViewModel
+import org.mifos.feature.watchlist.ui.PersonalWatchlistViewModel
+
+val WatchlistModule = module {
+    viewModel { PersonalWatchlistViewModel(get()) }
+    viewModel { params -> AddToWatchlistViewModel(coinId = params.get(), repository = get()) }
+}

--- a/feature/watchlist/src/commonMain/kotlin/org/mifos/feature/watchlist/navigation/PersonalWatchlistRoute.kt
+++ b/feature/watchlist/src/commonMain/kotlin/org/mifos/feature/watchlist/navigation/PersonalWatchlistRoute.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package org.mifos.feature.watchlist.navigation
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import kotlinx.serialization.Serializable
+import org.mifos.feature.watchlist.ui.PersonalWatchlistScreen
+import template.core.base.ui.nav.composableWithPushTransitions
+
+@Serializable
+data object PersonalWatchlistRoute
+
+fun NavController.navigateToPersonalWatchlist(navOptions: NavOptions? = null) {
+    navigate(route = PersonalWatchlistRoute, navOptions = navOptions)
+}
+
+fun NavGraphBuilder.personalWatchlistDestination(
+    onBackClick: () -> Unit,
+    onCoinClick: (String) -> Unit,
+) {
+    composableWithPushTransitions<PersonalWatchlistRoute> {
+        PersonalWatchlistScreen(
+            onBackClick = onBackClick,
+            onCoinClick = onCoinClick,
+        )
+    }
+}

--- a/feature/watchlist/src/commonMain/kotlin/org/mifos/feature/watchlist/ui/AddToWatchlistButton.kt
+++ b/feature/watchlist/src/commonMain/kotlin/org/mifos/feature/watchlist/ui/AddToWatchlistButton.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package org.mifos.feature.watchlist.ui
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.StarBorder
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import org.koin.compose.viewmodel.koinViewModel
+import org.koin.core.parameter.parametersOf
+import template.core.base.store.submit.SubmitState
+
+/**
+ * Star toggle that adds/removes a coin from the user's personal watchlist.
+ *
+ * Renders a filled star when the coin is in the watchlist, an outline star otherwise.
+ * Tapping toggles via [AddToWatchlistViewModel] (which uses `SubmitHandler` — the
+ * canonical simple-Mutation pattern). The button is disabled while a submit is in
+ * flight to prevent double-tap races.
+ *
+ * @param coinId Identifier of the coin being toggled. One [AddToWatchlistViewModel]
+ *   instance is created per coinId via Koin `parametersOf`.
+ */
+@Composable
+fun AddToWatchlistButton(
+    coinId: String,
+    modifier: Modifier = Modifier,
+    viewModel: AddToWatchlistViewModel = koinViewModel(key = coinId) { parametersOf(coinId) },
+) {
+    val isInWatchlist by viewModel.isInWatchlist.collectAsStateWithLifecycle(initialValue = false)
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    IconButton(
+        onClick = {
+            viewModel.onSubmit(
+                if (isInWatchlist) WatchlistMutation.Remove else WatchlistMutation.Add,
+            )
+        },
+        modifier = modifier,
+        enabled = uiState.submit !is SubmitState.Submitting,
+    ) {
+        Icon(
+            imageVector = if (isInWatchlist) Icons.Filled.Star else Icons.Outlined.StarBorder,
+            contentDescription = if (isInWatchlist) {
+                "Remove $coinId from watchlist"
+            } else {
+                "Add $coinId to watchlist"
+            },
+        )
+    }
+}

--- a/feature/watchlist/src/commonMain/kotlin/org/mifos/feature/watchlist/ui/AddToWatchlistViewModel.kt
+++ b/feature/watchlist/src/commonMain/kotlin/org/mifos/feature/watchlist/ui/AddToWatchlistViewModel.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package org.mifos.feature.watchlist.ui
+
+import kotlinx.coroutines.flow.Flow
+import org.mifos.core.data.watchlist.WatchlistRepository
+import template.core.base.ui.viewmodel.BaseMutationViewModel
+
+/**
+ * Toggle-write ViewModel for the watchlist star icon. Canonical `SubmitHandler` showcase.
+ *
+ * The submit lifecycle is driven by [BaseMutationViewModel] — calls flow through
+ * `submitHandler.submit { ... }` so concurrent taps are serialized into Idle → Submitting
+ * → Success/Failure transitions. The screen observes [uiState].submit for feedback
+ * (loading spinner during submit, error overlay on failure) and [isInWatchlist] for the
+ * icon variant (filled vs outline).
+ *
+ * @param coinId The coin identifier this button toggles. Injected via Koin parameters at
+ *   the call site — one VM instance per coin currently being rendered.
+ */
+class AddToWatchlistViewModel(
+    private val coinId: String,
+    private val repository: WatchlistRepository,
+) : BaseMutationViewModel<WatchlistMutation, Unit>() {
+
+    /** Reactive in-membership for the current [coinId] — drives the star icon variant. */
+    val isInWatchlist: Flow<Boolean> = repository.contains(coinId)
+
+    override suspend fun performSubmit(payload: WatchlistMutation): Unit = when (payload) {
+        WatchlistMutation.Add -> repository.add(coinId)
+        WatchlistMutation.Remove -> repository.remove(coinId)
+    }
+}
+
+/** Explicit toggle direction — avoids any ambiguity between Add and Remove. */
+sealed interface WatchlistMutation {
+    data object Add : WatchlistMutation
+    data object Remove : WatchlistMutation
+}

--- a/feature/watchlist/src/commonMain/kotlin/org/mifos/feature/watchlist/ui/PersonalWatchlistScreen.kt
+++ b/feature/watchlist/src/commonMain/kotlin/org/mifos/feature/watchlist/ui/PersonalWatchlistScreen.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package org.mifos.feature.watchlist.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import org.koin.compose.viewmodel.koinViewModel
+import template.core.base.ui.screen.ScreenContent
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PersonalWatchlistScreen(
+    onBackClick: () -> Unit,
+    onCoinClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: PersonalWatchlistViewModel = koinViewModel(),
+) {
+    val screenState by viewModel.screenState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("My Watchlist") },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        ScreenContent(
+            state = screenState,
+            onRetry = {},
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) { items, _ ->
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 16.dp),
+            ) {
+                items(items = items, key = { it.coinId }) { item ->
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onCoinClick(item.coinId) },
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            Text(
+                                text = item.coinId,
+                                style = MaterialTheme.typography.titleMedium,
+                            )
+                            Text(
+                                text = "Added ${item.addedAtMs}",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/feature/watchlist/src/commonMain/kotlin/org/mifos/feature/watchlist/ui/PersonalWatchlistViewModel.kt
+++ b/feature/watchlist/src/commonMain/kotlin/org/mifos/feature/watchlist/ui/PersonalWatchlistViewModel.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package org.mifos.feature.watchlist.ui
+
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import org.mifos.core.data.watchlist.WatchlistItem
+import org.mifos.core.data.watchlist.WatchlistRepository
+import template.core.base.store.screen.DataFreshness
+import template.core.base.store.screen.ScreenState
+import template.core.base.ui.viewmodel.BaseViewModel
+
+/**
+ * Read-side ViewModel for [PersonalWatchlistScreen].
+ *
+ * Maps the [WatchlistRepository.watchlist] flow into [ScreenState] so the screen renders
+ * via `ScreenContent` with the standard Loading/Empty/Content states. Pure-read, no
+ * actions — the local-only Room source has no error or network states to model.
+ */
+class PersonalWatchlistViewModel(
+    repository: WatchlistRepository,
+) : BaseViewModel<Unit, Nothing, Nothing>(Unit) {
+
+    val screenState: StateFlow<ScreenState<List<WatchlistItem>>> = repository.watchlist()
+        .map { items ->
+            if (items.isEmpty()) ScreenState.Empty
+            else ScreenState.Content(data = items, freshness = DataFreshness.FRESH)
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ScreenState.Loading)
+
+    override fun handleAction(action: Nothing) {}
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -117,6 +117,7 @@ include(":feature:settings")
 include(":feature:crypto")
 include(":feature:currency-rates")
 include(":feature:emi-calculator")
+include(":feature:watchlist")
 
 include(":core-base:analytics")
 include(":core-base:common")


### PR DESCRIPTION
## Summary

Part of epic **vm-mvi-and-framework-showcase**, sub-plan **03 of 5**.

Introduces a local-only Personal Watchlist where users star/unstar coins from CoinDetailScreen. This is the **first working example of the `SubmitHandler` simple-mutation pattern** in the template — until now, `BaseMutationViewModel` had zero consumers and forks had no example to copy.

## What's new

### Data layer (`core/database` + `core/data`)
- `WatchlistEntity` (table `personal_watchlist`, PK = `coinId`)
- `WatchlistDao` — `observeAll() / observeContains(coinId) / insert / delete`
- `AppDatabase`: registered entity + DAO, version bumped 5→6, `@AutoMigration(5, 6)` added
- `WatchlistRepository` + `WatchlistRepositoryImpl` (local-only, no Store5)
- Koin binding in `RepositoryModule`

### Feature module (`feature/watchlist` — new)
- **`AddToWatchlistViewModel`** : `BaseMutationViewModel<WatchlistMutation, Unit>` — the showcase
  - `sealed interface WatchlistMutation { Add, Remove }` — explicit toggle direction
  - `performSubmit` branches to `repository.add/remove(coinId)`
  - `isInWatchlist: Flow<Boolean>` for the star icon variant
- **`PersonalWatchlistViewModel`** : `BaseViewModel<Unit, Nothing, Nothing>`
  - Maps `repository.watchlist()` → `ScreenState<List<WatchlistItem>>`
  - `Empty` when list empty, `Content` otherwise; no error state (local-only)
- **`AddToWatchlistButton` @Composable** — `koinViewModel(key = coinId) { parametersOf(coinId) }`
  - Filled star when in watchlist, outline otherwise
  - Disabled while `uiState.submit is SubmitState.Submitting` (race prevention)
- **`PersonalWatchlistScreen` @Composable** — `Scaffold` + `ScreenContent` + `LazyColumn`
  - Row tap navigates to CoinDetail
- **`WatchlistModule`** (Koin) — `viewModelOf` for both VMs, parameterized by coinId
- **`PersonalWatchlistRoute`** + nav extensions

### Wiring
- `settings.gradle.kts`: `include(\":feature:watchlist\")`
- `cmp-navigation/build.gradle.kts`: `implementation(projects.feature.watchlist)`
- `feature/crypto/build.gradle.kts`: `implementation(projects.feature.watchlist)` — `CoinDetailScreen` embeds `AddToWatchlistButton` in TopAppBar `actions` slot
- `KoinModules.kt`: `featureModule.includes(WatchlistModule)`
- `AuthenticatedNavigation.kt`: `personalWatchlistDestination(...)` wired

## Showcase value for forks

| Pattern | How this shows it |
|---|---|
| `SubmitHandler` lifecycle | Single tap → `submitHandler.submit { … }` → Idle → Submitting → Success |
| Race-safe concurrent actions | Button disabled while submit in flight; framework also serializes via internal channel |
| `BaseMutationViewModel.performSubmit` | Branches on a typed payload (`WatchlistMutation`), not a raw Unit |
| Read-side `ScreenState` mapping | `repository.watchlist()` → Empty / Content with `DataFreshness.FRESH` (local source) |
| Per-coin VM with Koin params | `koinViewModel(key = coinId) { parametersOf(coinId) }` |

## What's NOT in this PR (intentionally deferred)

- Per-row star icons in `CryptoWatchlistScreen` — defer to a follow-up (paged-row UX complexity)
- Comprehensive tests — see sub-plan 03 Phase 4 (tests deferred for review economy)
- Home-dashboard widget linking to PersonalWatchlistScreen — that's sub-plan 05

The route IS registered, so sub-plan 05's dashboard can link to it once that ships.

## Backward compatibility with sub-plan 01

`AddToWatchlistViewModel` uses the current dev `BaseMutationViewModel` API (extends raw `ViewModel`, direct `onSubmit(payload)` method). When [#164](https://github.com/openMF/kmp-project-template/pull/164) merges and converts `BaseMutationViewModel` to extend `BaseViewModel<MutationUiState<T,R>, Nothing, MutationAction<T>>`, `onSubmit(payload)` becomes a `trySendAction(MutationAction.Submit(payload))` wrapper — **no source-level change** to this VM is required.

## Test plan

- [x] `:feature:watchlist:compileCommonMainKotlinMetadata` — passes (multiplatform — Android, Desktop, iOS, JS, WasmJS metadata)
- [x] `:feature:crypto`, `:cmp-navigation`, `:core:database`, `:core:data` — all compile
- [x] `./gradlew :feature:watchlist:detekt :cmp-navigation:detekt :feature:crypto:detekt :core:data:detekt :core:database:detekt :cmp-shared:detekt :cmp-android:detekt` — all 7 modules pass
- [ ] CI: full Android + Desktop + iOS + Web builds
- [ ] Smoke test on Android: open CoinDetail → tap star → check PersonalWatchlistScreen → tap row → returns to CoinDetail. Tap star again → coin removed.
- [ ] Smoke test on iOS Apple Silicon sim: same flow

## Epic context

- ✅ **01** ([#164](https://github.com/openMF/kmp-project-template/pull/164)): Unify BaseMutationViewModel
- ✅ **02** ([#165](https://github.com/openMF/kmp-project-template/pull/165)): Migrate cheating VMs
- ✅ **03 (this PR)**: Personal Watchlist — SubmitHandler showcase
- ⏳ **04**: Price Alerts — DraftSubmitHandler showcase
- ⏳ **05**: Home Dashboard — multi-source combine

🤖 Generated with [Claude Code](https://claude.com/claude-code)