### PR TITLE
fix(release): grant id-token + pages + contents write at caller boundary

### DIFF
--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -120,6 +120,18 @@ on:
 jobs:
   release:
     name: Release
+    # Permissions cascade through nested reusable workflows (this → orchestrator
+    # → publish-*-kmp). Declare here at the caller boundary so the deepest jobs
+    # — publish-web-kmp's gh-pages/cloudflare/netlify/vercel stages — can
+    # actually inherit what they require:
+    #   contents: write — gh release edit (desktop stages 2/3), gh-pages branch push (web)
+    #   pages:    write — actions/deploy-pages target (web gh-pages host)
+    #   id-token: write — OIDC for actions/deploy-pages (web gh-pages host)
+    # Other platforms (Android/iOS/Mac/Desktop-build) ignore the extra scopes.
+    permissions:
+      contents: write
+      pages:    write
+      id-token: write
     uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.24
     with:
       version_tag:          ${{ inputs.version_tag }}


### PR DESCRIPTION
## TL;DR

`Release · Multi-Platform` was failing at workflow startup with:

```
Error calling workflow 'therajanmaurya/mifos-x-actionhub-publish-web-kmp/.github/workflows/release.yaml@v2.0.6'.
The nested job 'stage-1-preview' is requesting 'id-token: write', but is only allowed 'id-token: none'.
The nested job 'stage-2-staging' is requesting 'id-token: write', but is only allowed 'id-token: none'.
```

Fix: 12-line `permissions:` block on the `release` job.

## Why it failed (after PR #199 merged)

GitHub Actions does NOT auto-propagate permissions through reusable-workflow chains. `publish-web-kmp/release.yaml@v2.0.6` declares at every stage:

```yaml
permissions: { contents: write, pages: write, id-token: write }
```

The chain is:
```
consumer release-multi-platform.yml  (this repo)
   └─ uses: openMF/mifos-x-actionhub/release-multi-platform-v2.yaml@v1.0.24
         └─ uses: publish-web-kmp/release.yaml@v2.0.6     ← declares id-token: write
```

The consumer (top of chain) is the ONLY layer that can grant these permissions. Without an explicit declaration, GH's default of read-only-everything cascades down — `id-token: none` — which fails the startup parse the moment it sees the web stages requesting `id-token: write`.

## Fix

```diff
 jobs:
   release:
     name: Release
+    permissions:
+      contents: write
+      pages:    write
+      id-token: write
     uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.24
```

The 3 grants align with publish-web-kmp's declaration:

| Permission | Required by |
|---|---|
| `contents: write` | `gh release edit` (publish-desktop-kmp stages 2/3 promote) + gh-pages branch push (publish-web-kmp) |
| `pages: write`    | actions/deploy-pages (publish-web-kmp gh-pages host) |
| `id-token: write` | OIDC for actions/deploy-pages (publish-web-kmp gh-pages host) |

Cascade: consumer declares → orchestrator has no permissions block (pass-through) → publish-* repos receive the grants. Other platforms (Android/iOS/Mac/Desktop-build) ignore the extra scopes.

## Why this wasn't caught earlier in the test suite

The 247 E2E assertions across the 5 repos verify:
- YAML parses
- actionlint clean
- No dynamic uses
- Caller↔callee input + secrets schemas
- Composite-action existence
- Stage structure + if-conditions

But **NOT permission inheritance through reusable-workflow chains** — actionlint and YAML parsers don't model GHA's permission cascade at PR-check time. The error only surfaces at workflow_dispatch time when the runner tries to instantiate the nested workflows.

Follow-up: add a test in the consumer test suite (PR #199 didn't include one) that asserts the workflow's job-level permissions cover every transitive publish-* repo's declared permissions. Defer to a separate PR.

## Test plan

- [ ] Merge this PR
- [ ] Dispatch `Release · Multi-Platform` with defaults again
- [ ] Workflow should now reach `validate-secrets` job successfully (no startup failure)
- [ ] Each platform's validate-secrets surfaces missing/present secrets clearly