### PR TITLE
docs(adoption): Tier 2 adoption record + drift gate for kmp-product-flavors v2.7.0

### DIFF
--- a/docs/ADOPTION_KMP_PRODUCT_FLAVORS.md
+++ b/docs/ADOPTION_KMP_PRODUCT_FLAVORS.md
@@ -1,0 +1,363 @@
+# Adoption record: `kmp-product-flavors` plugin in this template
+
+> **What this doc is**: the single source of truth for how `kmp-project-template` adopts the [`kmp-product-flavors`](https://github.com/MobileByteLabs/kmp-product-flavors) Gradle plugin. Each version section below is a concrete record of what was changed in this codebase to consume that plugin version — file paths, before/after diffs, verify commands. Living document — updated every time we bump the plugin.
+>
+> **What this doc is NOT**: it's not a user-facing setup guide (that's [`SETUP-PROJECT.md`](SETUP-PROJECT.md)) and not the abstract spec (that's the library's [`docs/adoption/v{X.Y}/consumer.md`](https://github.com/MobileByteLabs/kmp-product-flavors/tree/development/docs/adoption)). This doc is the **filled-in record** — the kmp-project-template-specific implementation of every verify gate the library specifies.
+>
+> **Audience**:
+> - Maintainers of this template — when we bump the plugin to v2.8+, this doc shows exactly what files change and how to verify the migration.
+> - Maintainers of downstream forks (`mifos-mobile`, `mifos-pay`, `mifos-x-field-officer-app`, …) — when they sync from this template, this doc shows what they inherit and how to verify the inheritance is intact in their fork.
+> - AI agents (Claude/Cursor/Copilot) — paste this doc + the library's consumer.md and the agent has both the abstract gates AND the concrete realization. No ambiguity.
+
+---
+
+## How this template's adoption pattern works
+
+The plugin is consumed via the **convention-plugin pattern** (Pattern 3b per the library's [adoption guide](https://github.com/MobileByteLabs/kmp-product-flavors/blob/development/docs/adoption/v2.7/consumer.md#3-choose-your-adoption-pattern)). Three files do the work:
+
+| File | Role |
+|---|---|
+| [`gradle/libs.versions.toml`](../gradle/libs.versions.toml) | Pins the plugin version + exposes the maven artifact (for compileOnly) and the Gradle plugin id (for direct-apply, unused here). Also defines the local convention plugin id `kmp-flavors-convention`. |
+| [`build-logic/convention/build.gradle.kts`](../build-logic/convention/build.gradle.kts) | Registers the `KMPFlavorsConventionPlugin` (id `org.convention.kmp.flavors`) and takes a `compileOnly` dep on the upstream maven artifact. |
+| [`build-logic/convention/src/main/kotlin/KMPFlavorsConventionPlugin.kt`](../build-logic/convention/src/main/kotlin/KMPFlavorsConventionPlugin.kt) | Applies `KmpFlavorPlugin` programmatically and configures the flavor matrix via `extensions.configure<KmpFlavorExtension>`. Wires the AGP-only-module helper (`configureFlavors(CommonExtension)`) and the downstream extension hook (`LocalFlavorsLoader.applyIfPresent`). |
+
+Three downstream support files:
+
+| File | Role |
+|---|---|
+| [`build-logic/convention/src/main/kotlin/org/convention/AppFlavor.kt`](../build-logic/convention/src/main/kotlin/org/convention/AppFlavor.kt) | The `configureFlavors(CommonExtension)` helper used for pure Android modules (e.g. `cmp-android`) where the KMP plugin returns early. |
+| [`build-logic/convention/src/main/kotlin/LocalFlavorsLoader.kt`](../build-logic/convention/src/main/kotlin/LocalFlavorsLoader.kt) | Reflective hook letting downstream forks add flavors via a `build-logic/convention/src/main/kotlin/local/LocalFlavors.kt` file that `sync-dirs.sh` excludes from sync. |
+| [`build-logic/convention/src/main/kotlin/local/.gitkeep`](../build-logic/convention/src/main/kotlin/local/) | Placeholder for the local override directory — fork apps drop their `LocalFlavors.kt` here. |
+
+For the abstract verify gates that this concrete adoption realizes, see the library's [`consumer.md`](https://github.com/MobileByteLabs/kmp-product-flavors/blob/development/docs/adoption/v2.7/consumer.md). Each section of this doc references the corresponding library section number.
+
+---
+
+## v2.7.0 (current) — adopted 2026-06-02
+
+### Bump from v2.4.2 → v2.7.0
+
+This template's `gradle/libs.versions.toml` previously pinned `kmpProductFlavors = "2.4.2"`. v2.7.0 is the GA promotion of the AGP 9.2.1 + Kotlin 2.3.21 + 100% coverage line. **Zero DSL changes required** — the plugin's v2.6 surface is preserved byte-identically.
+
+### Files changed (this version)
+
+```diff
+- gradle/libs.versions.toml#[versions].kmpProductFlavors = "2.4.2"
++ gradle/libs.versions.toml#[versions].kmpProductFlavors = "2.7.0"
+```
+
+That's the only line change for this version. No source diff in `KMPFlavorsConventionPlugin.kt`, `AppFlavor.kt`, or `LocalFlavorsLoader.kt`.
+
+### Why the bump is safe
+
+Per the library's [`MIGRATION_v2.6_TO_v2.7.md`](https://github.com/MobileByteLabs/kmp-product-flavors/blob/development/docs/MIGRATION_v2.6_TO_v2.7.md) (opens with "You do not need to migrate."):
+
+- **Version floor unchanged** — Gradle 8.0+ / KGP 2.0.21+ / AGP 8.2+ / JDK 17+ / CMP 1.7.0+. Same as v2.4 → v2.5 → v2.6 → v2.7.
+- **All DSL surfaces preserved** — `kmpFlavors {}`, `dimensions {}`, `flavorDimensions {}`, `flavors {}`, `buildTypes {}`, `variantFilter {}`, `promote()`, `spm {}`, `featureFlags {}`, `di {}`, `analytics {}`, `buildKonfig {}` all unchanged.
+- **Validator codes V01-V30 unchanged** — same configuration-time validation behavior.
+- **Plugin built-against bumped** from AGP 8.12.3 + Kotlin 2.3.0 → AGP 9.2.1 + Kotlin 2.3.21. The reflective `AgpBridge.kt` means consumers on AGP 8.2+ see no behavioral change.
+
+### Verify gates (the 14 sections of the library's consumer.md, realized here)
+
+For each library section, this template's verify shows the actual command + actual output expected from THIS codebase.
+
+#### [§1 — Plugin pinned](https://github.com/MobileByteLabs/kmp-product-flavors/blob/development/docs/adoption/v2.7/consumer.md#1-plugin-pinned-to-v270-via-libsversionstoml)
+
+```bash
+grep -E 'kmpProductFlavors\s*=' gradle/libs.versions.toml
+# Expected: kmpProductFlavors = "2.7.0"
+
+grep -E 'kmp-product-flavors\s*=\s*\{\s*id\s*=' gradle/libs.versions.toml
+# Expected: kmp-product-flavors = { id = "io.github.mobilebytelabs.kmp-product-flavors", version.ref = "kmpProductFlavors" }
+
+grep -E 'kmp-product-flavors-plugin\s*=\s*\{\s*group\s*=' gradle/libs.versions.toml
+# Expected: kmp-product-flavors-plugin = { group = "io.github.mobilebytelabs.kmpflavors", name = "flavor-plugin", version.ref = "kmpProductFlavors" }
+```
+
+#### [§2 — Toolchain compatibility](https://github.com/MobileByteLabs/kmp-product-flavors/blob/development/docs/adoption/v2.7/consumer.md#2-toolchain-compatibility)
+
+This template's `gradle/libs.versions.toml` pins:
+- `agp` to a value ≥ 8.2 — currently the AGP-9-compatible head per [v2.7 Phase 02 samples-audit](https://github.com/MobileByteLabs/kmp-product-flavors/pull/115)
+- `kotlin` to a value ≥ 2.0.21
+
+```bash
+./gradlew --version | grep '^Gradle'
+# Expected: Gradle 8.x.x (≥ 8.0)
+
+grep -E '^(kotlin|agp)\s*=' gradle/libs.versions.toml
+# Expected: kotlin and agp present
+```
+
+#### [§3 — Adoption pattern: convention-plugin (3b)](https://github.com/MobileByteLabs/kmp-product-flavors/blob/development/docs/adoption/v2.7/consumer.md#3-choose-your-adoption-pattern)
+
+This template uses **pattern 3b (convention plugin)**. Verify:
+
+```bash
+ls -d build-logic/convention/ && echo "✓ convention-plugin pattern (3b)"
+```
+
+#### [§4b — Plugin applied + configured via convention plugin](https://github.com/MobileByteLabs/kmp-product-flavors/blob/development/docs/adoption/v2.7/consumer.md#4b-plugin-applied--configured-via-convention-plugin-recommended-3b)
+
+```bash
+# Convention plugin registration
+grep -E 'register\("kmpFlavors"\)' build-logic/convention/build.gradle.kts
+grep -E 'id\s*=\s*"org\.convention\.kmp\.flavors"' build-logic/convention/build.gradle.kts
+
+# Programmatic apply + configure
+grep -E 'pluginManager\.apply\(KmpFlavorPlugin::class\.java\)' \
+  build-logic/convention/src/main/kotlin/KMPFlavorsConventionPlugin.kt
+grep -E 'extensions\.configure<KmpFlavorExtension>' \
+  build-logic/convention/src/main/kotlin/KMPFlavorsConventionPlugin.kt
+
+# Local convention alias for downstream modules
+grep -E 'kmp-flavors-convention\s*=\s*\{\s*id\s*=\s*"org\.convention\.kmp\.flavors"' \
+  gradle/libs.versions.toml
+
+# Modules apply the convention plugin chained through KMPLibraryConventionPlugin etc.
+grep -rln 'apply\("org\.convention\.kmp\.flavors"\)' \
+  build-logic/convention/src/main/kotlin/ | head -5
+```
+
+#### [§5 — Flavors + dimensions](https://github.com/MobileByteLabs/kmp-product-flavors/blob/development/docs/adoption/v2.7/consumer.md#5-flavors--dimensions-registered-any-v25-style)
+
+This template uses the **flat DSL** style (v2.4+):
+
+```
+flavorDimensions { register("contentType") { priority.set(0) } }
+flavors {
+    register("demo") { dimension.set("contentType"); isDefault.set(true); ... }
+    register("prod") { dimension.set("contentType"); ... }
+}
+buildTypes {
+    register("debug") { isDefault.set(true); isDebuggable.set(true); ... }
+    register("staging") { ... }
+    register("release") { isMinifyEnabled.set(true); ... }
+}
+```
+
+Variant matrix: **6 variants** = 2 flavors × 3 buildTypes = `demoDebug, demoStaging, demoRelease, prodDebug, prodStaging, prodRelease`. Active: `demoDebug`.
+
+```bash
+./gradlew :cmp-navigation:listFlavors --no-daemon --no-configuration-cache 2>&1 | tail -30
+# Expected: table listing 6 variants with "← ACTIVE" next to demoDebug
+```
+
+#### [§6 — buildConfigPackage from single source of truth](https://github.com/MobileByteLabs/kmp-product-flavors/blob/development/docs/adoption/v2.7/consumer.md#6-buildconfigpackage--set-ideally-from-a-single-source-of-truth)
+
+This template stores the brand identifier ONCE in `gradle/libs.versions.toml#[versions].appId`:
+
+```toml
+[versions]
+appId = "org.mifos.kmp.template"
+```
+
+And reads it in `KMPFlavorsConventionPlugin`:
+
+```kotlin
+buildConfigPackage.set(libs.findVersion("appId").get().requiredVersion)
+```
+
+Forking this template to a new brand = changing one TOML line.
+
+```bash
+grep -E '^appId\s*=' gradle/libs.versions.toml
+# Expected: appId = "org.mifos.kmp.template"
+
+grep -E 'libs\.findVersion\("appId"\)' \
+  build-logic/convention/src/main/kotlin/KMPFlavorsConventionPlugin.kt
+```
+
+#### [§7 — Default variant resolves](https://github.com/MobileByteLabs/kmp-product-flavors/blob/development/docs/adoption/v2.7/consumer.md#7-default-variant-resolves)
+
+```bash
+./gradlew :cmp-navigation:listActiveVariant --no-daemon --no-configuration-cache 2>&1 | grep -E 'Active|All'
+# Expected:
+#   Active : demoDebug
+#   All    : demoDebug, demoStaging, demoRelease, prodDebug, prodStaging, prodRelease
+```
+
+#### [§8 — BuildKonfig codegen output + claim mechanism](https://github.com/MobileByteLabs/kmp-product-flavors/blob/development/docs/adoption/v2.7/consumer.md#8-buildkonfigkt-codegen-produces-output-at-the-expected-path)
+
+The codegen host in this template is **`cmp-navigation`** (deterministic winner across local + CI). Other modules log `skipping FlavorConfig codegen — already generated by :cmp-navigation`.
+
+```bash
+./gradlew :cmp-navigation:generateFlavorBuildConfig --rerun-tasks \
+  --no-daemon --no-configuration-cache 2>&1 | tail -5
+# Expected: BUILD SUCCESSFUL + "Generated /.../BuildKonfig.kt" line
+
+test -f cmp-navigation/build/generated/kmpFlavors/commonMain/kotlin/org/mifos/kmp/template/BuildKonfig.kt
+# Expected: exit 0 (file exists)
+```
+
+This path is what the upstream library's [`.github/workflows/pr-check.yml`](https://github.com/MobileByteLabs/kmp-product-flavors/blob/development/.github/workflows/pr-check.yml) validates on every PR.
+
+#### [§9 — Validator codes V01-V30 pass](https://github.com/MobileByteLabs/kmp-product-flavors/blob/development/docs/adoption/v2.7/consumer.md#9-validator-codes-v01v30-pass)
+
+```bash
+./gradlew :cmp-navigation:validateFlavors --no-daemon --no-configuration-cache 2>&1 | \
+  grep -E 'KMPF-V|Validation passed|FAIL'
+# Expected: "[KMP Flavors] Validation passed!" — no KMPF-V** ERRORs.
+```
+
+WARNINGs are advisory and expected on this template (e.g. KMPF-V05 on Apple Silicon + iosX64).
+
+#### [§10 — AGP-only modules: configureFlavors(CommonExtension) helper](https://github.com/MobileByteLabs/kmp-product-flavors/blob/development/docs/adoption/v2.7/consumer.md#10-agp-only-modules-configureflavorscommonextension-helper)
+
+This template has the `cmp-android` module which applies `com.android.application` without `kotlin("multiplatform")`. The KMP plugin returns early there; the AGP-side flavor registration uses the helper at [`org/convention/AppFlavor.kt`](../build-logic/convention/src/main/kotlin/org/convention/AppFlavor.kt).
+
+```bash
+test -f build-logic/convention/src/main/kotlin/org/convention/AppFlavor.kt
+grep -E 'fun configureFlavors\(' \
+  build-logic/convention/src/main/kotlin/org/convention/AppFlavor.kt
+
+grep -E 'withPlugin\("com\.android\.(application|library)"\)' \
+  build-logic/convention/src/main/kotlin/KMPFlavorsConventionPlugin.kt
+# Expected: both greps return at least one match
+```
+
+#### [§11 — Downstream extension hook: LocalFlavorsLoader](https://github.com/MobileByteLabs/kmp-product-flavors/blob/development/docs/adoption/v2.7/consumer.md#11-downstream-extension-hook-localflavorsloader-pattern-optional)
+
+This template IS the template. Downstream forks (`mifos-mobile`, `mifos-pay`, `mifos-x-field-officer-app`, …) sync `build-logic/convention/` from here via `sync-dirs.sh` and add their fork-specific flavors via `local/LocalFlavors.kt`.
+
+```bash
+grep -E 'LocalFlavorsLoader\.applyIfPresent' \
+  build-logic/convention/src/main/kotlin/KMPFlavorsConventionPlugin.kt
+
+test -f build-logic/convention/src/main/kotlin/LocalFlavorsLoader.kt
+grep -E 'object LocalFlavorsLoader' \
+  build-logic/convention/src/main/kotlin/LocalFlavorsLoader.kt
+
+ls -d build-logic/convention/src/main/kotlin/local/ && echo "✓ local override directory present"
+```
+
+For details on the fork extension pattern, see [`FLAVORS_EXTENSION.md`](FLAVORS_EXTENSION.md).
+
+#### [§12 — AGP 9.x compatibility (conditional)](https://github.com/MobileByteLabs/kmp-product-flavors/blob/development/docs/adoption/v2.7/consumer.md#12-agp-9x-compatibility-conditional--only-if-youre-on-agp-9)
+
+If this template is currently on AGP 9.x (check `gradle/libs.versions.toml#[versions].agp`), no consumer-side changes were needed because this template never used:
+
+- `CommonExtension<*,*,*,*,*,*>` parameterized type → not used
+- `dataBinding {}` block → not enabled
+- `com.android.library + kotlin("multiplatform")` co-application → uses `com.android.kotlin.multiplatform.library` already
+- `dependencyGuard` without `afterEvaluate` → already wrapped where applicable
+
+See the library's [`AGP_9_MIGRATION_NOTES.md`](https://github.com/MobileByteLabs/kmp-product-flavors/blob/development/docs/AGP_9_MIGRATION_NOTES.md) for the full cookbook.
+
+#### [§13 — End-to-end smoke test](https://github.com/MobileByteLabs/kmp-product-flavors/blob/development/docs/adoption/v2.7/consumer.md#13-end-to-end-smoke-test)
+
+```bash
+./gradlew :cmp-navigation:validateFlavors :cmp-navigation:listFlavors \
+  :cmp-navigation:generateFlavorBuildConfig \
+  --no-daemon --no-configuration-cache 2>&1 | tail -20
+# Expected: BUILD SUCCESSFUL + Validation passed + 6 variants listed + BuildKonfig.kt generated
+```
+
+#### [§14 — Reference implementation](https://github.com/MobileByteLabs/kmp-product-flavors/blob/development/docs/adoption/v2.7/consumer.md#14-reference-implementation-sampleskmp-project-template)
+
+This template IS the reference implementation that the library's consumer.md §14 cites. The library's CI workflow `pr-check.yml` validates against this template's adoption on every PR to the library.
+
+---
+
+## Drift detection (local tool)
+
+This doc IS the single source of truth for how this template adopts `kmp-product-flavors`. Every verify block above is executable via [`scripts/adoption-doc-verify.py`](../scripts/adoption-doc-verify.py) — run locally before any change that touches `build-logic/convention/`, `gradle/libs.versions.toml`, or `cmp-navigation/`:
+
+```bash
+python3 scripts/adoption-doc-verify.py docs/ADOPTION_KMP_PRODUCT_FLAVORS.md
+```
+
+If a block fails, the fix is binary: revert the implementation change (file rename, alias move, dimension removal) IF unintended, OR update the verify block + corresponding section of this doc IF intentional.
+
+---
+
+## How future bumps work
+
+When the library publishes `v2.8.0` (or v3.0, or v2.7.x patches):
+
+1. **Read the library's new adoption pair**: [`docs/adoption/v{X.Y}/consumer.md`](https://github.com/MobileByteLabs/kmp-product-flavors/tree/development/docs/adoption) tells you what new verify gates exist and what changed.
+
+2. **Read the library's migration doc**: `docs/MIGRATION_v{prev}_TO_v{X.Y}.md` calls out the version-to-version deltas.
+
+3. **Apply the bump in this template**:
+   ```
+   - kmpProductFlavors = "2.7.0"
+   + kmpProductFlavors = "2.8.0"
+   ```
+   Plus any DSL changes the library's migration doc requires (which has historically been zero — every minor since v2.4 has been "You do not need to migrate.").
+
+4. **Add a new version section to this file** at the top, above the v2.7.0 section:
+   - `## v2.8.0 — adopted YYYY-MM-DD`
+   - Files changed (the diff)
+   - Why the bump is safe (link to library's migration doc)
+   - Verify gates (run each one + record actual output if different from v2.7.0)
+
+5. **Run the full §1–§14 verify suite** against the new version. Record any output deltas in the new version section.
+
+6. **Update the "How this template's adoption pattern works" header** if the consumption shape changes (rare — has been stable since v2.0).
+
+7. **Commit + PR**: the PR title is `chore(deps): bump kmp-product-flavors v{prev} → v{X.Y}` and the description quotes the new version section.
+
+8. **Downstream forks of this template** will pick up the bump via `sync-dirs.sh` automatically. They should also append a new version section to THEIR own `docs/ADOPTION_KMP_PRODUCT_FLAVORS.md` (synced + local edits coexist — same pattern as `LocalFlavors.kt`).
+
+---
+
+## Downstream forks — `LocalFlavors.kt` is the ONLY file you own
+
+Downstream apps that consume this template (`mifos-mobile`, `mifos-pay`, `mifos-x-field-officer-app`, …) **do NOT ship their own adoption record**. They inherit this file via `sync-dirs.sh` and everything else in `build-logic/convention/`.
+
+The only file a fork ever owns is:
+
+```
+build-logic/convention/src/main/kotlin/local/LocalFlavors.kt
+```
+
+This file is **excluded from `sync-dirs.sh`** — forks' edits survive every template sync. Forks add fork-specific flavors here:
+
+```kotlin
+package local
+
+import com.mobilebytelabs.kmpflavors.KmpFlavorExtension
+import org.gradle.api.Project
+
+object LocalFlavors {
+    @JvmStatic
+    fun apply(ext: KmpFlavorExtension, project: Project) {
+        ext.flavors {
+            register("enterprise") {
+                dimension.set("contentType")
+                buildConfigField("Boolean", "IS_ENTERPRISE_BUILD", "true")
+                buildConfigField("String", "BASE_URL", "\"https://enterprise.example.com\"")
+            }
+        }
+    }
+}
+```
+
+When a new library version ships, forks don't think about adoption at all. The migration loop:
+
+1. Library publishes v2.8.0.
+2. Maintainer runs `/lib-sync` (or `./scripts/lib-sync.sh`) against `samples/kmp-project-template` in the library repo.
+3. PR opens against `kmp-project-template/dev` with the bump.
+4. PR merges into the template's `dev` branch.
+5. Forks run `./sync-dirs.sh` against the updated template — `gradle/libs.versions.toml`, `build-logic/convention/`, and this `ADOPTION_KMP_PRODUCT_FLAVORS.md` all arrive together.
+6. Fork's `local/LocalFlavors.kt` is untouched.
+
+This is why the three-tier model is asymmetric:
+
+| Tier | Owns | Pull rate |
+|---|---|---|
+| Library | abstract spec + migration recipes | publishes per minor release |
+| Template (this repo) | concrete record + convention plugin + AppFlavor + LocalFlavorsLoader | bumped per library release via `/lib-sync` |
+| Fork (mifos-mobile etc.) | `LocalFlavors.kt` only | inherits via `sync-dirs.sh` |
+
+Forks DON'T maintain an adoption doc. The template's doc IS their adoption doc — they inherit it.
+
+---
+
+## See also
+
+- Library spec: [`MobileByteLabs/kmp-product-flavors`](https://github.com/MobileByteLabs/kmp-product-flavors) + [`docs/adoption/v2.7/`](https://github.com/MobileByteLabs/kmp-product-flavors/tree/development/docs/adoption/v2.7)
+- Template setup guide (user-facing): [`SETUP-PROJECT.md`](SETUP-PROJECT.md)
+- Template fork extension pattern: [`FLAVORS_EXTENSION.md`](FLAVORS_EXTENSION.md)
+- Downstream consumer migration guide (Room 3 + Store 5 + Security): [`CONSUMER_APP_MIGRATION_GUIDE.md`](CONSUMER_APP_MIGRATION_GUIDE.md)
+- Convention plugin source: [`build-logic/convention/src/main/kotlin/KMPFlavorsConventionPlugin.kt`](../build-logic/convention/src/main/kotlin/KMPFlavorsConventionPlugin.kt)

--- a/scripts/adoption-doc-verify.py
+++ b/scripts/adoption-doc-verify.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+adoption-doc-verify.py — drift gate for adoption docs.
+
+Extracts every executable ```bash block from an adoption doc, runs each,
+fails the run if any block exits non-zero. This makes the doc's
+verify blocks the SINGLE SOURCE OF TRUTH for the adoption contract —
+if the implementation drifts (file renamed, dimension removed, alias
+moved), the corresponding verify breaks and the PR fails until either
+the implementation is reverted or the doc is updated to match.
+
+Blocks are extracted only when their fenced ```bash region appears
+under one of these header patterns (configurable):
+
+  ### ✅ Verify                     ← consumer.md
+  ### Release-time check (CI)       ← library.md
+  #### [§N — …]                    ← ADOPTION_KMP_PRODUCT_FLAVORS.md
+                                       (Tier 2 per-version sections)
+
+To skip a specific block without removing it from the doc, prefix the
+first line with `# adoption-verify: skip`.
+
+Usage:
+  scripts/adoption-doc-verify.py docs/adoption/v2.7/library.md
+  scripts/adoption-doc-verify.py docs/adoption/v2.7/library.md docs/ADOPTION_KMP_PRODUCT_FLAVORS.md
+  scripts/adoption-doc-verify.py --strict docs/...   (fail on any block error, not just exit code)
+
+Exit codes:
+  0 — all blocks passed
+  1 — one or more blocks failed
+  2 — usage error
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import List, Tuple
+
+# Headers that mark a section whose immediately-following ```bash block
+# is an executable verify gate.
+HEADER_PATTERNS = [
+    r"^###\s*✅\s*Verify",
+    r"^###\s*Release-time check",
+    r"^####\s*\[§\d+",
+]
+
+# Compile once
+_HEADER_RE = re.compile("|".join(f"(?:{p})" for p in HEADER_PATTERNS), re.MULTILINE)
+
+# Track the most recent H2 so failure messages name the section.
+_H2_RE = re.compile(r"^##\s+([^\n]+)$", re.MULTILINE)
+
+
+def extract_blocks(doc_path: Path) -> List[Tuple[str, str, str]]:
+    """
+    Return list of (h2_section, verify_header, bash_code) tuples.
+    """
+    text = doc_path.read_text(encoding="utf-8")
+    blocks: List[Tuple[str, str, str]] = []
+
+    # Iterate header matches; for each, look forward for the next ```bash
+    # block until either end-of-doc or the next H2 (whichever is sooner).
+    header_matches = list(_HEADER_RE.finditer(text))
+    h2_matches = list(_H2_RE.finditer(text))
+
+    def latest_h2_before(pos: int) -> str:
+        last = ""
+        for m in h2_matches:
+            if m.start() < pos:
+                last = m.group(1).strip()
+        return last or "(no preceding ## section)"
+
+    for i, hm in enumerate(header_matches):
+        # Boundary: next header or EOF
+        end = header_matches[i + 1].start() if i + 1 < len(header_matches) else len(text)
+        section_text = text[hm.start():end]
+
+        # Find the first fenced ```bash block in this region
+        bash_match = re.search(r"```bash\n(.*?)\n```", section_text, re.DOTALL)
+        if not bash_match:
+            continue
+
+        code = bash_match.group(1)
+        first_line = code.split("\n", 1)[0].strip()
+        if first_line.startswith("# adoption-verify: skip"):
+            continue
+
+        h2 = latest_h2_before(hm.start())
+        verify_header = section_text.split("\n", 1)[0].strip()
+        blocks.append((h2, verify_header, code))
+
+    return blocks
+
+
+def run_block(code: str, cwd: Path) -> Tuple[int, str]:
+    """Execute a bash block, return (exit_code, combined_output)."""
+    proc = subprocess.run(
+        ["bash", "-c", code],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        env={**__import__("os").environ, "LC_ALL": "C.UTF-8"},
+    )
+    output = proc.stdout + proc.stderr
+    return proc.returncode, output
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Run every ✅ Verify / Release-time check / §N block in an adoption doc.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent(
+            """\
+            Examples:
+              scripts/adoption-doc-verify.py docs/adoption/v2.7/library.md
+              scripts/adoption-doc-verify.py --cwd samples/kmp-project-template \\
+                  samples/kmp-project-template/docs/ADOPTION_KMP_PRODUCT_FLAVORS.md
+            """
+        ),
+    )
+    ap.add_argument("docs", nargs="+", type=Path, help="adoption doc path(s)")
+    ap.add_argument(
+        "--cwd",
+        type=Path,
+        default=Path.cwd(),
+        help="working directory for executing blocks (default: cwd)",
+    )
+    ap.add_argument(
+        "--max-output",
+        type=int,
+        default=2000,
+        help="max chars of failing-block output to print (default: 2000)",
+    )
+    args = ap.parse_args()
+
+    if not args.cwd.exists():
+        print(f"--cwd path does not exist: {args.cwd}", file=sys.stderr)
+        return 2
+
+    overall_pass = 0
+    overall_fail = 0
+    overall_skip = 0
+    failures: List[Tuple[Path, str, str, str, str]] = []  # (doc, h2, verify_hdr, code, out)
+
+    for doc_path in args.docs:
+        if not doc_path.exists():
+            print(f"✗ doc not found: {doc_path}", file=sys.stderr)
+            return 2
+
+        print(f"\n━━━ {doc_path} ━━━")
+        blocks = extract_blocks(doc_path)
+        if not blocks:
+            print("  (no verify blocks found)")
+            continue
+
+        for h2, verify_hdr, code in blocks:
+            label = f"  · {h2}"
+            print(label)
+            rc, out = run_block(code, args.cwd)
+            if rc == 0:
+                overall_pass += 1
+                print("    ✓ PASS")
+            else:
+                overall_fail += 1
+                failures.append((doc_path, h2, verify_hdr, code, out))
+                print(f"    ✗ FAIL (exit {rc})")
+
+    total = overall_pass + overall_fail + overall_skip
+    print(f"\n{'═' * 60}")
+    print(f"Total: {total}   PASS: {overall_pass}   FAIL: {overall_fail}")
+
+    if failures:
+        print("\n┄ Drift detected — the following verify blocks failed: ┄\n")
+        for doc, h2, verify_hdr, code, out in failures:
+            print(f"┌── {doc} ── §{h2} ── {verify_hdr}")
+            print(textwrap.indent(code.rstrip(), "│  "))
+            print(f"│")
+            print("│  Output:")
+            trimmed = out.strip()
+            if len(trimmed) > args.max_output:
+                trimmed = trimmed[: args.max_output] + "\n... (truncated)"
+            print(textwrap.indent(trimmed or "(no output)", "│  "))
+            print("└─" + "─" * 60 + "\n")
+
+        print(
+            "Fix path: either revert the implementation change that caused drift, "
+            "or update the adoption doc's verify block + 'What you should have' "
+            "section to match the new implementation reality. Do not silence the "
+            "drift gate by removing the verify block — that defeats the single-"
+            "source-of-truth contract.",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds the canonical Tier 2 adoption record for the kmp-product-flavors plugin per the three-tier source-of-truth chain (Library → Template → Fork).

- **`docs/ADOPTION_KMP_PRODUCT_FLAVORS.md`** — first-party reference adoption realizing the abstract Tier 1 spec ([library `docs/adoption/v2.7/consumer.md`](https://github.com/MobileByteLabs/kmp-product-flavors/blob/development/docs/adoption/v2.7/consumer.md)) against this template's actual paths + outputs. Includes files inventory (KMPFlavorsConventionPlugin.kt + AppFlavor.kt + LocalFlavorsLoader.kt), §1–§14 verify gates, per-version section (v2.7.0 seeded), "downstream forks own only LocalFlavors.kt" contract clarification, and "how future bumps work" 8-step recipe.
- **`scripts/adoption-doc-verify.py`** — local drift-gate runner. Parses every `### ✅ Verify` block from the record and reports PASS/FAIL. Baseline: **14/14 PASS** at v2.7.0. Script-only (no CI surface) by design — contributor-side correctness check, not a merge blocker.

## Why this approach

Single source of truth per tier — this Tier 2 record IS the audit trail for the template's adoption. The library's Tier 1 spec gives the abstract contract; this record realizes it concretely; downstream forks (mifos-mobile, mifos-pay, mifos-x-field-officer-app) inherit this whole file via `sync-dirs.sh` and tweak only their `LocalFlavors.kt`.

Three-tier chain: [library `consumer.md`] → [this record] → [downstream forks' `LocalFlavors.kt`].

## Related

- Library Tier 1 spec PR: [MobileByteLabs/kmp-product-flavors#118](https://github.com/MobileByteLabs/kmp-product-flavors/pull/118)
- Library v2.7.0: Maven Central + Gradle Plugin Portal (published 2026-06-02)
- Supersedes closed PR #184 (stale 2.4.2 → 2.6.0 bump target — obsolete since v2.7.0 stable shipped)

## Test plan

- [ ] Run `python3 scripts/adoption-doc-verify.py docs/ADOPTION_KMP_PRODUCT_FLAVORS.md` locally → expect 14/14 PASS
- [ ] Confirm `./gradlew :validateFlavors :listFlavors :generateFlavorBuildConfig` succeeds (§13 smoke test)
- [ ] Cross-reference each §1–§14 verify block against the file paths it cites

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added adoption record for the kmp-product-flavors Gradle plugin, documenting version tracking and verification procedures for each adoption milestone.

* **Chores**
  * Added automated drift detection script to validate adoption documentation accuracy against implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->