### PR TITLE
feat(alerts): add Price Alerts feature — canonical DraftSubmitHandler showcase

### DIFF
--- a/cmp-navigation/build.gradle.kts
+++ b/cmp-navigation/build.gradle.kts
@@ -35,6 +35,7 @@ kotlin {
             implementation(projects.feature.emiCalculator)
             implementation(projects.feature.profile)
             implementation(projects.feature.settings)
+            implementation(projects.feature.alerts)
 
             //put your multiplatform dependencies here
             implementation(compose.material3)

--- a/cmp-navigation/src/commonMain/kotlin/cmp/navigation/authenticated/AuthenticatedNavigation.kt
+++ b/cmp-navigation/src/commonMain/kotlin/cmp/navigation/authenticated/AuthenticatedNavigation.kt
@@ -18,6 +18,7 @@ import androidx.navigation.navigation
 import cmp.navigation.authenticatednavbar.AuthenticatedNavbarRoute
 import cmp.navigation.authenticatednavbar.authenticatedNavbarGraph
 import kotlinx.serialization.Serializable
+import org.mifos.feature.alerts.navigation.alertsGraph
 import org.mifos.feature.crypto.navigation.cryptoGraph
 import org.mifos.feature.crypto.navigation.navigateToCrypto
 import org.mifos.feature.currencyrates.navigation.currencyRatesGraph
@@ -62,5 +63,8 @@ internal fun NavGraphBuilder.authenticatedGraph(
         cryptoGraph(navController)
         currencyRatesGraph(navController)
         emiCalculatorDestination(onBackClick = navController::popBackStack)
+
+        // Price alerts (DraftSubmitHandler showcase — offline-resilient form submit)
+        alertsGraph(navController)
     }
 }

--- a/cmp-navigation/src/commonMain/kotlin/cmp/navigation/di/KoinModules.kt
+++ b/cmp-navigation/src/commonMain/kotlin/cmp/navigation/di/KoinModules.kt
@@ -18,6 +18,7 @@ import org.mifos.core.data.di.DataModule
 import org.mifos.core.database.di.DatabaseModule
 import org.mifos.core.datastore.di.DatastoreModule
 import org.mifos.core.store.di.appStoreModule
+import org.mifos.feature.alerts.di.AlertsModule
 import org.mifos.feature.crypto.di.CryptoModule
 import org.mifos.feature.currencyrates.di.CurrencyRatesModule
 import org.mifos.feature.emicalculator.di.EmiCalculatorModule
@@ -52,6 +53,7 @@ object KoinModules {
             EmiCalculatorModule,
             HomeModule,
             SettingsModule,
+            AlertsModule,
         )
     }
 

--- a/core/data/src/commonMain/kotlin/org/mifos/core/data/alerts/AlertsRepository.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/core/data/alerts/AlertsRepository.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package org.mifos.core.data.alerts
+
+import kotlinx.coroutines.flow.Flow
+import org.mifos.core.model.alerts.PriceAlert
+
+/**
+ * Repository for the Price Alerts feature.
+ *
+ * Read side: observable list of committed alerts (from [AlertsApi.observe]).
+ * Pending drafts (in the framework outbox) are tracked at the form-handler
+ * level via `DraftSubmitHandler` — the `framework_submit_drafts` row for
+ * formKey `"price_alert"` indicates an in-flight or failed submission, surfaced
+ * to the user via the form screen's `DraftResumeBanner` rather than the list.
+ *
+ * Write side: [submitAlert] is the suspend block passed to
+ * `DraftSubmitHandler.submit { repo.submitAlert(payload) }`. On network failure
+ * the handler persists the payload to the outbox; on reconnect, the
+ * [template.core.base.store.submit.OfflineSubmitSyncer] retries it through the
+ * same block.
+ */
+interface AlertsRepository {
+
+    /** Reactive list of server-committed alerts, newest first. */
+    fun alertsStream(): Flow<List<PriceAlert>>
+
+    /**
+     * Direct API submit — used by `DraftSubmitHandler`'s block parameter and by
+     * `OfflineSubmitSyncer` for reconnect retries. Throws on failure; the
+     * handler / syncer route the error to the outbox.
+     */
+    suspend fun submitAlert(alert: PriceAlert): PriceAlert
+
+    /** Delete by id. */
+    suspend fun deleteAlert(id: String)
+}

--- a/core/data/src/commonMain/kotlin/org/mifos/core/data/alerts/impl/AlertsRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/core/data/alerts/impl/AlertsRepositoryImpl.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package org.mifos.core.data.alerts.impl
+
+import kotlinx.coroutines.flow.Flow
+import org.mifos.core.data.alerts.AlertsRepository
+import org.mifos.core.model.alerts.PriceAlert
+import org.mifos.core.network.alerts.api.AlertsApi
+
+internal class AlertsRepositoryImpl(
+    private val api: AlertsApi,
+) : AlertsRepository {
+
+    override fun alertsStream(): Flow<List<PriceAlert>> = api.observe()
+
+    override suspend fun submitAlert(alert: PriceAlert): PriceAlert = api.create(alert)
+
+    override suspend fun deleteAlert(id: String) = api.delete(id)
+}

--- a/core/data/src/commonMain/kotlin/org/mifos/core/data/di/RepositoryModule.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/core/data/di/RepositoryModule.kt
@@ -10,16 +10,22 @@
 package org.mifos.core.data.di
 
 import io.github.mobilebytelabs.kmptoolkit.networkmonitor.NetworkMonitorProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
+import org.mifos.core.data.alerts.AlertsRepository
+import org.mifos.core.data.alerts.impl.AlertsRepositoryImpl
 import org.mifos.core.data.crypto.CryptoRepository
 import org.mifos.core.data.crypto.impl.CryptoRepositoryImpl
 import org.mifos.core.data.currency.CurrencyRepository
 import org.mifos.core.data.currency.impl.CurrencyRepositoryImpl
 import org.mifos.core.data.infra.NetworkMonitor
 import org.mifos.core.data.infra.impl.RoomFetchedAtRepository
+import org.mifos.core.data.infra.impl.RoomSubmitOutbox
 import org.mifos.core.data.user.UserDataRepository
 import org.mifos.core.data.user.UserLogoutManager
 import org.mifos.core.data.user.impl.UserDataRepositoryImpl
@@ -27,10 +33,15 @@ import org.mifos.core.data.user.impl.UserLogoutManagerImpl
 import org.mifos.core.database.AppDatabase
 import org.mifos.core.database.di.DatabaseModule
 import org.mifos.core.datastore.di.DatastoreModule
+import org.mifos.core.model.alerts.PriceAlert
+import org.mifos.core.network.alerts.api.AlertsApi
+import org.mifos.core.network.alerts.api.FakeAlertsApi
 import org.mifos.core.network.di.NetworkModule
 import org.mifos.core.store.AppStoreRegistry
 import template.core.base.common.di.CommonModule
 import template.core.base.store.infra.FetchedAtRepository
+import template.core.base.store.submit.OfflineSubmitSyncer
+import template.core.base.store.submit.SubmitOutbox
 
 val DataModule = module {
     includes(platformModule, CommonModule, DatabaseModule, DatastoreModule, NetworkModule)
@@ -63,6 +74,32 @@ val DataModule = module {
             networkMonitor = get(),
             fetchedAtRepository = get(),
         )
+    }
+
+    // Price alerts — fake-API-backed, with DraftSubmitHandler offline-resilience showcase.
+    // Real forks substitute FakeAlertsApi with a Ktorfit-backed AlertsApi client.
+    single<AlertsApi> { FakeAlertsApi() }
+    single<AlertsRepository> { AlertsRepositoryImpl(api = get()) }
+
+    // Outbox for PriceAlert payloads — RoomSubmitOutbox writes to framework_submit_drafts.
+    single<SubmitOutbox<PriceAlert>> {
+        RoomSubmitOutbox(dao = get(), serializer = PriceAlert.serializer())
+    }
+
+    // App-scoped CoroutineScope for cross-VM long-running coroutines (e.g., OfflineSubmitSyncer).
+    single<CoroutineScope> { CoroutineScope(SupervisorJob() + Dispatchers.Default) }
+
+    // Eager singleton — starts watching network online events at Koin start; retries
+    // any pending alerts when connectivity returns.
+    single(createdAtStart = true) {
+        val syncer = OfflineSubmitSyncer<PriceAlert, PriceAlert>(
+            scope = get(),
+            outbox = get(),
+            isOnlineFlow = get<NetworkMonitor>().isOnline,
+            submitBlock = { payload -> get<AlertsApi>().create(payload) },
+        )
+        syncer.start()
+        syncer
     }
 }
 

--- a/core/model/src/commonMain/kotlin/org/mifos/core/model/alerts/PriceAlert.kt
+++ b/core/model/src/commonMain/kotlin/org/mifos/core/model/alerts/PriceAlert.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package org.mifos.core.model.alerts
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A price alert configured by the user for a specific coin.
+ *
+ * Serializable because [org.mifos.core.data.alerts.AlertsRepository] persists
+ * unsent alerts to the `framework_submit_drafts` outbox during offline
+ * submission — RoomSubmitOutbox writes the payload as JSON.
+ *
+ * @property id Stable identifier (UUID or other client-generated id). Used as the
+ *   primary key both client-side and on the fake server.
+ * @property coinId CoinGecko identifier (e.g., "bitcoin", "ethereum").
+ * @property direction Above / Below / PCT_CHANGE comparison applied to [targetValue].
+ * @property targetValue Threshold value — interpreted in USD for ABOVE/BELOW,
+ *   in percentage for PCT_CHANGE.
+ * @property enabled Whether the alert is currently active. Disabled alerts persist
+ *   but don't trigger notifications.
+ * @property createdAtMs Epoch millis when the alert was first saved (client time).
+ */
+@Serializable
+data class PriceAlert(
+    val id: String,
+    val coinId: String,
+    val direction: AlertDirection,
+    val targetValue: Double,
+    val enabled: Boolean = true,
+    val createdAtMs: Long,
+)
+
+@Serializable
+enum class AlertDirection {
+    /** Trigger when price rises above [PriceAlert.targetValue]. */
+    ABOVE,
+
+    /** Trigger when price falls below [PriceAlert.targetValue]. */
+    BELOW,
+
+    /** Trigger on a percent-change of at least [PriceAlert.targetValue]% over 24h. */
+    PCT_CHANGE,
+}

--- a/core/network/src/commonMain/kotlin/org/mifos/core/network/alerts/api/AlertsApi.kt
+++ b/core/network/src/commonMain/kotlin/org/mifos/core/network/alerts/api/AlertsApi.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package org.mifos.core.network.alerts.api
+
+import kotlinx.coroutines.flow.Flow
+import org.mifos.core.model.alerts.PriceAlert
+
+/**
+ * Server-side API for managing price alerts.
+ *
+ * The template ships a [FakeAlertsApi] in-memory implementation since no real
+ * backend exists. Real forks substitute a Ktorfit-backed implementation pointing
+ * at their server. The fake retains a 800 ms simulated latency so the showcase
+ * exercises the `DraftSubmitHandler` Submitting state visibly.
+ */
+interface AlertsApi {
+
+    /** Persist a new alert (or upsert an existing one with the same [PriceAlert.id]). */
+    suspend fun create(alert: PriceAlert): PriceAlert
+
+    /** Update an existing alert (e.g., toggle enabled). */
+    suspend fun update(alert: PriceAlert): PriceAlert
+
+    /** Delete by id. */
+    suspend fun delete(id: String)
+
+    /** Snapshot of all committed alerts. */
+    suspend fun list(): List<PriceAlert>
+
+    /** Reactive committed alerts — emits whenever the server-side store changes. */
+    fun observe(): Flow<List<PriceAlert>>
+}

--- a/core/network/src/commonMain/kotlin/org/mifos/core/network/alerts/api/FakeAlertsApi.kt
+++ b/core/network/src/commonMain/kotlin/org/mifos/core/network/alerts/api/FakeAlertsApi.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package org.mifos.core.network.alerts.api
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import org.mifos.core.model.alerts.PriceAlert
+
+private const val SIMULATED_LATENCY_MS = 800L
+
+/**
+ * In-memory [AlertsApi] for template showcase purposes — no real backend.
+ *
+ * Holds alerts in a [MutableStateFlow]; mutations are simulated with an 800 ms
+ * delay so the `DraftSubmitHandler` Submitting state is visible to the user.
+ * Replace with a Ktorfit-backed implementation when a real backend is available.
+ */
+class FakeAlertsApi : AlertsApi {
+
+    private val store = MutableStateFlow<Map<String, PriceAlert>>(emptyMap())
+
+    override suspend fun create(alert: PriceAlert): PriceAlert {
+        delay(SIMULATED_LATENCY_MS)
+        store.update { it + (alert.id to alert) }
+        return alert
+    }
+
+    override suspend fun update(alert: PriceAlert): PriceAlert {
+        delay(SIMULATED_LATENCY_MS)
+        store.update { it + (alert.id to alert) }
+        return alert
+    }
+
+    override suspend fun delete(id: String) {
+        delay(SIMULATED_LATENCY_MS)
+        store.update { it - id }
+    }
+
+    override suspend fun list(): List<PriceAlert> = store.value.values.toList()
+
+    override fun observe(): Flow<List<PriceAlert>> {
+        return store.asStateFlow().let { snapshot ->
+            kotlinx.coroutines.flow.flow {
+                snapshot.collect { map ->
+                    emit(map.values.toList().sortedByDescending { it.createdAtMs })
+                }
+            }
+        }
+    }
+}

--- a/feature/alerts/build.gradle.kts
+++ b/feature/alerts/build.gradle.kts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+plugins {
+    alias(libs.plugins.cmp.feature.convention)
+}
+
+android {
+    namespace = "org.mifos.feature.alerts"
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(projects.core.common)
+            implementation(projects.core.domain)
+            implementation(projects.core.ui)
+            implementation(projects.core.data)
+            implementation(projects.core.model)
+            implementation(projects.coreBase.store)
+
+            implementation(compose.ui)
+            implementation(compose.material3)
+            implementation(compose.foundation)
+            implementation(compose.materialIconsExtended)
+        }
+    }
+}

--- a/feature/alerts/src/commonMain/kotlin/org/mifos/feature/alerts/di/AlertsModule.kt
+++ b/feature/alerts/src/commonMain/kotlin/org/mifos/feature/alerts/di/AlertsModule.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package org.mifos.feature.alerts.di
+
+import org.koin.core.module.dsl.viewModel
+import org.koin.dsl.module
+import org.mifos.feature.alerts.ui.PriceAlertsListViewModel
+import org.mifos.feature.alerts.ui.SetPriceAlertViewModel
+
+val AlertsModule = module {
+    viewModel { PriceAlertsListViewModel(get()) }
+    viewModel { SetPriceAlertViewModel(repository = get(), outbox = get()) }
+}

--- a/feature/alerts/src/commonMain/kotlin/org/mifos/feature/alerts/navigation/AlertsNavigation.kt
+++ b/feature/alerts/src/commonMain/kotlin/org/mifos/feature/alerts/navigation/AlertsNavigation.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+@file:Suppress("MatchingDeclarationName")
+
+package org.mifos.feature.alerts.navigation
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.navigation
+import kotlinx.serialization.Serializable
+import org.mifos.feature.alerts.ui.PriceAlertsListScreen
+import org.mifos.feature.alerts.ui.SetPriceAlertScreen
+import template.core.base.ui.nav.composableWithPushTransitions
+
+@Serializable
+data object AlertsGraphRoute
+
+@Serializable
+data object PriceAlertsListRoute
+
+@Serializable
+data object SetPriceAlertRoute
+
+fun NavController.navigateToAlerts(navOptions: NavOptions? = null) {
+    navigate(route = AlertsGraphRoute, navOptions = navOptions)
+}
+
+fun NavGraphBuilder.alertsGraph(navController: NavController) {
+    navigation<AlertsGraphRoute>(startDestination = PriceAlertsListRoute) {
+        composableWithPushTransitions<PriceAlertsListRoute> {
+            PriceAlertsListScreen(
+                onBackClick = navController::popBackStack,
+                onNewAlertClick = { navController.navigate(SetPriceAlertRoute) },
+            )
+        }
+        composableWithPushTransitions<SetPriceAlertRoute> {
+            SetPriceAlertScreen(onBackClick = navController::popBackStack)
+        }
+    }
+}

--- a/feature/alerts/src/commonMain/kotlin/org/mifos/feature/alerts/ui/PriceAlertsListScreen.kt
+++ b/feature/alerts/src/commonMain/kotlin/org/mifos/feature/alerts/ui/PriceAlertsListScreen.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package org.mifos.feature.alerts.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import org.koin.compose.viewmodel.koinViewModel
+import org.mifos.core.model.alerts.AlertDirection
+import template.core.base.ui.screen.ScreenContent
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PriceAlertsListScreen(
+    onBackClick: () -> Unit,
+    onNewAlertClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: PriceAlertsListViewModel = koinViewModel(),
+) {
+    val screenState by viewModel.screenState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Price Alerts") },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = onNewAlertClick) {
+                Icon(Icons.Filled.Add, contentDescription = "New alert")
+            }
+        },
+    ) { padding ->
+        ScreenContent(
+            state = screenState,
+            onRetry = {},
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) { alerts, _ ->
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp),
+                contentPadding = PaddingValues(vertical = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                items(items = alerts, key = { it.id }) { alert ->
+                    Card(modifier = Modifier.fillMaxWidth()) {
+                        Column(
+                            modifier = Modifier.padding(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            Text(
+                                text = alert.coinId,
+                                style = MaterialTheme.typography.titleMedium,
+                            )
+                            val dirLabel = directionLabel(alert.direction)
+                            val target = formatTarget(alert.direction, alert.targetValue)
+                            Text(
+                                text = "$dirLabel  $target",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            if (!alert.enabled) {
+                                Text(
+                                    text = "Disabled",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.outline,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun directionLabel(d: AlertDirection): String = when (d) {
+    AlertDirection.ABOVE -> "↑ Above"
+    AlertDirection.BELOW -> "↓ Below"
+    AlertDirection.PCT_CHANGE -> "Δ % change"
+}
+
+private fun formatTarget(d: AlertDirection, value: Double): String = when (d) {
+    AlertDirection.ABOVE, AlertDirection.BELOW -> "$$value"
+    AlertDirection.PCT_CHANGE -> "$value%"
+}

--- a/feature/alerts/src/commonMain/kotlin/org/mifos/feature/alerts/ui/PriceAlertsListViewModel.kt
+++ b/feature/alerts/src/commonMain/kotlin/org/mifos/feature/alerts/ui/PriceAlertsListViewModel.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package org.mifos.feature.alerts.ui
+
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import org.mifos.core.data.alerts.AlertsRepository
+import org.mifos.core.model.alerts.PriceAlert
+import template.core.base.store.screen.DataFreshness
+import template.core.base.store.screen.ScreenState
+import template.core.base.ui.viewmodel.BaseViewModel
+
+/**
+ * Read-side ViewModel for [PriceAlertsListScreen].
+ *
+ * Observes [AlertsRepository.alertsStream] (committed alerts from the fake API)
+ * and maps to [ScreenState]. Pending drafts are tracked at the form-handler
+ * level — they surface on the form screen's resume UI rather than here.
+ */
+class PriceAlertsListViewModel(
+    repository: AlertsRepository,
+) : BaseViewModel<Unit, Nothing, Nothing>(Unit) {
+
+    val screenState: StateFlow<ScreenState<List<PriceAlert>>> = repository.alertsStream()
+        .map { alerts ->
+            if (alerts.isEmpty()) ScreenState.Empty
+            else ScreenState.Content(data = alerts, freshness = DataFreshness.FRESH)
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ScreenState.Loading)
+
+    override fun handleAction(action: Nothing) {}
+}

--- a/feature/alerts/src/commonMain/kotlin/org/mifos/feature/alerts/ui/SetPriceAlertScreen.kt
+++ b/feature/alerts/src/commonMain/kotlin/org/mifos/feature/alerts/ui/SetPriceAlertScreen.kt
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package org.mifos.feature.alerts.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import org.koin.compose.viewmodel.koinViewModel
+import org.mifos.core.model.alerts.AlertDirection
+import template.core.base.store.submit.SubmitState
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SetPriceAlertScreen(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: SetPriceAlertViewModel = koinViewModel(),
+) {
+    val form by viewModel.formState.collectAsStateWithLifecycle()
+    val submit by viewModel.submitState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("New Price Alert") },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            OutlinedTextField(
+                value = form.coinId,
+                onValueChange = viewModel::onCoinIdChange,
+                label = { Text("Coin id (e.g. bitcoin)") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+                enabled = submit !is SubmitState.Submitting,
+            )
+
+            Text("Direction", style = MaterialTheme.typography.titleSmall)
+            AlertDirection.entries.forEach { dir ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .selectable(
+                            selected = form.direction == dir,
+                            onClick = { viewModel.onDirectionChange(dir) },
+                            enabled = submit !is SubmitState.Submitting,
+                        )
+                        .padding(vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    RadioButton(
+                        selected = form.direction == dir,
+                        onClick = null,
+                        enabled = submit !is SubmitState.Submitting,
+                    )
+                    Text(
+                        text = directionLabel(dir),
+                        modifier = Modifier.padding(start = 8.dp),
+                    )
+                }
+            }
+
+            OutlinedTextField(
+                value = if (form.targetValue == 0.0) "" else form.targetValue.toString(),
+                onValueChange = { input ->
+                    viewModel.onTargetValueChange(input.toDoubleOrNull() ?: 0.0)
+                },
+                label = {
+                    Text(
+                        if (form.direction == AlertDirection.PCT_CHANGE) "Change (%)" else "Target (USD)",
+                    )
+                },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+                enabled = submit !is SubmitState.Submitting,
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text("Enabled", style = MaterialTheme.typography.bodyLarge)
+                Switch(
+                    checked = form.enabled,
+                    onCheckedChange = viewModel::onEnabledChange,
+                    enabled = submit !is SubmitState.Submitting,
+                )
+            }
+
+            Button(
+                onClick = viewModel::onSubmit,
+                modifier = Modifier.fillMaxWidth(),
+                enabled = submit !is SubmitState.Submitting && form.coinId.isNotBlank() && form.targetValue > 0.0,
+            ) {
+                if (submit is SubmitState.Submitting) {
+                    CircularProgressIndicator(modifier = Modifier.padding(end = 8.dp))
+                }
+                Text("Save Alert")
+            }
+
+            SubmitStatusLine(submit, onRetry = viewModel::onRetry, onDismiss = viewModel::onDismissResult)
+        }
+    }
+}
+
+@Composable
+private fun SubmitStatusLine(
+    submit: SubmitState<*>,
+    onRetry: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    when (submit) {
+        is SubmitState.Idle -> Unit
+        is SubmitState.Submitting -> Text(
+            "Saving…",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        is SubmitState.Submitted<*> -> {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    "Alert saved ✓",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Button(onClick = onDismiss) { Text("New alert") }
+            }
+        }
+        is SubmitState.Failed -> {
+            val isOffline = submit.draftSaved
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = if (isOffline) {
+                        "Saved offline — will sync when online."
+                    } else {
+                        "Submit failed: ${submit.error.message ?: "unknown error"}"
+                    },
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Button(onClick = onRetry) { Text("Retry") }
+                    Button(onClick = onDismiss) { Text("Dismiss") }
+                }
+            }
+        }
+    }
+}
+
+private fun directionLabel(d: AlertDirection): String = when (d) {
+    AlertDirection.ABOVE -> "Rises above"
+    AlertDirection.BELOW -> "Falls below"
+    AlertDirection.PCT_CHANGE -> "% change over 24h"
+}

--- a/feature/alerts/src/commonMain/kotlin/org/mifos/feature/alerts/ui/SetPriceAlertViewModel.kt
+++ b/feature/alerts/src/commonMain/kotlin/org/mifos/feature/alerts/ui/SetPriceAlertViewModel.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package org.mifos.feature.alerts.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlin.random.Random
+import kotlin.time.Clock
+import org.mifos.core.data.alerts.AlertsRepository
+import org.mifos.core.model.alerts.AlertDirection
+import org.mifos.core.model.alerts.PriceAlert
+import template.core.base.store.submit.SubmitOutbox
+import template.core.base.store.submit.SubmitState
+import template.core.base.store.submit.draftSubmitHandler
+
+/**
+ * **Canonical `DraftSubmitHandler` showcase.**
+ *
+ * This ViewModel demonstrates the framework's offline-resilient form submission
+ * pattern: when the user taps Save while online, the alert is sent via
+ * [AlertsRepository.submitAlert] immediately. When offline, the payload persists
+ * in the framework outbox (`framework_submit_drafts` table, formKey =
+ * `"price_alert"`); the `OfflineSubmitSyncer` (wired in `DataModule`) retries
+ * it automatically on the next online transition.
+ *
+ * The ViewModel does NOT extend `BaseMutationViewModel` — instead it uses
+ * `draftSubmitHandler` directly because the canonical Mutation base supports
+ * `SubmitHandler` (one-shot fire-and-forget), not `DraftSubmitHandler`
+ * (persistent outbox). A future framework refactor could unify both, but
+ * right now this is the cleaner shape.
+ *
+ * Form state lives in [formState] (mutable while typing). On Save, the form
+ * is snapshotted into a [PriceAlert] payload and submitted via
+ * [draftHandler.submit]; [submitState] exposes the Idle/Submitting/Submitted/Failed
+ * lifecycle for the screen to render feedback overlays.
+ *
+ * @param autoSaveDraft When `true`, network failures silently persist the
+ *   payload to the outbox (no user prompt). The plan's recommended default for
+ *   showcase clarity — fork apps may flip to `false` for explicit user consent.
+ */
+class SetPriceAlertViewModel(
+    private val repository: AlertsRepository,
+    private val outbox: SubmitOutbox<PriceAlert>,
+) : ViewModel() {
+
+    private val _formState = MutableStateFlow(PriceAlertFormState())
+    val formState: StateFlow<PriceAlertFormState> = _formState.asStateFlow()
+
+    private val draftHandler = viewModelScope.draftSubmitHandler<PriceAlert, PriceAlert>(
+        outbox = outbox,
+        formKey = "price_alert",
+        autoSaveDraft = true,
+    )
+
+    val submitState: StateFlow<SubmitState<PriceAlert>> = draftHandler.state.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = SubmitState.Idle,
+    )
+
+    fun onCoinIdChange(value: String) {
+        _formState.update { it.copy(coinId = value) }
+    }
+
+    fun onDirectionChange(direction: AlertDirection) {
+        _formState.update { it.copy(direction = direction) }
+    }
+
+    fun onTargetValueChange(value: Double) {
+        _formState.update { it.copy(targetValue = value) }
+    }
+
+    fun onEnabledChange(enabled: Boolean) {
+        _formState.update { it.copy(enabled = enabled) }
+    }
+
+    /** Validate, snapshot to a [PriceAlert] payload, and submit through the draft handler. */
+    fun onSubmit() {
+        val form = _formState.value
+        if (form.coinId.isBlank() || form.targetValue <= 0.0) return
+        val payload = PriceAlert(
+            id = randomId(),
+            coinId = form.coinId.trim(),
+            direction = form.direction,
+            targetValue = form.targetValue,
+            enabled = form.enabled,
+            createdAtMs = Clock.System.now().toEpochMilliseconds(),
+        )
+        draftHandler.submit(payload) { repository.submitAlert(it) }
+    }
+
+    fun onRetry() {
+        draftHandler.retry()
+    }
+
+    fun onDismissResult() {
+        draftHandler.reset()
+        _formState.value = PriceAlertFormState()
+    }
+
+    private fun randomId(): String {
+        // Compact client-side ID; replace with UUID4 once kotlinx.uuid or okio.UUID is wired.
+        val chars = ('a'..'z') + ('0'..'9')
+        return (1..16).map { chars[Random.nextInt(chars.size)] }.joinToString("")
+    }
+}
+
+/** UI form state — observable so the screen can re-render on each keystroke. */
+data class PriceAlertFormState(
+    val coinId: String = "",
+    val direction: AlertDirection = AlertDirection.ABOVE,
+    val targetValue: Double = 0.0,
+    val enabled: Boolean = true,
+)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -117,6 +117,7 @@ include(":feature:settings")
 include(":feature:crypto")
 include(":feature:currency-rates")
 include(":feature:emi-calculator")
+include(":feature:alerts")
 
 include(":core-base:analytics")
 include(":core-base:common")


### PR DESCRIPTION
## Summary

Part of epic **vm-mvi-and-framework-showcase**, sub-plan **04 of 5**.

Introduces a fully working example of the framework's offline-resilient form submit pattern: **DraftSubmitHandler + OfflineSubmitSyncer + SubmitOutbox**. Until this PR, those classes had zero in-template consumers and forks had no working example to copy.

## Showcase value

Tap **Save Alert** while online → submit completes in ~800ms → status shows \"Alert saved ✓\".

Tap **Save Alert** while offline → form payload persists in `framework_submit_drafts` (formKey `\"price_alert\"`) → status shows \"Saved offline — will sync when online.\" Force-kill the app → reopen → on network reconnect, `OfflineSubmitSyncer` retries the submission automatically; the alert appears on the list.

## Layers

### Domain (`core/model/alerts`)
- `PriceAlert` (`@Serializable` — required for outbox JSON persistence) — id, coinId, direction, targetValue, enabled, createdAtMs
- `AlertDirection` enum — ABOVE / BELOW / PCT_CHANGE

### Network (`core/network/alerts/api`)
- `AlertsApi` interface (create/update/delete/list/observe)
- `FakeAlertsApi` — in-memory store, 800ms simulated latency so the Submitting state is visible. Replace with Ktorfit for a real backend.

### Data (`core/data/alerts`)
- `AlertsRepository` (read via `alertsStream`; write via `submitAlert`)
- `AlertsRepositoryImpl` — delegates to `AlertsApi`
- DI bindings in `DataModule`:
  - `single<AlertsApi> { FakeAlertsApi() }`
  - `single<AlertsRepository> { AlertsRepositoryImpl(api = get()) }`
  - `single<SubmitOutbox<PriceAlert>> { RoomSubmitOutbox(get(), PriceAlert.serializer()) }`
  - `single<CoroutineScope> { CoroutineScope(SupervisorJob() + Dispatchers.Default) }` — app-scoped scope for long-running coroutines
  - `single(createdAtStart = true) { OfflineSubmitSyncer<PriceAlert, PriceAlert>(...) .also { it.start() } }` — eagerly starts watching `NetworkMonitor.isOnline`; retries pending drafts on reconnect

### Feature (`feature/alerts` — new module)
- `SetPriceAlertViewModel` — uses `draftSubmitHandler<PriceAlert, PriceAlert>` with `formKey = \"price_alert\"`, `autoSaveDraft = true`. Form state lives in a separate `MutableStateFlow`; `submitState` exposes the Idle/Submitting/Submitted/Failed lifecycle from `draftHandler.state`.
- `PriceAlertsListViewModel` — observes `repository.alertsStream()` → `ScreenState<List<PriceAlert>>` (Empty / Content with `DataFreshness.FRESH`)
- `SetPriceAlertScreen` — multi-field form: coin id text input, direction radio buttons, target value numeric input, enabled switch, Save button. Inputs disabled while `Submitting`. Status line renders Submitting / Saved✓ / Failed-offline-saved / Failed-with-retry conditionally.
- `PriceAlertsListScreen` — `ScreenContent` + `LazyColumn` + FAB to navigate to SetPriceAlertScreen
- `AlertsModule` (Koin) — viewModel registrations
- `AlertsNavigation` — `AlertsGraphRoute` → `PriceAlertsListRoute` (start) + `SetPriceAlertRoute`

### Wiring
- `settings.gradle.kts`: `include(\":feature:alerts\")`
- `cmp-navigation/build.gradle.kts`: `implementation(projects.feature.alerts)`
- `KoinModules.kt`: `featureModule.includes(AlertsModule)`
- `AuthenticatedNavigation.kt`: `alertsGraph(navController)`

## Two intentional design decisions worth surfacing

### 1. SetPriceAlertViewModel does NOT extend BaseMutationViewModel

Rationale: `BaseMutationViewModel` wraps `SubmitHandler` (one-shot, no outbox persistence). For the `DraftSubmitHandler` showcase, the VM bypasses it and uses `draftSubmitHandler` directly to preserve the `autoSaveDraft` + `formKey` semantics. A future framework refactor could parameterize `BaseMutationViewModel` by handler type — out of scope here.

### 2. Single-pending-per-formKey trade-off

`DraftDao` supports one PENDING draft per `formKey` by design (framework's `SubmitHandler` semantics: \"one in-flight submit per form\"). The list shows only **server-committed** alerts; the plan's \"Active / Pending / Failed\" status badges would require a multi-formKey scheme (e.g., `\"price_alert_${id}\"`) or different framework primitives. Deferred — the current single-pending model is the framework's natural fit and keeps this PR focused on the canonical pattern.

## Test plan

- [x] `./gradlew :feature:alerts:compileCommonMainKotlinMetadata` — passes (multiplatform)
- [x] `:core:data`, `:core:network`, `:core:model`, `:cmp-navigation` commonMain compile
- [x] Detekt across `:feature:alerts`, `:cmp-navigation`, `:core:data`, `:core:network`, `:core:model`, `:cmp-shared`, `:cmp-android` — all pass
- [ ] CI: full Android + Desktop + iOS + Web builds
- [ ] Smoke test on Android: open alerts → tap FAB → fill form → Save → see in list. Toggle airplane mode → save another → status \"Saved offline\". Toggle airplane off → wait ~2s → alert appears in list.

## Epic context

- ✅ **01** ([#164](https://github.com/openMF/kmp-project-template/pull/164)): Unify BaseMutationViewModel
- ✅ **02** ([#165](https://github.com/openMF/kmp-project-template/pull/165)): Migrate cheating VMs
- ✅ **03** ([#166](https://github.com/openMF/kmp-project-template/pull/166)): Personal Watchlist — SubmitHandler showcase
- ✅ **04 (this PR)**: Price Alerts — DraftSubmitHandler showcase
- ⏳ **05**: Home Dashboard — multi-source combine (needs 03 + 04 data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)