### PR TITLE
feat: home widgets + p1-framework-prerequisites (SP01 drafts, SP02 BMV split, SP03 FetchPolicy TDD)

### DIFF
--- a/cmp-navigation/src/commonMain/kotlin/cmp/navigation/authenticated/AuthenticatedNavigation.kt
+++ b/cmp-navigation/src/commonMain/kotlin/cmp/navigation/authenticated/AuthenticatedNavigation.kt
@@ -19,6 +19,7 @@ import cmp.navigation.authenticatednavbar.AuthenticatedNavbarRoute
 import cmp.navigation.authenticatednavbar.authenticatedNavbarGraph
 import kotlinx.serialization.Serializable
 import org.mifos.feature.alerts.navigation.alertsGraph
+import org.mifos.feature.alerts.navigation.navigateToAlerts
 import org.mifos.feature.crypto.navigation.CoinDetailRoute
 import org.mifos.feature.crypto.navigation.cryptoGraph
 import org.mifos.feature.crypto.navigation.navigateToCrypto
@@ -30,6 +31,7 @@ import org.mifos.feature.emicalculator.navigation.navigateToEmiCalculator
 import org.mifos.feature.settings.navigateToSettings
 import org.mifos.feature.settings.notificationDestination
 import org.mifos.feature.settings.settingsDestination
+import org.mifos.feature.watchlist.navigation.navigateToPersonalWatchlist
 import org.mifos.feature.watchlist.navigation.personalWatchlistDestination
 
 @Serializable
@@ -49,6 +51,8 @@ internal fun NavGraphBuilder.authenticatedGraph(navController: NavController) {
             navigateToHistory = { navController.navigateToRateHistory() },
             navigateToCrypto = { navController.navigateToCrypto() },
             navigateToEmi = { navController.navigateToEmiCalculator() },
+            navigateToWatchlist = { navController.navigateToPersonalWatchlist() },
+            navigateToAlerts = { navController.navigateToAlerts() },
         )
 
         notificationDestination(

--- a/cmp-navigation/src/commonMain/kotlin/cmp/navigation/authenticatednavbar/AuthenticatedNavbarNavigation.kt
+++ b/cmp-navigation/src/commonMain/kotlin/cmp/navigation/authenticatednavbar/AuthenticatedNavbarNavigation.kt
@@ -30,6 +30,8 @@ internal fun NavGraphBuilder.authenticatedNavbarGraph(
     navigateToHistory: () -> Unit,
     navigateToCrypto: () -> Unit,
     navigateToEmi: () -> Unit,
+    navigateToWatchlist: () -> Unit,
+    navigateToAlerts: () -> Unit,
 ) {
     composableWithStayTransitions<AuthenticatedNavbarRoute> {
         AuthenticatedNavbarNavigationScreen(
@@ -38,6 +40,8 @@ internal fun NavGraphBuilder.authenticatedNavbarGraph(
             navigateToHistory = navigateToHistory,
             navigateToCrypto = navigateToCrypto,
             navigateToEmi = navigateToEmi,
+            navigateToWatchlist = navigateToWatchlist,
+            navigateToAlerts = navigateToAlerts,
         )
     }
 }

--- a/cmp-navigation/src/commonMain/kotlin/cmp/navigation/authenticatednavbar/AuthenticatedNavbarNavigationScreen.kt
+++ b/cmp-navigation/src/commonMain/kotlin/cmp/navigation/authenticatednavbar/AuthenticatedNavbarNavigationScreen.kt
@@ -57,6 +57,8 @@ internal fun AuthenticatedNavbarNavigationScreen(
     navigateToHistory: () -> Unit,
     navigateToCrypto: () -> Unit,
     navigateToEmi: () -> Unit,
+    navigateToWatchlist: () -> Unit,
+    navigateToAlerts: () -> Unit,
     modifier: Modifier = Modifier,
     navController: NavHostController = rememberKptNavController(
         name = "AuthenticatedNavbarScreen",
@@ -109,6 +111,8 @@ internal fun AuthenticatedNavbarNavigationScreen(
         navigateToHistory = navigateToHistory,
         navigateToCrypto = navigateToCrypto,
         navigateToEmi = navigateToEmi,
+        navigateToWatchlist = navigateToWatchlist,
+        navigateToAlerts = navigateToAlerts,
         onAction = remember(viewModel) {
             { viewModel.trySendAction(it) }
         },
@@ -123,6 +127,8 @@ internal fun AuthenticatedNavbarNavigationScreenContent(
     navigateToHistory: () -> Unit,
     navigateToCrypto: () -> Unit,
     navigateToEmi: () -> Unit,
+    navigateToWatchlist: () -> Unit,
+    navigateToAlerts: () -> Unit,
     modifier: Modifier = Modifier,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onAction: (AuthenticatedNavBarAction) -> Unit,
@@ -178,6 +184,8 @@ internal fun AuthenticatedNavbarNavigationScreenContent(
                 onNavigateToHistory = navigateToHistory,
                 onNavigateToCrypto = navigateToCrypto,
                 onNavigateToEmi = navigateToEmi,
+                onNavigateToWatchlist = navigateToWatchlist,
+                onNavigateToAlerts = navigateToAlerts,
             )
 
             profileDestination()

--- a/core-base/store/src/commonMain/kotlin/template/core/base/store/submit/DraftSubmitHandler.kt
+++ b/core-base/store/src/commonMain/kotlin/template/core/base/store/submit/DraftSubmitHandler.kt
@@ -62,16 +62,27 @@ import template.core.base.store.error.categorize
  * fun onDismissDraftPrompt() = draftHandler.discardDraft()       // user-prompted mode only
  * ```
  *
+ * **Multi-pending drafts (optional [uniqueKey]):**
+ * When N concurrent independent drafts must coexist under one [formKey] (e.g. Portfolio
+ * Tracker per-holding, Bill Reminders per-bill, wizard per-step), pass a distinct
+ * [uniqueKey] per handler instance. The handler then routes through
+ * [SubmitOutbox.saveByUniqueKey] / [SubmitOutbox.deleteByUniqueKey] so drafts don't
+ * overwrite each other. `uniqueKey = null` (default) preserves the legacy singleton
+ * semantics — one PENDING draft per [formKey].
+ *
  * @param P             Serializable payload type (the data collected by the form).
  * @param R             Result type returned by the server on success.
  * @param autoSaveDraft When true, saves to outbox silently on network failure.
  *   When false (default), the UI must show [DraftSavePrompt] and call [saveDraft].
+ * @param uniqueKey     Optional sub-identifier within [formKey]. `null` = singleton mode
+ *   (existing behavior). Non-null = multi-pending mode — one draft per `(formKey, uniqueKey)`.
  */
 class DraftSubmitHandler<P, R>(
     private val scope: CoroutineScope,
     private val outbox: SubmitOutbox<P>,
     private val formKey: String,
     private val autoSaveDraft: Boolean = false,
+    private val uniqueKey: String? = null,
 ) {
     private val _state = MutableStateFlow<SubmitState<R>>(SubmitState.Idle)
 
@@ -120,7 +131,7 @@ class DraftSubmitHandler<P, R>(
     fun saveDraft() {
         val payload = lastPayload ?: return
         scope.launch {
-            val draftId = outbox.save(formKey, payload)
+            val draftId = persistDraft(payload)
             lastDraftId = draftId
             val current = _state.value
             if (current is SubmitState.Failed) {
@@ -128,6 +139,18 @@ class DraftSubmitHandler<P, R>(
             }
         }
     }
+
+    /**
+     * Routes the upsert through the right outbox API: [SubmitOutbox.saveByUniqueKey] in
+     * multi-pending mode, [SubmitOutbox.save] in singleton mode. Defined once so the two
+     * call sites (user-prompted [saveDraft] + silent auto-save inside [execute]) stay aligned.
+     */
+    private suspend fun persistDraft(payload: P): Long =
+        if (uniqueKey != null) {
+            outbox.saveByUniqueKey(formKey, uniqueKey, payload)
+        } else {
+            outbox.save(formKey, payload)
+        }
 
     /**
      * Discards the in-memory payload and returns to [SubmitState.Idle] without saving to outbox.
@@ -167,7 +190,7 @@ class DraftSubmitHandler<P, R>(
             } catch (e: Exception) {
                 val category = categorize(e)
                 if (autoSaveDraft && category == ErrorCategory.Network) {
-                    val draftId = outbox.save(formKey, payload)
+                    val draftId = persistDraft(payload)
                     lastDraftId = draftId
                     SubmitState.Failed(error = e, category = category, draftSaved = true)
                 } else {
@@ -201,4 +224,5 @@ fun <P, R> CoroutineScope.draftSubmitHandler(
     outbox: SubmitOutbox<P>,
     formKey: String,
     autoSaveDraft: Boolean = false,
-): DraftSubmitHandler<P, R> = DraftSubmitHandler(this, outbox, formKey, autoSaveDraft)
+    uniqueKey: String? = null,
+): DraftSubmitHandler<P, R> = DraftSubmitHandler(this, outbox, formKey, autoSaveDraft, uniqueKey)

--- a/core-base/store/src/commonMain/kotlin/template/core/base/store/submit/SubmitOutbox.kt
+++ b/core-base/store/src/commonMain/kotlin/template/core/base/store/submit/SubmitOutbox.kt
@@ -25,20 +25,46 @@ import kotlinx.coroutines.flow.Flow
 interface SubmitOutbox<P> {
 
     /**
-     * Save [payload] as a PENDING draft under [formKey].
+     * Save [payload] as the singleton PENDING draft under [formKey].
      *
-     * If a PENDING draft already exists for [formKey], this method updates it in-place and
-     * returns its existing id (idempotent upsert — no duplicate rows).
+     * If a PENDING draft already exists for [formKey] with `uniqueKey IS NULL`, this method
+     * updates it in-place and returns its existing id (idempotent upsert — no duplicate rows).
+     *
+     * Use [saveByUniqueKey] when a screen needs N concurrent independent drafts under one
+     * `formKey` (e.g. Portfolio Tracker per-holding, Bill Reminders per-bill).
      *
      * @return The surrogate id of the upserted row, useful for subsequent status updates.
      */
     suspend fun save(formKey: String, payload: P): Long
 
-    /** Retrieve the current PENDING entry for [formKey], or `null` if none. */
+    /**
+     * Multi-pending companion to [save]. Saves [payload] as a PENDING draft scoped on
+     * `(formKey, uniqueKey)`. N concurrent drafts can coexist under one [formKey] as long as
+     * each carries a distinct [uniqueKey] (e.g. `loan_id`, `bill_id`, wizard `"step_N"`).
+     *
+     * If a PENDING draft already exists for the exact `(formKey, uniqueKey)` pair, this method
+     * updates it in-place — preserves single-pending-per-(formKey, uniqueKey) semantics.
+     */
+    suspend fun saveByUniqueKey(formKey: String, uniqueKey: String, payload: P): Long
+
+    /** Retrieve the current singleton PENDING entry for [formKey], or `null` if none. */
     suspend fun getPending(formKey: String): SubmitOutboxEntry<P>?
 
-    /** Hot flow that emits the current PENDING entry whenever it changes. */
+    /** Retrieve the PENDING entry for a specific `(formKey, uniqueKey)` pair, or `null` if none. */
+    suspend fun getPendingByUniqueKey(formKey: String, uniqueKey: String): SubmitOutboxEntry<P>?
+
+    /** Hot flow that emits the current singleton PENDING entry whenever it changes. */
     fun observePending(formKey: String): Flow<SubmitOutboxEntry<P>?>
+
+    /** Streaming variant of [getPendingByUniqueKey]. */
+    fun observePendingByUniqueKey(formKey: String, uniqueKey: String): Flow<SubmitOutboxEntry<P>?>
+
+    /**
+     * Observes ALL non-terminal drafts (PENDING / RETRYING / FAILED) for [formKey], ordered
+     * newest-first. Used by feature UIs that need to display "N drafts pending sync" across
+     * multiple uniqueKeys (e.g. Portfolio: "3 holdings pending").
+     */
+    fun observeAllByFormKey(formKey: String): Flow<List<SubmitOutboxEntry<P>>>
 
     /** All entries currently in PENDING status (excludes RETRYING) — used by [OfflineSubmitSyncer]. */
     suspend fun getAllPending(): List<SubmitOutboxEntry<P>>
@@ -55,6 +81,12 @@ interface SubmitOutbox<P> {
     /** Delete all drafts for [formKey] (e.g. on screen close or after successful submit). */
     suspend fun deleteByFormKey(formKey: String)
 
+    /**
+     * Delete a single `(formKey, uniqueKey)` row. Use after a multi-pending draft successfully
+     * submits. Does NOT affect the singleton draft (uniqueKey IS NULL) under the same [formKey].
+     */
+    suspend fun deleteByUniqueKey(formKey: String, uniqueKey: String)
+
     /** Delete every draft — called from [StoreCacheManager.clearAll] on logout. */
     suspend fun deleteAll()
 }
@@ -64,6 +96,10 @@ interface SubmitOutbox<P> {
  *
  * @param id        Surrogate row id from the database.
  * @param formKey   Consumer-defined screen/form identifier.
+ * @param uniqueKey Sub-identifier within [formKey]. `null` = singleton draft (legacy [save]);
+ *                  non-null = one of N concurrent drafts under one form type (via
+ *                  [SubmitOutbox.saveByUniqueKey]). Surfaced here so [SubmitOutbox.getAllPending]
+ *                  consumers (notably [OfflineSubmitSyncer]) can re-route the retry per uniqueKey.
  * @param payload   Decoded payload (already deserialized by the concrete [SubmitOutbox]).
  * @param status    Current lifecycle state.
  * @param createdAtMs Epoch millis when the draft was first saved.
@@ -75,6 +111,7 @@ data class SubmitOutboxEntry<out P>(
     val payload: P,
     val status: SubmitOutboxStatus,
     val createdAtMs: Long,
+    val uniqueKey: String? = null,
     val errorMessage: String? = null,
 )
 

--- a/core-base/store/src/commonTest/kotlin/template/core/base/store/screen/FetchPolicyEnforcementTest.kt
+++ b/core-base/store/src/commonTest/kotlin/template/core/base/store/screen/FetchPolicyEnforcementTest.kt
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package template.core.base.store.screen
+
+import app.cash.turbine.test
+import io.github.mobilebytelabs.kmptoolkit.networkmonitor.NetworkInfo
+import io.github.mobilebytelabs.kmptoolkit.networkmonitor.NetworkStatus
+import io.github.mobilebytelabs.kmptoolkit.networkmonitor.NetworkType
+import kotlinx.coroutines.test.runTest
+import org.mobilenativefoundation.store.store5.Fetcher
+import org.mobilenativefoundation.store.store5.StoreBuilder
+import template.core.base.store.fixtures.FakeNetworkMonitor
+import template.core.base.store.infra.FakeFetchedAtRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Enforcement tests for [FetchPolicy] semantics that production features depend on.
+ *
+ * **Why this file exists separately from [DecisionEngineTest] and
+ * [ScreenDataStreamIntegrationTest]:**
+ * - [DecisionEngineTest] tests `(StoreData, NetworkStatus) → ScreenState` in isolation —
+ *   `FetchPolicy` is not an input there because the engine only reacts to what the Store
+ *   pipeline emits. Policy selection happens one layer up in
+ *   [template.core.base.store.screen.streamDataForPolicy].
+ * - [ScreenDataStreamIntegrationTest] covers the default `CACHE_THEN_NETWORK` happy path
+ *   plus a `CACHE_ONLY` smoke test (T3).
+ *
+ * This file covers the **gaps** that production features depend on:
+ * - Stocks Tracker / Gas Tracker → `NETWORK_ONLY` (no stale prices ever)
+ * - Bill Reminders fallback → `CACHE_THEN_NETWORK` offline (must serve cached without crash)
+ * - Crypto Glossary → `CACHE_ONLY` empty path (graceful when never primed)
+ *
+ * Each test corresponds to a row of the decision table documented in
+ * `p1-framework-prerequisites/03-fetchpolicy-tdd.md` (plan file, Phase 1.2 table).
+ */
+class FetchPolicyEnforcementTest {
+
+    private val onlineInfo = NetworkInfo(type = NetworkType.WiFi, isMetered = false)
+    private val online = NetworkStatus.Available(onlineInfo)
+    private val offline = NetworkStatus.Unavailable
+
+    // ─── NETWORK_ONLY ────────────────────────────────────────────────────────
+
+    @Test
+    fun networkOnly_empty_cache_online_calls_fetcher_and_emits_Content() = runTest {
+        var fetchCount = 0
+        val store = StoreBuilder
+            .from<String, String>(
+                fetcher = Fetcher.of { _ ->
+                    fetchCount++
+                    "fresh-from-network"
+                },
+            )
+            .build()
+
+        val stream = store.asScreenStream(
+            key = "no-network-online",
+            networkMonitor = FakeNetworkMonitor(online),
+            fetchedAtRepository = FakeFetchedAtRepository(),
+            cacheKey = "test:network-only-empty-online",
+            scope = backgroundScope,
+            fetchPolicy = FetchPolicy.NETWORK_ONLY,
+        )
+
+        stream.state.test {
+            var state: ScreenState<String> = awaitItem()
+            while (state is ScreenState.Loading) state = awaitItem()
+            assertIs<ScreenState.Content<String>>(state)
+            assertEquals("fresh-from-network", state.data)
+            assertTrue(fetchCount >= 1, "NETWORK_ONLY must invoke fetcher; got fetchCount=$fetchCount")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun networkOnly_empty_cache_offline_emits_NoNetwork() = runTest {
+        // Critical for Stocks/Gas Tracker: when offline + no cached data,
+        // NETWORK_ONLY must surface NoNetwork (no spinner-forever, no fake-content).
+        val store = StoreBuilder
+            .from<String, String>(
+                fetcher = Fetcher.of { _ ->
+                    error("Fetcher should not succeed when offline")
+                },
+            )
+            .build()
+
+        val stream = store.asScreenStream(
+            key = "no-network-offline",
+            networkMonitor = FakeNetworkMonitor(offline),
+            fetchedAtRepository = FakeFetchedAtRepository(),
+            cacheKey = "test:network-only-empty-offline",
+            scope = backgroundScope,
+            fetchPolicy = FetchPolicy.NETWORK_ONLY,
+        )
+
+        stream.state.test {
+            var state: ScreenState<String> = awaitItem()
+            while (state is ScreenState.Loading) state = awaitItem()
+            assertIs<ScreenState.NoNetwork>(state)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // ─── CACHE_THEN_NETWORK fallback ─────────────────────────────────────────
+
+    @Test
+    fun cacheThenNetwork_empty_cache_offline_emits_NoNetwork() = runTest {
+        // Negative case: CACHE_THEN_NETWORK should NOT spin forever when offline +
+        // empty cache. DecisionEngine should route to NoNetwork promptly.
+        val store = StoreBuilder
+            .from<String, String>(
+                fetcher = Fetcher.of { _ ->
+                    error("Fetcher should not succeed when offline")
+                },
+            )
+            .build()
+
+        val stream = store.asScreenStream(
+            key = "ctn-empty-offline",
+            networkMonitor = FakeNetworkMonitor(offline),
+            fetchedAtRepository = FakeFetchedAtRepository(),
+            cacheKey = "test:ctn-empty-offline",
+            scope = backgroundScope,
+            fetchPolicy = FetchPolicy.CACHE_THEN_NETWORK,
+        )
+
+        stream.state.test {
+            var state: ScreenState<String> = awaitItem()
+            while (state is ScreenState.Loading) state = awaitItem()
+            assertIs<ScreenState.NoNetwork>(state)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun cacheThenNetwork_cached_offline_emits_Content_STALE() = runTest {
+        // After priming the cache, going offline should still show content with STALE
+        // freshness — the user sees their last-known data with a clear staleness banner.
+        var fetchCount = 0
+        val store = StoreBuilder
+            .from<String, String>(
+                fetcher = Fetcher.of { _ ->
+                    fetchCount++
+                    "primed-content"
+                },
+            )
+            .build()
+
+        // Prime the in-memory cache while online.
+        store.streamData("ctn-cached-offline").test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        // Switch to offline and read via asScreenStream.
+        val stream = store.asScreenStream(
+            key = "ctn-cached-offline",
+            networkMonitor = FakeNetworkMonitor(offline),
+            fetchedAtRepository = FakeFetchedAtRepository(),
+            cacheKey = "test:ctn-cached-offline",
+            scope = backgroundScope,
+            fetchPolicy = FetchPolicy.CACHE_THEN_NETWORK,
+        )
+
+        stream.state.test {
+            var state: ScreenState<String> = awaitItem()
+            while (state is ScreenState.Loading) state = awaitItem()
+            // Either Content(STALE) when cache serves through, or NoNetwork if the
+            // Store5 path fails the SoT fallback. Both are acceptable for the
+            // offline-cached scenario per the plan's risk row 4 — what's NOT
+            // acceptable is silent failure or spinner-forever.
+            val acceptable = state is ScreenState.Content<String> || state is ScreenState.NoNetwork
+            assertTrue(
+                acceptable,
+                "CACHE_THEN_NETWORK offline+cached must emit Content or NoNetwork; got $state",
+            )
+            if (state is ScreenState.Content<*>) {
+                assertTrue(
+                    state.freshness == DataFreshness.STALE ||
+                        state.freshness == DataFreshness.UPDATING,
+                    "Offline cached content must be STALE or UPDATING; got ${state.freshness}",
+                )
+            }
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/core-base/store/src/commonTest/kotlin/template/core/base/store/submit/FakeSubmitOutbox.kt
+++ b/core-base/store/src/commonTest/kotlin/template/core/base/store/submit/FakeSubmitOutbox.kt
@@ -31,7 +31,9 @@ class FakeSubmitOutbox<P> : SubmitOutbox<P> {
     val entries: List<SubmitOutboxEntry<P>> get() = _entries.value
 
     override suspend fun save(formKey: String, payload: P): Long {
-        val existing = _entries.value.firstOrNull { it.formKey == formKey && it.status == SubmitOutboxStatus.PENDING }
+        val existing = _entries.value.firstOrNull {
+            it.formKey == formKey && it.uniqueKey == null && it.status == SubmitOutboxStatus.PENDING
+        }
         if (existing != null) {
             _entries.value = _entries.value.map {
                 if (it.id == existing.id) it.copy(payload = payload) else it
@@ -45,15 +47,63 @@ class FakeSubmitOutbox<P> : SubmitOutbox<P> {
             payload = payload,
             status = SubmitOutboxStatus.PENDING,
             createdAtMs = 0L,
+            uniqueKey = null,
+        )
+        return id
+    }
+
+    override suspend fun saveByUniqueKey(formKey: String, uniqueKey: String, payload: P): Long {
+        val existing = _entries.value.firstOrNull {
+            it.formKey == formKey && it.uniqueKey == uniqueKey && it.status == SubmitOutboxStatus.PENDING
+        }
+        if (existing != null) {
+            _entries.value = _entries.value.map {
+                if (it.id == existing.id) it.copy(payload = payload) else it
+            }
+            return existing.id
+        }
+        val id = nextId++
+        _entries.value = _entries.value + SubmitOutboxEntry(
+            id = id,
+            formKey = formKey,
+            payload = payload,
+            status = SubmitOutboxStatus.PENDING,
+            createdAtMs = 0L,
+            uniqueKey = uniqueKey,
         )
         return id
     }
 
     override suspend fun getPending(formKey: String): SubmitOutboxEntry<P>? =
-        _entries.value.firstOrNull { it.formKey == formKey && it.status == SubmitOutboxStatus.PENDING }
+        _entries.value.firstOrNull {
+            it.formKey == formKey && it.uniqueKey == null && it.status == SubmitOutboxStatus.PENDING
+        }
+
+    override suspend fun getPendingByUniqueKey(formKey: String, uniqueKey: String): SubmitOutboxEntry<P>? =
+        _entries.value.firstOrNull {
+            it.formKey == formKey && it.uniqueKey == uniqueKey && it.status == SubmitOutboxStatus.PENDING
+        }
 
     override fun observePending(formKey: String): Flow<SubmitOutboxEntry<P>?> =
-        _entries.map { list -> list.firstOrNull { it.formKey == formKey && it.status == SubmitOutboxStatus.PENDING } }
+        _entries.map { list ->
+            list.firstOrNull {
+                it.formKey == formKey && it.uniqueKey == null && it.status == SubmitOutboxStatus.PENDING
+            }
+        }
+
+    override fun observePendingByUniqueKey(formKey: String, uniqueKey: String): Flow<SubmitOutboxEntry<P>?> =
+        _entries.map { list ->
+            list.firstOrNull {
+                it.formKey == formKey && it.uniqueKey == uniqueKey && it.status == SubmitOutboxStatus.PENDING
+            }
+        }
+
+    override fun observeAllByFormKey(formKey: String): Flow<List<SubmitOutboxEntry<P>>> =
+        _entries.map { list ->
+            list.filter {
+                it.formKey == formKey && it.status in NON_TERMINAL_STATES
+            }.sortedByDescending { it.createdAtMs }
+        }
 
     override suspend fun getAllPending(): List<SubmitOutboxEntry<P>> =
         _entries.value.filter { it.status == SubmitOutboxStatus.PENDING }
@@ -72,6 +122,10 @@ class FakeSubmitOutbox<P> : SubmitOutbox<P> {
         _entries.value = _entries.value.filter { it.formKey != formKey }
     }
 
+    override suspend fun deleteByUniqueKey(formKey: String, uniqueKey: String) {
+        _entries.value = _entries.value.filter { !(it.formKey == formKey && it.uniqueKey == uniqueKey) }
+    }
+
     override suspend fun deleteAll() {
         _entries.value = emptyList()
     }
@@ -80,5 +134,13 @@ class FakeSubmitOutbox<P> : SubmitOutbox<P> {
         _entries.value = _entries.value.map {
             if (it.id == id) it.copy(status = status) else it
         }
+    }
+
+    private companion object {
+        val NON_TERMINAL_STATES = setOf(
+            SubmitOutboxStatus.PENDING,
+            SubmitOutboxStatus.RETRYING,
+            SubmitOutboxStatus.FAILED,
+        )
     }
 }

--- a/core-base/ui/src/commonMain/kotlin/template/core/base/ui/viewmodel/BaseDraftMutationViewModel.kt
+++ b/core-base/ui/src/commonMain/kotlin/template/core/base/ui/viewmodel/BaseDraftMutationViewModel.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package template.core.base.ui.viewmodel
+
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import template.core.base.store.screen.ScreenState
+import template.core.base.store.submit.MutationUiState
+import template.core.base.store.submit.SubmitOutbox
+import template.core.base.store.submit.SubmitState
+import template.core.base.store.submit.draftSubmitHandler
+
+/**
+ * Base class for edit-screen ViewModels whose submit MUST survive process death and auto-retry
+ * on reconnect.
+ *
+ * Sibling of [BaseSubmitMutationViewModel]. Both extend the same MVI base
+ * ([BaseViewModel]); the difference is which submit handler is wrapped:
+ *
+ * | Class | Wraps | Persistence | Auto-retry |
+ * |---|---|---|---|
+ * | [BaseSubmitMutationViewModel] | `SubmitHandler<R>` | None — in-session | No |
+ * | [BaseDraftMutationViewModel]  | `DraftSubmitHandler` + `SubmitOutbox` | Across restarts | Yes (syncer) |
+ *
+ * Use this base when the form's failure mode requires durable retry:
+ * - Personal Loan Tracker (one PENDING draft per loan via [uniqueKey] = loan_id)
+ * - Bill Reminders (one PENDING draft per bill via [uniqueKey] = bill_id)
+ * - Loan Calculator multi-step wizard (one PENDING per step via [uniqueKey] = "step_N")
+ *
+ * Multi-pending semantics: pass a non-null [uniqueKey] when N concurrent independent drafts
+ * must coexist under one [formKey]. Pass `null` (default) for the singleton case — one PENDING
+ * draft per [formKey].
+ *
+ * Save modes — controlled by [autoSaveDraft]:
+ * - `false` (default) — user-prompted: on network failure, UI shows DraftSavePrompt; user calls
+ *   [onSaveDraft] to confirm persistence (the underlying [DraftSubmitHandler.saveDraft]).
+ * - `true` — silent: on network failure, the draft is persisted to the outbox immediately and
+ *   the next form open surfaces it via DraftResumeBanner.
+ *
+ * Subclasses override [performSubmit] for the network/repository call and populate
+ * [mutableScreenState] when read-side data resolves.
+ *
+ * Usage:
+ * ```kotlin
+ * class EditLoanViewModel(
+ *     outbox: SubmitOutbox<LoanPayload>,
+ *     private val repo: LoanRepository,
+ *     private val loanId: String,
+ * ) : BaseDraftMutationViewModel<LoanPayload, Unit>(
+ *     outbox = outbox,
+ *     formKey = "loan_edit",
+ *     uniqueKey = loanId,        // ← per-loan multi-pending
+ *     autoSaveDraft = true,
+ * ) {
+ *     override suspend fun performSubmit(payload: LoanPayload): Unit =
+ *         repo.update(loanId, payload)
+ * }
+ * ```
+ *
+ * @param T Serializable payload type (form data + result type — both `T` because mutation
+ *   typically returns the persisted entity; use a separate `R` if your server returns a
+ *   different shape).
+ * @param R Result type returned by the server on a successful submit.
+ * @param outbox Durable outbox for [T]. Inject via DI per form type.
+ * @param formKey Stable identifier for the form (e.g. `"loan_edit"`). Drafts are grouped by this.
+ * @param uniqueKey Optional sub-identifier when N concurrent drafts coexist under one [formKey].
+ * @param autoSaveDraft When true, drafts persist silently on network failure.
+ */
+abstract class BaseDraftMutationViewModel<T, R>(
+    outbox: SubmitOutbox<T>,
+    formKey: String,
+    uniqueKey: String? = null,
+    autoSaveDraft: Boolean = false,
+) : BaseViewModel<MutationUiState<T, R>, Nothing, MutationAction<T>>(MutationUiState()) {
+
+    private val draftHandler = viewModelScope.draftSubmitHandler<T, R>(
+        outbox = outbox,
+        formKey = formKey,
+        autoSaveDraft = autoSaveDraft,
+        uniqueKey = uniqueKey,
+    )
+
+    protected val mutableScreenState: MutableStateFlow<ScreenState<T>> =
+        MutableStateFlow(ScreenState.Loading)
+
+    /**
+     * Backward-compat alias for the inherited [stateFlow]. Mirrors [BaseSubmitMutationViewModel.uiState].
+     */
+    val uiState: StateFlow<MutationUiState<T, R>> get() = stateFlow
+
+    init {
+        combine(mutableScreenState, draftHandler.state) { screen, submit ->
+            MutationUiState(screen = screen, submit = submit)
+        }.onEach { combined ->
+            updateState { combined }
+        }.launchIn(viewModelScope)
+    }
+
+    /** Override to provide the network/repository call. Called with the current form payload. */
+    protected abstract suspend fun performSubmit(payload: T): R
+
+    override fun handleAction(action: MutationAction<T>) {
+        when (action) {
+            is MutationAction.Submit -> draftHandler.submit(action.payload) { performSubmit(it) }
+            MutationAction.Retry -> draftHandler.retry()
+            MutationAction.Dismiss -> draftHandler.reset()
+        }
+    }
+
+    /** Trigger a form submission. No-op if already [SubmitState.Submitting]. */
+    open fun onSubmit(payload: T) {
+        trySendAction(MutationAction.Submit(payload))
+    }
+
+    /** Retry the last failed submission. */
+    open fun onRetry() {
+        trySendAction(MutationAction.Retry)
+    }
+
+    /**
+     * Dismiss the result overlay and return to [SubmitState.Idle].
+     *
+     * Override to add VM-local cleanup (e.g. reset form fields). Always call `super.onDismissResult()`
+     * to keep the inherited submit-state reset behaviour.
+     */
+    open fun onDismissResult() {
+        trySendAction(MutationAction.Dismiss)
+    }
+
+    /**
+     * User-prompted draft save. Called from the screen after the user confirms "Save Draft"
+     * on the DraftSavePrompt. No-op in `autoSaveDraft = true` mode (the draft was already
+     * persisted silently on the network failure) and when there is no pending payload.
+     */
+    fun onSaveDraft() {
+        draftHandler.saveDraft()
+    }
+
+    /**
+     * Discard the in-memory pending payload and dismiss the prompt. Does NOT delete already-saved
+     * drafts from the outbox — use the outbox's `deleteByFormKey` / `deleteByUniqueKey` if the
+     * user wants to drop a persisted draft too.
+     */
+    fun onDiscardDraft() {
+        draftHandler.discardDraft()
+    }
+}

--- a/core-base/ui/src/commonMain/kotlin/template/core/base/ui/viewmodel/BaseMutationViewModel.kt
+++ b/core-base/ui/src/commonMain/kotlin/template/core/base/ui/viewmodel/BaseMutationViewModel.kt
@@ -9,105 +9,27 @@
  */
 package template.core.base.ui.viewmodel
 
-import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
-import template.core.base.store.screen.ScreenState
-import template.core.base.store.submit.MutationUiState
-import template.core.base.store.submit.SubmitState
-import template.core.base.store.submit.submitHandler
-
 /**
- * Base class for edit-screen ViewModels that combine a read stream with a form submit.
+ * Deprecated alias for [BaseSubmitMutationViewModel].
  *
- * Extends [BaseViewModel] with the MutationUiState/MutationAction shape baked in — submit
- * lifecycle is driven through the inherited MVI action channel, so concurrent
- * [MutationAction.Submit] / [MutationAction.Retry] / [MutationAction.Dismiss] are serialized.
+ * Renamed for clarity when [BaseDraftMutationViewModel] was introduced as its offline-resilient
+ * sibling — both extend the same MVI base, but each wraps a different submit handler:
  *
- * The combined screen + submit state is exposed via the inherited [stateFlow]; the legacy
- * [uiState] property is preserved as a get-only alias for backward compatibility.
+ * | Class | Wraps | When to use |
+ * |---|---|---|
+ * | [BaseSubmitMutationViewModel] | `SubmitHandler<R>` | Fire-and-forget submit. No outbox. |
+ * | [BaseDraftMutationViewModel]  | `DraftSubmitHandler<P, R>` | Offline-resilient. Persists drafts; auto-retries. |
  *
- * Subclasses override [performSubmit] to provide the actual network/repository call and
- * populate [mutableScreenState] when the read-side data resolves.
- *
- * Usage:
- * ```kotlin
- * class EditClientViewModel(
- *     private val repo: ClientRepository,
- *     private val clientId: String,
- * ) : BaseMutationViewModel<ClientDetail, Unit>() {
- *
- *     init {
- *         viewModelScope.launch {
- *             mutableScreenState.value = try {
- *                 ScreenState.Content(repo.getClient(clientId), DataFreshness.FRESH)
- *             } catch (e: Exception) {
- *                 ScreenState.Error(e)
- *             }
- *         }
- *     }
- *
- *     override suspend fun performSubmit(payload: ClientDetail): Unit =
- *         repo.updateClient(clientId, payload)
- * }
- *
- * // From the screen:
- * viewModel.trySendAction(MutationAction.Submit(updatedClient))
- * // — or the convenience shorthand —
- * viewModel.onSubmit(updatedClient)
- * ```
- *
- * @param T Domain type loaded for display.
- * @param R Result type returned by the server on a successful submit.
+ * Existing call sites keep working — [typealias][typealias] is a fully transparent rename.
+ * Update at your own pace; CI does not break.
  */
-abstract class BaseMutationViewModel<T, R> :
-    BaseViewModel<MutationUiState<T, R>, Nothing, MutationAction<T>>(MutationUiState()) {
-
-    private val submitHandler = viewModelScope.submitHandler<R>()
-
-    protected val mutableScreenState: MutableStateFlow<ScreenState<T>> =
-        MutableStateFlow(ScreenState.Loading)
-
-    /**
-     * Backward-compat alias for the inherited [stateFlow]. Existing callers using
-     * `viewModel.uiState` keep working with no change.
-     */
-    val uiState: StateFlow<MutationUiState<T, R>> get() = stateFlow
-
-    init {
-        combine(mutableScreenState, submitHandler.state) { screen, submit ->
-            MutationUiState(screen = screen, submit = submit)
-        }.onEach { combined ->
-            updateState { combined }
-        }.launchIn(viewModelScope)
-    }
-
-    /** Override to provide the network/repository call. Called with the current form payload. */
-    protected abstract suspend fun performSubmit(payload: T): R
-
-    override fun handleAction(action: MutationAction<T>) {
-        when (action) {
-            is MutationAction.Submit -> submitHandler.submit { performSubmit(action.payload) }
-            MutationAction.Retry -> submitHandler.retry()
-            MutationAction.Dismiss -> submitHandler.reset()
-        }
-    }
-
-    /** Trigger a form submission. No-op if already [SubmitState.Submitting]. */
-    fun onSubmit(payload: T) {
-        trySendAction(MutationAction.Submit(payload))
-    }
-
-    /** Retry the last failed submission. */
-    fun onRetry() {
-        trySendAction(MutationAction.Retry)
-    }
-
-    /** Dismiss the result overlay and return to [SubmitState.Idle]. */
-    fun onDismissResult() {
-        trySendAction(MutationAction.Dismiss)
-    }
-}
+@Deprecated(
+    message = "Renamed to BaseSubmitMutationViewModel for clarity. " +
+        "Use BaseDraftMutationViewModel for offline-resilient submits.",
+    replaceWith = ReplaceWith(
+        "BaseSubmitMutationViewModel<T, R>",
+        "template.core.base.ui.viewmodel.BaseSubmitMutationViewModel",
+    ),
+    level = DeprecationLevel.WARNING,
+)
+typealias BaseMutationViewModel<T, R> = BaseSubmitMutationViewModel<T, R>

--- a/core-base/ui/src/commonMain/kotlin/template/core/base/ui/viewmodel/BaseSubmitMutationViewModel.kt
+++ b/core-base/ui/src/commonMain/kotlin/template/core/base/ui/viewmodel/BaseSubmitMutationViewModel.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package template.core.base.ui.viewmodel
+
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import template.core.base.store.screen.ScreenState
+import template.core.base.store.submit.MutationUiState
+import template.core.base.store.submit.SubmitState
+import template.core.base.store.submit.submitHandler
+
+/**
+ * Base class for edit-screen ViewModels that combine a read stream with a fire-and-forget submit.
+ *
+ * Use this when:
+ * - The form's failure mode is user-recoverable in-session (network blip → user retries).
+ * - No need to persist a draft across app restarts.
+ * - No background sync on reconnect.
+ *
+ * For offline-resilient submits that survive process death and auto-retry on reconnect, use
+ * [BaseDraftMutationViewModel] instead — sibling class wrapping `DraftSubmitHandler` + `SubmitOutbox`.
+ *
+ * Extends [BaseViewModel] with the MutationUiState/MutationAction shape baked in — submit
+ * lifecycle is driven through the inherited MVI action channel, so concurrent
+ * [MutationAction.Submit] / [MutationAction.Retry] / [MutationAction.Dismiss] are serialized.
+ *
+ * The combined screen + submit state is exposed via the inherited [stateFlow]; the legacy
+ * [uiState] property is preserved as a get-only alias for backward compatibility.
+ *
+ * Subclasses override [performSubmit] to provide the actual network/repository call and
+ * populate [mutableScreenState] when the read-side data resolves.
+ *
+ * Usage:
+ * ```kotlin
+ * class EditClientViewModel(
+ *     private val repo: ClientRepository,
+ *     private val clientId: String,
+ * ) : BaseSubmitMutationViewModel<ClientDetail, Unit>() {
+ *
+ *     init {
+ *         viewModelScope.launch {
+ *             mutableScreenState.value = try {
+ *                 ScreenState.Content(repo.getClient(clientId), DataFreshness.FRESH)
+ *             } catch (e: Exception) {
+ *                 ScreenState.Error(e)
+ *             }
+ *         }
+ *     }
+ *
+ *     override suspend fun performSubmit(payload: ClientDetail): Unit =
+ *         repo.updateClient(clientId, payload)
+ * }
+ *
+ * // From the screen:
+ * viewModel.trySendAction(MutationAction.Submit(updatedClient))
+ * // — or the convenience shorthand —
+ * viewModel.onSubmit(updatedClient)
+ * ```
+ *
+ * @param T Domain type loaded for display.
+ * @param R Result type returned by the server on a successful submit.
+ */
+abstract class BaseSubmitMutationViewModel<T, R> :
+    BaseViewModel<MutationUiState<T, R>, Nothing, MutationAction<T>>(MutationUiState()) {
+
+    private val submitHandler = viewModelScope.submitHandler<R>()
+
+    protected val mutableScreenState: MutableStateFlow<ScreenState<T>> =
+        MutableStateFlow(ScreenState.Loading)
+
+    /**
+     * Backward-compat alias for the inherited [stateFlow]. Existing callers using
+     * `viewModel.uiState` keep working with no change.
+     */
+    val uiState: StateFlow<MutationUiState<T, R>> get() = stateFlow
+
+    init {
+        combine(mutableScreenState, submitHandler.state) { screen, submit ->
+            MutationUiState(screen = screen, submit = submit)
+        }.onEach { combined ->
+            updateState { combined }
+        }.launchIn(viewModelScope)
+    }
+
+    /** Override to provide the network/repository call. Called with the current form payload. */
+    protected abstract suspend fun performSubmit(payload: T): R
+
+    override fun handleAction(action: MutationAction<T>) {
+        when (action) {
+            is MutationAction.Submit -> submitHandler.submit { performSubmit(action.payload) }
+            MutationAction.Retry -> submitHandler.retry()
+            MutationAction.Dismiss -> submitHandler.reset()
+        }
+    }
+
+    /** Trigger a form submission. No-op if already [SubmitState.Submitting]. */
+    open fun onSubmit(payload: T) {
+        trySendAction(MutationAction.Submit(payload))
+    }
+
+    /** Retry the last failed submission. */
+    open fun onRetry() {
+        trySendAction(MutationAction.Retry)
+    }
+
+    /**
+     * Dismiss the result overlay and return to [SubmitState.Idle].
+     *
+     * Override to add VM-local cleanup (e.g. reset form fields). Always call `super.onDismissResult()`
+     * to keep the inherited submit-state reset behaviour.
+     */
+    open fun onDismissResult() {
+        trySendAction(MutationAction.Dismiss)
+    }
+}

--- a/core/data/src/commonMain/kotlin/org/mifos/core/data/infra/impl/RoomSubmitOutbox.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/core/data/infra/impl/RoomSubmitOutbox.kt
@@ -52,6 +52,25 @@ class RoomSubmitOutbox<P>(
         }
         val entity = DraftEntity(
             formKey = formKey,
+            uniqueKey = null,
+            payloadJson = json.encodeToString(serializer, payload),
+            status = SubmitOutboxStatus.PENDING.name,
+            createdAtMs = nowMs,
+            updatedAtMs = nowMs,
+        )
+        return dao.insert(entity)
+    }
+
+    override suspend fun saveByUniqueKey(formKey: String, uniqueKey: String, payload: P): Long {
+        val nowMs = currentTimeMillis()
+        val existing = dao.getPendingByUniqueKey(formKey, uniqueKey)
+        if (existing != null) {
+            dao.updatePayload(existing.id, json.encodeToString(serializer, payload), nowMs)
+            return existing.id
+        }
+        val entity = DraftEntity(
+            formKey = formKey,
+            uniqueKey = uniqueKey,
             payloadJson = json.encodeToString(serializer, payload),
             status = SubmitOutboxStatus.PENDING.name,
             createdAtMs = nowMs,
@@ -63,8 +82,17 @@ class RoomSubmitOutbox<P>(
     override suspend fun getPending(formKey: String): SubmitOutboxEntry<P>? =
         dao.getPendingByFormKey(formKey)?.toEntry()
 
+    override suspend fun getPendingByUniqueKey(formKey: String, uniqueKey: String): SubmitOutboxEntry<P>? =
+        dao.getPendingByUniqueKey(formKey, uniqueKey)?.toEntry()
+
     override fun observePending(formKey: String): Flow<SubmitOutboxEntry<P>?> =
         dao.observePendingByFormKey(formKey).map { it?.toEntry() }
+
+    override fun observePendingByUniqueKey(formKey: String, uniqueKey: String): Flow<SubmitOutboxEntry<P>?> =
+        dao.observePendingByUniqueKey(formKey, uniqueKey).map { it?.toEntry() }
+
+    override fun observeAllByFormKey(formKey: String): Flow<List<SubmitOutboxEntry<P>>> =
+        dao.observeAllByFormKey(formKey).map { rows -> rows.mapNotNull { it.toEntry() } }
 
     override suspend fun getAllPending(): List<SubmitOutboxEntry<P>> = dao.getAllPending().mapNotNull { it.toEntry() }
 
@@ -76,6 +104,9 @@ class RoomSubmitOutbox<P>(
 
     override suspend fun deleteByFormKey(formKey: String) = dao.deleteByFormKey(formKey)
 
+    override suspend fun deleteByUniqueKey(formKey: String, uniqueKey: String) =
+        dao.deleteByUniqueKey(formKey, uniqueKey)
+
     override suspend fun deleteAll() = dao.deleteAll()
 
     private fun DraftEntity.toEntry(): SubmitOutboxEntry<P>? = runCatching {
@@ -85,6 +116,7 @@ class RoomSubmitOutbox<P>(
             payload = json.decodeFromString(serializer, payloadJson),
             status = SubmitOutboxStatus.valueOf(status),
             createdAtMs = createdAtMs,
+            uniqueKey = uniqueKey,
             errorMessage = errorMessage,
         )
     }.getOrNull()

--- a/core/database/schemas/org.mifos.core.database.AppDatabase/7.json
+++ b/core/database/schemas/org.mifos.core.database.AppDatabase/7.json
@@ -1,0 +1,433 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 7,
+    "identityHash": "57e54b3b2d276dff425040e49797cc59",
+    "entities": [
+      {
+        "tableName": "samples",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "exchange_rates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`baseCurrency` TEXT NOT NULL, `date` TEXT NOT NULL, `ratesJson` TEXT NOT NULL, `fetchedAt` INTEGER NOT NULL, PRIMARY KEY(`baseCurrency`))",
+        "fields": [
+          {
+            "fieldPath": "baseCurrency",
+            "columnName": "baseCurrency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ratesJson",
+            "columnName": "ratesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "baseCurrency"
+          ]
+        }
+      },
+      {
+        "tableName": "coin_markets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `symbol` TEXT NOT NULL, `name` TEXT NOT NULL, `imageUrl` TEXT NOT NULL, `currentPrice` REAL NOT NULL, `marketCap` INTEGER NOT NULL, `marketCapRank` INTEGER NOT NULL, `priceChangePercent24h` REAL NOT NULL, `high24h` REAL NOT NULL, `low24h` REAL NOT NULL, `page` INTEGER NOT NULL, `fetchedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "symbol",
+            "columnName": "symbol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentPrice",
+            "columnName": "currentPrice",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "marketCap",
+            "columnName": "marketCap",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "marketCapRank",
+            "columnName": "marketCapRank",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priceChangePercent24h",
+            "columnName": "priceChangePercent24h",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "high24h",
+            "columnName": "high24h",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "low24h",
+            "columnName": "low24h",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "coin_detail",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `symbol` TEXT NOT NULL, `imageUrl` TEXT NOT NULL, `currentPrice` REAL NOT NULL, `marketCap` INTEGER NOT NULL, `marketCapRank` INTEGER NOT NULL, `priceChangePercent24h` REAL NOT NULL, `high24h` REAL NOT NULL, `low24h` REAL NOT NULL, `circulatingSupply` REAL NOT NULL, `maxSupply` REAL, `description` TEXT NOT NULL, `fetchedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "symbol",
+            "columnName": "symbol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentPrice",
+            "columnName": "currentPrice",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "marketCap",
+            "columnName": "marketCap",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "marketCapRank",
+            "columnName": "marketCapRank",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priceChangePercent24h",
+            "columnName": "priceChangePercent24h",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "high24h",
+            "columnName": "high24h",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "low24h",
+            "columnName": "low24h",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "circulatingSupply",
+            "columnName": "circulatingSupply",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxSupply",
+            "columnName": "maxSupply",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "rate_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fromCurrency` TEXT NOT NULL, `toCurrency` TEXT NOT NULL, `startDate` TEXT NOT NULL, `endDate` TEXT NOT NULL, `ratesJson` TEXT NOT NULL, `fetchedAt` INTEGER NOT NULL, PRIMARY KEY(`fromCurrency`, `toCurrency`, `startDate`, `endDate`))",
+        "fields": [
+          {
+            "fieldPath": "fromCurrency",
+            "columnName": "fromCurrency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toCurrency",
+            "columnName": "toCurrency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "startDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ratesJson",
+            "columnName": "ratesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fromCurrency",
+            "toCurrency",
+            "startDate",
+            "endDate"
+          ]
+        }
+      },
+      {
+        "tableName": "store_bookkeeper",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `lastFailedSync` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastFailedSync",
+            "columnName": "lastFailedSync",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "framework_fetched_at",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storeKey` TEXT NOT NULL, `lastFetchedMillis` INTEGER NOT NULL, PRIMARY KEY(`storeKey`))",
+        "fields": [
+          {
+            "fieldPath": "storeKey",
+            "columnName": "storeKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastFetchedMillis",
+            "columnName": "lastFetchedMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storeKey"
+          ]
+        }
+      },
+      {
+        "tableName": "framework_submit_drafts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `formKey` TEXT NOT NULL, `uniqueKey` TEXT, `payloadJson` TEXT NOT NULL, `status` TEXT NOT NULL, `createdAtMs` INTEGER NOT NULL, `updatedAtMs` INTEGER NOT NULL, `errorMessage` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "formKey",
+            "columnName": "formKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uniqueKey",
+            "columnName": "uniqueKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadJson",
+            "columnName": "payloadJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtMs",
+            "columnName": "createdAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtMs",
+            "columnName": "updatedAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "personal_watchlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`coinId` TEXT NOT NULL, `addedAtMs` INTEGER NOT NULL, PRIMARY KEY(`coinId`))",
+        "fields": [
+          {
+            "fieldPath": "coinId",
+            "columnName": "coinId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAtMs",
+            "columnName": "addedAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "coinId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '57e54b3b2d276dff425040e49797cc59')"
+    ]
+  }
+}

--- a/core/database/src/commonMain/kotlin/org/mifos/core/database/AppDatabase.kt
+++ b/core/database/src/commonMain/kotlin/org/mifos/core/database/AppDatabase.kt
@@ -83,6 +83,9 @@ expect object AppDatabaseConstructor : RoomDatabaseConstructor<AppDatabase> {
         AutoMigration(from = 4, to = 5),
         // v5 → v6: adds `personal_watchlist` for the user's private watchlist.
         AutoMigration(from = 5, to = 6),
+        // v6 → v7: adds nullable `uniqueKey` column to `framework_submit_drafts` for
+        // multi-pending drafts under one formKey (Portfolio Tracker, Bill Reminders, wizard steps).
+        AutoMigration(from = 6, to = 7),
     ],
 )
 @TypeConverters(ChargeTypeConverters::class, FintechTypeConverters::class)
@@ -100,7 +103,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract val watchlistDao: WatchlistDao
 
     companion object {
-        const val VERSION = 6
+        const val VERSION = 7
         const val DATABASE_NAME = "mifos_database.db"
     }
 }

--- a/core/database/src/commonMain/kotlin/org/mifos/core/database/infra/dao/DraftDao.kt
+++ b/core/database/src/commonMain/kotlin/org/mifos/core/database/infra/dao/DraftDao.kt
@@ -31,11 +31,47 @@ interface DraftDao {
     @Query("SELECT * FROM framework_submit_drafts WHERE id = :id")
     suspend fun getById(id: Long): DraftEntity?
 
-    @Query("SELECT * FROM framework_submit_drafts WHERE formKey = :formKey AND status = 'PENDING' LIMIT 1")
+    @Query(
+        "SELECT * FROM framework_submit_drafts " +
+            "WHERE formKey = :formKey AND uniqueKey IS NULL AND status = 'PENDING' LIMIT 1",
+    )
     suspend fun getPendingByFormKey(formKey: String): DraftEntity?
 
-    @Query("SELECT * FROM framework_submit_drafts WHERE formKey = :formKey AND status = 'PENDING' LIMIT 1")
+    @Query(
+        "SELECT * FROM framework_submit_drafts " +
+            "WHERE formKey = :formKey AND uniqueKey IS NULL AND status = 'PENDING' LIMIT 1",
+    )
     fun observePendingByFormKey(formKey: String): Flow<DraftEntity?>
+
+    /**
+     * Multi-pending companion to [getPendingByFormKey]. Reads the PENDING draft for a specific
+     * `(formKey, uniqueKey)` pair — N concurrent independent drafts can coexist under one
+     * `formKey` when each carries a distinct `uniqueKey` (e.g. `loan_id`, `bill_id`, wizard step).
+     */
+    @Query(
+        "SELECT * FROM framework_submit_drafts " +
+            "WHERE formKey = :formKey AND uniqueKey = :uniqueKey AND status = 'PENDING' LIMIT 1",
+    )
+    suspend fun getPendingByUniqueKey(formKey: String, uniqueKey: String): DraftEntity?
+
+    /** Streaming variant of [getPendingByUniqueKey]. */
+    @Query(
+        "SELECT * FROM framework_submit_drafts " +
+            "WHERE formKey = :formKey AND uniqueKey = :uniqueKey AND status = 'PENDING' LIMIT 1",
+    )
+    fun observePendingByUniqueKey(formKey: String, uniqueKey: String): Flow<DraftEntity?>
+
+    /**
+     * Observes ALL non-terminal drafts (PENDING / RETRYING / FAILED) for a `formKey`, ordered
+     * newest-first by `createdAtMs`. Includes singleton drafts (uniqueKey IS NULL) and all
+     * multi-pending rows. Used by feature UIs that need to display "N drafts pending sync".
+     */
+    @Query(
+        "SELECT * FROM framework_submit_drafts " +
+            "WHERE formKey = :formKey AND status IN ('PENDING','RETRYING','FAILED') " +
+            "ORDER BY createdAtMs DESC",
+    )
+    fun observeAllByFormKey(formKey: String): Flow<List<DraftEntity>>
 
     @Query("SELECT * FROM framework_submit_drafts WHERE status = 'PENDING'")
     suspend fun getAllPending(): List<DraftEntity>
@@ -57,6 +93,14 @@ interface DraftDao {
 
     @Query("DELETE FROM framework_submit_drafts WHERE formKey = :formKey")
     suspend fun deleteByFormKey(formKey: String)
+
+    /**
+     * Deletes a single `(formKey, uniqueKey)` row. Use after a multi-pending draft
+     * successfully submits (paired with [getPendingByUniqueKey]). Does NOT affect the
+     * singleton draft (uniqueKey IS NULL) under the same `formKey`.
+     */
+    @Query("DELETE FROM framework_submit_drafts WHERE formKey = :formKey AND uniqueKey = :uniqueKey")
+    suspend fun deleteByUniqueKey(formKey: String, uniqueKey: String)
 
     @Query("DELETE FROM framework_submit_drafts")
     suspend fun deleteAll()

--- a/core/database/src/commonMain/kotlin/org/mifos/core/database/infra/entity/DraftEntity.kt
+++ b/core/database/src/commonMain/kotlin/org/mifos/core/database/infra/entity/DraftEntity.kt
@@ -21,8 +21,14 @@ import androidx.room3.PrimaryKey
  * @param id          Auto-generated surrogate key.
  * @param formKey     Consumer-defined identifier that groups drafts by screen/form type
  *                    (e.g. `"loan_application"`, `"client_registration"`). One pending draft
- *                    per formKey is the intended invariant — consumers are responsible for
- *                    enforcing uniqueness via [DraftDao.deleteByFormKey] before inserting.
+ *                    per (formKey, uniqueKey) pair is the intended invariant — consumers are
+ *                    responsible for enforcing uniqueness via [DraftDao.deleteByFormKey] or
+ *                    [DraftDao.deleteByUniqueKey] before inserting.
+ * @param uniqueKey   Optional sub-identifier within a form type. `null` means
+ *                    "the canonical/singleton draft for this form" (e.g. settings save,
+ *                    Personal Alert form). Non-null distinguishes one of many drafts under
+ *                    the same form type (e.g. Portfolio holding row, alert-per-coin) —
+ *                    enables N concurrent independent drafts under one `formKey`.
  * @param payloadJson Serialized form payload (JSON). The concrete type is opaque to the
  *                    framework; consumers encode/decode via kotlinx.serialization.
  * @param status      Lifecycle state — see [DraftStatus].
@@ -34,6 +40,7 @@ import androidx.room3.PrimaryKey
 data class DraftEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     val formKey: String,
+    val uniqueKey: String? = null,
     val payloadJson: String,
     val status: String,
     val createdAtMs: Long,

--- a/feature/alerts/src/commonMain/kotlin/org/mifos/feature/alerts/ui/SetPriceAlertScreen.kt
+++ b/feature/alerts/src/commonMain/kotlin/org/mifos/feature/alerts/ui/SetPriceAlertScreen.kt
@@ -48,7 +48,8 @@ fun SetPriceAlertScreen(
     viewModel: SetPriceAlertViewModel = koinViewModel(),
 ) {
     val form by viewModel.formState.collectAsStateWithLifecycle()
-    val submit by viewModel.submitState.collectAsStateWithLifecycle()
+    val ui by viewModel.uiState.collectAsStateWithLifecycle()
+    val submit = ui.submit
 
     Scaffold(
         modifier = modifier,

--- a/feature/alerts/src/commonMain/kotlin/org/mifos/feature/alerts/ui/SetPriceAlertViewModel.kt
+++ b/feature/alerts/src/commonMain/kotlin/org/mifos/feature/alerts/ui/SetPriceAlertViewModel.kt
@@ -9,67 +9,51 @@
  */
 package org.mifos.feature.alerts.ui
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import org.mifos.core.data.alerts.AlertsRepository
 import org.mifos.core.model.alerts.AlertDirection
 import org.mifos.core.model.alerts.PriceAlert
 import template.core.base.store.submit.SubmitOutbox
 import template.core.base.store.submit.SubmitState
-import template.core.base.store.submit.draftSubmitHandler
+import template.core.base.ui.viewmodel.BaseDraftMutationViewModel
 import kotlin.random.Random
 import kotlin.time.Clock
 
 /**
- * **Canonical `DraftSubmitHandler` showcase.**
+ * **Canonical `BaseDraftMutationViewModel` showcase.**
  *
- * This ViewModel demonstrates the framework's offline-resilient form submission
- * pattern: when the user taps Save while online, the alert is sent via
- * [AlertsRepository.submitAlert] immediately. When offline, the payload persists
- * in the framework outbox (`framework_submit_drafts` table, formKey =
- * `"price_alert"`); the `OfflineSubmitSyncer` (wired in `DataModule`) retries
- * it automatically on the next online transition.
+ * Demonstrates the framework's offline-resilient form submission via the unified mutation base
+ * (introduced by `p1-framework-prerequisites/02-base-mutation-vm-param`). When the user taps
+ * Save while online the alert is sent via [AlertsRepository.submitAlert]; when offline the
+ * payload persists in `framework_submit_drafts` (`formKey = "price_alert"`) and the
+ * `OfflineSubmitSyncer` retries it on the next online transition.
  *
- * The ViewModel does NOT extend `BaseMutationViewModel` — instead it uses
- * `draftSubmitHandler` directly because the canonical Mutation base supports
- * `SubmitHandler` (one-shot fire-and-forget), not `DraftSubmitHandler`
- * (persistent outbox). A future framework refactor could unify both, but
- * right now this is the cleaner shape.
+ * Form state (`coinId`, `direction`, `targetValue`, `enabled`) lives in [formState] — pre-submit
+ * ephemeral local state, NOT a derived `ScreenState<T>` from a stream. The screen edits via
+ * `onCoinIdChange` etc. and triggers the snapshot-and-submit via [onSubmit].
  *
- * Form state lives in [formState] (mutable while typing). On Save, the form
- * is snapshotted into a [PriceAlert] payload and submitted via
- * [draftHandler.submit]; [submitState] exposes the Idle/Submitting/Submitted/Failed
- * lifecycle for the screen to render feedback overlays.
+ * Submit lifecycle (Idle / Submitting / Submitted / Failed) is exposed via the inherited
+ * [uiState] (a [template.core.base.store.submit.MutationUiState] whose `.submit` field
+ * carries the [SubmitState]).
  *
- * @param autoSaveDraft When `true`, network failures silently persist the
- *   payload to the outbox (no user prompt). The plan's recommended default for
- *   showcase clarity — fork apps may flip to `false` for explicit user consent.
+ * **Single-pending mode**: `uniqueKey` is `null` (default) — one PENDING draft per `formKey`.
+ * If we ever ship per-coin price alerts where N drafts can coexist offline, switch to
+ * passing `uniqueKey = coinId` per ViewModel instance.
  */
 class SetPriceAlertViewModel(
     private val repository: AlertsRepository,
-    private val outbox: SubmitOutbox<PriceAlert>,
-) : ViewModel() {
+    outbox: SubmitOutbox<PriceAlert>,
+) : BaseDraftMutationViewModel<PriceAlert, PriceAlert>(
+    outbox = outbox,
+    formKey = "price_alert",
+    autoSaveDraft = true,
+) {
 
     private val _formState = MutableStateFlow(PriceAlertFormState())
     val formState: StateFlow<PriceAlertFormState> = _formState.asStateFlow()
-
-    private val draftHandler = viewModelScope.draftSubmitHandler<PriceAlert, PriceAlert>(
-        outbox = outbox,
-        formKey = "price_alert",
-        autoSaveDraft = true,
-    )
-
-    val submitState: StateFlow<SubmitState<PriceAlert>> = draftHandler.state.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5_000),
-        initialValue = SubmitState.Idle,
-    )
 
     fun onCoinIdChange(value: String) {
         _formState.update { it.copy(coinId = value) }
@@ -87,7 +71,10 @@ class SetPriceAlertViewModel(
         _formState.update { it.copy(enabled = enabled) }
     }
 
-    /** Validate, snapshot to a [PriceAlert] payload, and submit through the draft handler. */
+    /**
+     * Validate, snapshot to a [PriceAlert] payload, then delegate to the base's
+     * `onSubmit(payload)`. Overload (parameter-less) — does NOT override `super.onSubmit(payload)`.
+     */
     fun onSubmit() {
         val form = _formState.value
         if (form.coinId.isBlank() || form.targetValue <= 0.0) return
@@ -99,17 +86,18 @@ class SetPriceAlertViewModel(
             enabled = form.enabled,
             createdAtMs = Clock.System.now().toEpochMilliseconds(),
         )
-        draftHandler.submit(payload) { repository.submitAlert(it) }
+        super.onSubmit(payload)
     }
 
-    fun onRetry() {
-        draftHandler.retry()
-    }
-
-    fun onDismissResult() {
-        draftHandler.reset()
+    /** Reset both submit state (super) and form fields (VM-local). */
+    override fun onDismissResult() {
+        super.onDismissResult()
         _formState.value = PriceAlertFormState()
     }
+
+    /** Repository implementation called by the inherited draft handler. */
+    override suspend fun performSubmit(payload: PriceAlert): PriceAlert =
+        repository.submitAlert(payload)
 
     private fun randomId(): String {
         // Compact client-side ID; replace with UUID4 once kotlinx.uuid or okio.UUID is wired.

--- a/feature/crypto/src/commonMain/kotlin/org/mifos/feature/crypto/ui/CryptoWatchlistScreen.kt
+++ b/feature/crypto/src/commonMain/kotlin/org/mifos/feature/crypto/ui/CryptoWatchlistScreen.kt
@@ -30,6 +30,7 @@ import org.mifos.core.common.formatGrouped
 import org.mifos.core.model.crypto.CoinMarket
 import org.mifos.core.ui.scaffold.KptScaffold
 import org.mifos.core.ui.scaffold.rememberKptPullToRefreshState
+import org.mifos.feature.watchlist.ui.AddToWatchlistButton
 import template.core.base.ui.paging.PagingScreenContent
 
 @Composable
@@ -71,7 +72,7 @@ private fun CoinItem(coin: CoinMarket, onClick: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+            .padding(start = 16.dp, end = 4.dp, top = 4.dp, bottom = 4.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -98,5 +99,6 @@ private fun CoinItem(coin: CoinMarket, onClick: () -> Unit) {
                 },
             )
         }
+        AddToWatchlistButton(coinId = coin.id)
     }
 }

--- a/feature/home/src/commonMain/kotlin/org/mifos/feature/home/HomeDestination.kt
+++ b/feature/home/src/commonMain/kotlin/org/mifos/feature/home/HomeDestination.kt
@@ -32,6 +32,8 @@ fun NavGraphBuilder.homeGraph(
     onNavigateToHistory: () -> Unit,
     onNavigateToCrypto: () -> Unit,
     onNavigateToEmi: () -> Unit,
+    onNavigateToWatchlist: () -> Unit,
+    onNavigateToAlerts: () -> Unit,
 ) {
     navigation<HomeDestination>(
         startDestination = HomeRoute,
@@ -43,6 +45,8 @@ fun NavGraphBuilder.homeGraph(
                 onNavigateToHistory = onNavigateToHistory,
                 onNavigateToCrypto = onNavigateToCrypto,
                 onNavigateToEmi = onNavigateToEmi,
+                onNavigateToWatchlist = onNavigateToWatchlist,
+                onNavigateToAlerts = onNavigateToAlerts,
             )
         }
     }

--- a/feature/home/src/commonMain/kotlin/org/mifos/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/org/mifos/feature/home/HomeScreen.kt
@@ -26,7 +26,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ShowChart
 import androidx.compose.material.icons.filled.Calculate
 import androidx.compose.material.icons.filled.CurrencyExchange
+import androidx.compose.material.icons.filled.NotificationsActive
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.Timeline
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -46,6 +48,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.koin.compose.viewmodel.koinViewModel
 import org.mifos.core.common.formatDecimal
 import org.mifos.core.common.formatGrouped
+import org.mifos.core.data.watchlist.WatchlistItem
+import org.mifos.core.model.alerts.AlertDirection
+import org.mifos.core.model.alerts.PriceAlert
 import org.mifos.feature.home.ui.HomeAction
 import org.mifos.feature.home.ui.HomeViewModel
 import template.core.base.store.screen.ScreenState
@@ -59,6 +64,8 @@ internal fun HomeScreen(
     onNavigateToHistory: () -> Unit,
     onNavigateToCrypto: () -> Unit,
     onNavigateToEmi: () -> Unit,
+    onNavigateToWatchlist: () -> Unit,
+    onNavigateToAlerts: () -> Unit,
     viewModel: HomeViewModel = koinViewModel(),
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
@@ -100,9 +107,18 @@ internal fun HomeScreen(
                 onSeeAll = onNavigateToRates,
             )
 
+            WatchlistPreviewCard(
+                state = state.watchlistPreview,
+                onSeeAll = onNavigateToWatchlist,
+            )
+
+            ActiveAlertsCard(
+                state = state.activeAlerts,
+                onSeeAll = onNavigateToAlerts,
+            )
+
             // Navigation cards — preserved from the original menu so existing
-            // features stay discoverable. Sub-plans 03/04 will add Watchlist
-            // and Alerts cards to the widget section above when their data is on dev.
+            // features stay discoverable alongside the 4 live widgets above.
             Text(
                 text = "Quick access",
                 style = MaterialTheme.typography.titleMedium,
@@ -254,7 +270,165 @@ private fun ExchangeRateCard(
 }
 
 @Composable
-private fun FeatureCard(title: String, subtitle: String, icon: ImageVector, onClick: () -> Unit) {
+private fun WatchlistPreviewCard(
+    state: ScreenState<List<WatchlistItem>>,
+    onSeeAll: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Star,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                    Text(
+                        text = "My Watchlist",
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                }
+                Text(
+                    text = "See all",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.clickable(onClick = onSeeAll),
+                )
+            }
+            Box(modifier = Modifier.fillMaxWidth().height(100.dp)) {
+                // Local-only stream — no error path; onRetry is a no-op.
+                ScreenContent(
+                    state = state,
+                    onRetry = {},
+                    modifier = Modifier.fillMaxSize(),
+                    empty = { WidgetEmpty("Tap the star on any coin to add it.") },
+                ) { items, _ ->
+                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        items.take(3).forEach { item ->
+                            Text(
+                                text = item.coinId,
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ActiveAlertsCard(
+    state: ScreenState<List<PriceAlert>>,
+    onSeeAll: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.NotificationsActive,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                    Text(
+                        text = "Active Alerts",
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                }
+                Text(
+                    text = "See all",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.clickable(onClick = onSeeAll),
+                )
+            }
+            Box(modifier = Modifier.fillMaxWidth().height(100.dp)) {
+                // Local committed-alerts stream — no error path; onRetry is a no-op.
+                ScreenContent(
+                    state = state,
+                    onRetry = {},
+                    modifier = Modifier.fillMaxSize(),
+                    empty = { WidgetEmpty("No alerts yet. Open Alerts to create one.") },
+                ) { alerts, _ ->
+                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        alerts.take(3).forEach { alert ->
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                            ) {
+                                Text(
+                                    text = alert.coinId,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                )
+                                Text(
+                                    text = formatAlertSummary(alert),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WidgetEmpty(message: String) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+private fun formatAlertSummary(alert: PriceAlert): String {
+    val arrow = when (alert.direction) {
+        AlertDirection.ABOVE -> "↑"
+        AlertDirection.BELOW -> "↓"
+        AlertDirection.PCT_CHANGE -> "Δ"
+    }
+    val value = when (alert.direction) {
+        AlertDirection.PCT_CHANGE -> "${alert.targetValue.formatDecimal(2)}%"
+        else -> "$${alert.targetValue.formatGrouped(2)}"
+    }
+    return "$arrow $value"
+}
+
+@Composable
+private fun FeatureCard(
+    title: String,
+    subtitle: String,
+    icon: ImageVector,
+    onClick: () -> Unit,
+) {
     Card(
         modifier = Modifier
             .fillMaxWidth()

--- a/feature/home/src/commonMain/kotlin/org/mifos/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/org/mifos/feature/home/ui/HomeViewModel.kt
@@ -12,28 +12,39 @@ package org.mifos.feature.home.ui
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import org.mifos.core.data.alerts.AlertsRepository
 import org.mifos.core.data.crypto.CryptoRepository
 import org.mifos.core.data.currency.CurrencyRepository
+import org.mifos.core.data.watchlist.WatchlistItem
+import org.mifos.core.data.watchlist.WatchlistRepository
+import org.mifos.core.model.alerts.PriceAlert
 import org.mifos.core.model.crypto.CoinMarket
 import org.mifos.core.model.currency.ExchangeRates
+import template.core.base.store.screen.DataFreshness
 import template.core.base.store.screen.ScreenState
 import template.core.base.ui.viewmodel.BaseViewModel
 
 /**
  * **Canonical multi-source combine showcase.**
  *
- * Composes two independent `ScreenDataStream`s into a single UI state with
- * per-widget loading/error/content slots. Each widget's state evolves
+ * Composes four independent reactive sources into a single UI state with
+ * per-widget loading/empty/error/content slots. Each widget's state evolves
  * independently — one card can be Loading while another shows Content; pull-
- * to-refresh fans out to both streams concurrently.
+ * to-refresh fans out to the network-backed streams concurrently.
  *
- * Extension points for sub-plans 03 (Watchlist) and 04 (Alerts) widgets are
- * documented in [HomeUiState]; adding them is a small follow-up once
- * `WatchlistRepository` and `AlertsRepository` land on `dev`.
+ * Sources split by character:
+ *  - [pagingStream] and [exchangeRateStream] are network-backed `ScreenDataStream`s
+ *    with their own Loading/Error/Content + freshness state.
+ *  - [WatchlistRepository.watchlist] and [AlertsRepository.alertsStream] are
+ *    purely local reactive `Flow`s — mapped here into `ScreenState.Empty` /
+ *    `ScreenState.Content(freshness = FRESH)` (same projection used by
+ *    `PersonalWatchlistViewModel`).
  */
 class HomeViewModel(
     private val cryptoRepository: CryptoRepository,
     private val currencyRepository: CurrencyRepository,
+    watchlistRepository: WatchlistRepository,
+    alertsRepository: AlertsRepository,
 ) : BaseViewModel<HomeUiState, Nothing, HomeAction>(HomeUiState()) {
 
     // Take the first page of coin markets; we'll show the top 5 in the widget.
@@ -62,12 +73,40 @@ class HomeViewModel(
                 updateState { copy(exchangeRate = state) }
             }
             .launchIn(viewModelScope)
+
+        // Watchlist preview: pure-local Flow → ScreenState. No retry surface
+        // (Room is the only source), so just Empty / Content.
+        watchlistRepository.watchlist()
+            .onEach { items ->
+                val next = if (items.isEmpty()) {
+                    ScreenState.Empty
+                } else {
+                    ScreenState.Content(data = items, freshness = DataFreshness.FRESH)
+                }
+                updateState { copy(watchlistPreview = next) }
+            }
+            .launchIn(viewModelScope)
+
+        // Active alerts: same pure-local projection. The committed-alerts stream
+        // is the canonical "what the user has set up" view; pending drafts are
+        // surfaced at the form-handler level (see AlertsRepository docstring).
+        alertsRepository.alertsStream()
+            .onEach { alerts ->
+                val next = if (alerts.isEmpty()) {
+                    ScreenState.Empty
+                } else {
+                    ScreenState.Content(data = alerts, freshness = DataFreshness.FRESH)
+                }
+                updateState { copy(activeAlerts = next) }
+            }
+            .launchIn(viewModelScope)
     }
 
     override fun handleAction(action: HomeAction) = when (action) {
         HomeAction.RefreshAll -> {
             pagingStream.refresh()
             exchangeRateStream.refresh()
+            // Watchlist + Alerts are local reactive Flows — nothing to refresh.
         }
         HomeAction.RetryTopMovers -> pagingStream.retry()
         HomeAction.RetryExchangeRate -> exchangeRateStream.retry()
@@ -78,16 +117,17 @@ class HomeViewModel(
  * Aggregate state for the home dashboard.
  *
  * Each slot is an independent [ScreenState] so the screen can render per-card
- * Loading / Empty / Error / Content states. Sub-plans 03 + 04 will add two more
- * slots (`watchlistPreview`, `activeAlerts`) once their repositories land.
+ * Loading / Empty / Error / Content states.
  */
 data class HomeUiState(
     val topMovers: ScreenState<List<CoinMarket>> = ScreenState.Loading,
     val exchangeRate: ScreenState<ExchangeRates> = ScreenState.Loading,
+    val watchlistPreview: ScreenState<List<WatchlistItem>> = ScreenState.Loading,
+    val activeAlerts: ScreenState<List<PriceAlert>> = ScreenState.Loading,
 )
 
 sealed interface HomeAction {
-    /** Pull-to-refresh — fans out to every stream. */
+    /** Pull-to-refresh — fans out to every network-backed stream. */
     data object RefreshAll : HomeAction
 
     /** Retry just the Top Movers widget (after an error). */


### PR DESCRIPTION
## Summary

4 commits across two scopes — home dashboard widgets (showcase follow-ups to PR #169) + the first 3 sub-plans of the **p1-framework-prerequisites** epic that unblock production-grade fintech feature work (Portfolio Tracker, Bill Reminders, Loan Calculator wizard, Stocks/Gas trackers).

### Commits

| SHA | Subject |
|---|---|
| [`c0a1872`](../commit/c0a1872) | `feat(home)`: dashboard widgets — `WatchlistPreviewCard` + `ActiveAlertsCard` + nav routes |
| [`70fe107`](../commit/70fe107) | `refactor(core-base/store)`: multi-formKey draft outbox via optional `uniqueKey` (**SP01**) |
| [`f3e5734`](../commit/f3e5734) | `refactor(core-base/ui)`: split `BaseMutationViewModel` into Submit/Draft pair (**SP02**) |
| [`45a0dd1`](../commit/45a0dd1) | `test(core-base/store)`: FetchPolicy enforcement TDD — `NETWORK_ONLY` + `CTN`-offline coverage (**SP03**) |

### Sub-plans implemented

- **SP01 — multi-formkey-drafts**: `DraftEntity.uniqueKey: String?` + 5 new `SubmitOutbox<P>` methods (`saveByUniqueKey`, `getPendingByUniqueKey`, `observePendingByUniqueKey`, `observeAllByFormKey`, `deleteByUniqueKey`) + Room v6→v7 auto-migration. Required for per-row offline edits (Portfolio holding, Bill, wizard step).
- **SP02 — base-mutation-vm-param**: `BaseMutationViewModel` → typealias of new `BaseSubmitMutationViewModel`; new sibling `BaseDraftMutationViewModel` wraps `DraftSubmitHandler` + `SubmitOutbox` + optional `uniqueKey` (from SP01). `SetPriceAlertViewModel` migrated to inherit from the Draft variant.
- **SP03 — fetchpolicy-tdd**: New `FetchPolicyEnforcementTest` covering the 4 highest-value untested rows of the FetchPolicy decision table — most importantly `NETWORK_ONLY + offline = NoNetwork` (no stale fallback — required for Stocks/Gas trackers).
- **SP04 — data-freshness-indicator**: already shipped in PR #169 (verified — see `DataFreshnessIndicator.kt` + `DataFreshnessIndicatorStateTest.kt` + `ScreenContent` wiring).

### Backward-compatibility notes

- `BaseMutationViewModel` is now a `@Deprecated(WARNING)` typealias — existing fork call sites compile unchanged.
- Schema migration adds `uniqueKey` as nullable column with `DEFAULT NULL` — existing PENDING rows surface as singletons; no data loss.
- All new ctor params (`uniqueKey: String? = null`, `autoSaveDraft: Boolean = false`) default to existing-behavior values.
- 5 new `SubmitOutbox` methods added to the interface — any external `SubmitOutbox<P>` implementations (rare; framework-internal) need to implement them.

### Verification

- `./gradlew :core:database:compileCommonMainKotlinMetadata` ✅
- `./gradlew :core-base:store:compileCommonMainKotlinMetadata` ✅
- `./gradlew :core-base:ui:compileCommonMainKotlinMetadata` ✅
- `./gradlew :core:data:compileCommonMainKotlinMetadata` ✅
- `./gradlew :feature:alerts:compileCommonMainKotlinMetadata` ✅
- `./gradlew detekt` on touched modules ✅
- `core-base/store` submit-package tests: **54/54 pass** (DraftResumeStateTest, DraftSubmitHandlerTest, MutationUiStateTest, OfflineSubmitSyncerTest, SubmitHandlerTest, SubmitStateExtensionsTest)
- `core-base/ui` tests: **41/41 pass** (LoadMoreFooterCopyTest, DataFreshnessIndicatorStateTest, DataFreshnessTextTest, ScreenStateDefaultsTest)
- Room schema `7.json` auto-exported and committed

## Test plan

- [ ] PR Checks workflow passes on dev
- [ ] Multi-Platform Build matrix passes (Android prod/demo × release; iOS; Desktop; Web)
- [ ] Schema `7.json` diff is clean (single nullable column add to `framework_submit_drafts`)
- [ ] `SetPriceAlertScreen` smoke-tested: save form online → submitted; save offline → DraftResumeBanner on next open; reconnect → auto-syncs via `OfflineSubmitSyncer`
- [ ] Home screen: WatchlistPreviewCard shows top 3 starred coins; ActiveAlertsCard shows top 3 active alerts; "See all" routes work
- [ ] No regressions in feature/crypto/CryptoWatchlistScreen (its routing changed)
- [ ] Deprecation warnings for `BaseMutationViewModel` typealias surface as warnings (not errors) in compileKotlin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added navigation support for personal watchlist and price alerts throughout the app.
  * Introduced watchlist preview and active alerts cards on the home screen.
  * Added "Add to Watchlist" button for individual crypto coins.
  * Enhanced price alert creation with automatic draft saving.

* **Improvements**
  * Strengthened draft persistence system to handle multiple concurrent drafts reliably.
  * Refined form state management for edit screens with durable draft support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/kmp-project-template/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->