### PR TITLE
ci(release): bump actionhub orchestrator pin v1.0.22 → v1.0.23

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,10 +1,32 @@
 # GitHub Actions - CI/CD Infrastructure
 
-**Last Updated:** 2026-02-13
-**Reusable Workflows:** `openMF/mifos-x-actionhub@v1.0.8`
+**Last Updated:** 2026-06-18
+**Reusable Workflows:** [openMF/mifos-x-actionhub — releases](https://github.com/openMF/mifos-x-actionhub/releases) (workflows pin specific tags; check actual `.github/workflows/*.yml` files for the live pin)
 **Custom Actions:** 13 total (4 Android, 4 iOS, 2 macOS, 1 Desktop, 1 Web, 1 Static Analysis)
 
 [← Back to Main](../CLAUDE.md)
+
+---
+
+> 📌 **About version pins in this document**
+>
+> Throughout this guide you'll see references like `@v1.0.8`, `@v1.0.2`, etc. — those are **the versions in use at the time this section was last reviewed**, not necessarily the current pin. The authoritative source for the version any workflow uses is **the workflow file itself**:
+>
+> ```bash
+> grep "openMF/mifos-x-actionhub" .github/workflows/*.yml
+> ```
+>
+> For the **latest available release** of each repo, browse:
+>
+> | Repo | Releases |
+> |---|---|
+> | `openMF/mifos-x-actionhub` (orchestrator) | [releases page](https://github.com/openMF/mifos-x-actionhub/releases) |
+> | `*-publish-android-kmp` | [releases](https://github.com/openMF/mifos-x-actionhub-publish-android-kmp/releases) |
+> | `*-publish-apple-kmp` (iOS + macOS) | [releases](https://github.com/openMF/mifos-x-actionhub-publish-apple-kmp/releases) |
+> | `*-publish-desktop-kmp` | [releases](https://github.com/openMF/mifos-x-actionhub-publish-desktop-kmp/releases) |
+> | `*-publish-web-kmp` | [releases](https://github.com/openMF/mifos-x-actionhub-publish-web-kmp/releases) |
+>
+> When bumping a pin, update the workflow `.yml` — **don't try to bump every doc reference**. The doc is descriptive; the workflow is authoritative.
 
 ---
 

--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -1,6 +1,6 @@
 # .github/workflows/release-multi-platform.yml
 #
-# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.22
+# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.23
 #
 # All orchestration logic lives in the centralized reusable workflow.
 # This file just declares the dispatch inputs + passes secrets through.
@@ -105,7 +105,7 @@ on:
 jobs:
   release:
     name: Release
-    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.22
+    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.23
     with:
       version_tag:          ${{ inputs.version_tag }}
       android_package_name: cmp-android


### PR DESCRIPTION
## Summary

Bump the Release · Multi-Platform orchestrator pin from `@v1.0.22` to `@v1.0.23` to absorb the workflow-parse-time fix in [openMF/mifos-x-actionhub#60](https://github.com/openMF/mifos-x-actionhub/pull/60).

## Why

`@v1.0.22` transitively pinned `publish-web-kmp@v2.0.5` which had a dynamic `uses:` form rejected by GitHub Actions at parse time:

```
Invalid workflow file: .github/workflows/release-multi-platform.yml#L108
error parsing called workflow
".github/workflows/release-multi-platform.yml"
  -> "openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.22"
  --> "therajanmaurya/mifos-x-actionhub-publish-web-kmp/.github/workflows/release.yaml@v2.0.5"
Unrecognized named-value: 'inputs'. Located at position 1 within expression: inputs.host
```

The parser walks every transitive reusable workflow before any input is bound — even non-web dispatches were blocked. Affected every `Release · Multi-Platform` run.

## Coordinated release

| Tier | Repo | PR | Tag |
|---|---|---|---|
| 3 | `therajanmaurya/mifos-x-actionhub-publish-web-kmp` | [#3](https://github.com/therajanmaurya/mifos-x-actionhub-publish-web-kmp/pull/3) ✅ | **v2.0.6** ✅ |
| 2 | `openMF/mifos-x-actionhub` | [#60](https://github.com/openMF/mifos-x-actionhub/pull/60) ✅ | **v1.0.23** ✅ |
| 1 | `openMF/kmp-project-template` (this PR) | this PR | — |

## What landed in v2.0.6 / v1.0.23

`publish-web-kmp/release.yaml` replaced the 3 dynamic-uses steps with 12 per-host conditional static-uses steps (4 hosts × 3 stages), gated by `if: inputs.host == '…'`. Only the matching step runs per dispatch. All other workflow logic preserved.

`mifos-x-actionhub/release-multi-platform-v2.yaml` line 346 bumped its internal `publish-web-kmp` pin from `@v2.0.5` → `@v2.0.6`.

## Diff

```diff
-# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.22
+# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.23

-uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.23
+uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.23
```

## Test plan

- [ ] PR-Check workflow passes (validates the consumer wrapper still parses)
- [ ] `Release · Multi-Platform` test-dispatch reaches the orchestrator job instead of failing at parse
- [ ] Web dispatch with `web_host: vercel` routes to the vercel deploy step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multi-platform release workflow configuration to reference the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->