### PR TITLE
chore(deps): bump kmp-product-flavors plugin 2.4.2 → 2.6.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 buildkonfig = "0.15.2"
-kmpProductFlavors = "2.4.2"
+kmpProductFlavors = "2.6.0"
 
 # ── Fork Identity — edit ONLY these 6 lines, then run ./gradlew syncForkConfig ──────────────────
 appId            = "org.mifos.kmp.template"   # Android applicationId + iOS bundle ID


### PR DESCRIPTION
## Summary

Picks up [kmp-product-flavors v2.6.0 GA](https://github.com/MobileByteLabs/kmp-product-flavors/releases/tag/2.6.0) published 2026-06-01. Single-line bump in `gradle/libs.versions.toml`; no convention-plugin or DSL changes required.

## Why now

The v2.6.0 release ships the **Tier E.1 fix** for the `"Unused Kotlin Source Sets"` warning that surfaced 2026-06-01 in this consumer's build logs:

```
[KMP Flavors] Applied Android applicationIdSuffix: .demo.debug
w: ⚠️ Unused Kotlin Source Sets
The Kotlin source set commonProd was configured but not added to any Kotlin compilation.
```

Local smoke test confirms the warning is gone after the bump:

| Command | v2.4.2 (before) | v2.6.0 (after) |
|---|---|---|
| `./gradlew :cmp-shared:tasks --warning-mode=all` | 1+ Unused-source-set warning | **0** |
| `./gradlew :cmp-navigation:generateFlavorBuildConfig` | OK | OK (identical output) |

### How v2.6.0 silences it

Default `createInactiveFlavorSourceSets=false` causes the plugin to silently SKIP creating the inactive `commonProd` source set (matrix mode is off here, so prod-flavor code is currently dead anyway). KGP never sees an orphan source set → no warning, structurally.

Hypothesis A (`commonProd.dependsOn(commonMain)`) was tried upstream in `2.5.0-alpha.2` and **disproved** — KGP's check is compilation-membership-based, not `dependsOn`-graph-based. v2.6 Tier E.1 ships Hypothesis D (opt-in flag).

## Other v2.6 features (all opt-in, no impact here)

| Feature | Opt-in path | Notes |
|---|---|---|
| KMP↔AGP variantFilter parity | Automatic | Forwards `kmpFlavors.variantFilter { exclude() }` to AGP's `beforeVariants`. Transparent. |
| Koin per-variant DI codegen | `di { koin { variantModule } }` | This template already wires Koin manually; opt-in only if you want auto-codegen. |
| Cross-platform analytics tags | `analytics { customTag }` | Useful for Firebase Crashlytics integration. |
| Conditional target exclusion | `variantFilter { excludeTargets(...) }` | Useful if `demo` doesn't need watchOS/tvOS. |
| Variant-aware Ktor base URLs | `buildKonfig { network { baseUrl } }` | Could replace the per-flavor `BASE_URL` `buildConfigField` declarations. |

See [upstream MIGRATION_v2.5_TO_v2.6.md](https://github.com/MobileByteLabs/kmp-product-flavors/blob/2.6.0/docs/MIGRATION_v2.5_TO_v2.6.md) for the cookbook (opens with "You do not need to migrate.").

## Version-floor unchanged

UNCHANGED across v2.4 → v2.5 → v2.6: Gradle 8.0+ / KGP 2.0.21+ / AGP 8.2+ / JDK 17+ / CMP 1.7.0+. This consumer at AGP 8.12.3 + Kotlin 2.3.20 is well clear of every floor.

## Test plan

- [ ] CI matrix green on the bump
- [ ] Confirm `./gradlew check --warning-mode=all` reports `0` `Unused Kotlin Source Sets` warnings
- [ ] Confirm both `demoDebug` (default active variant) and `prodRelease` (via `-PkmpFlavor=prodRelease`) build cleanly
- [ ] If anything looks off in CI, the upstream issue tracker has the full [Tier E.1 PR #108](https://github.com/MobileByteLabs/kmp-product-flavors/pull/108) context (now folded into [#107](https://github.com/MobileByteLabs/kmp-product-flavors/pull/107))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded kmp-product-flavors plugin to version 2.6.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->