### PR TITLE
ci(release): bump actionhub orchestrator pin v1.0.24 → v1.0.25 (publish-android-kmp + publish-apple-kmp gem-permission fixes)

### DIFF
--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -1,6 +1,6 @@
 # .github/workflows/release-multi-platform.yml
 #
-# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.24
+# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.25
 #
 # All orchestration logic lives in the centralized reusable workflow.
 # This file just declares the dispatch inputs + passes secrets through.
@@ -132,7 +132,7 @@ jobs:
       contents: write
       pages:    write
       id-token: write
-    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.24
+    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.25
     with:
       version_tag:          ${{ inputs.version_tag }}
       android_package_name: cmp-android


### PR DESCRIPTION
## TL;DR

Final hop of a 3-tier coordinated release fixing the Android Stage 0 + iOS firebase-distribution runtime failures.

```
Error loading plugin 'fastlane-plugin-firebase_app_distribution':
  You don't have write permissions for the /var/lib/gems/3.2.0 directory.
```

Root cause: GHA runner images post-2026-06 made `/var/lib/gems/3.2.0` root-owned. Bare `fastlane add_plugin` / `gem install` operations fail without `sudo` or `bundle exec`.

## Full 3-tier chain

| Tier | Repo | PR | Tag |
|---|---|---|---|
| 3 | `publish-android-kmp` | [#5](https://github.com/therajanmaurya/mifos-x-actionhub-publish-android-kmp/pull/5) | v2.0.6 |
| 3 | `publish-apple-kmp` | [#4](https://github.com/therajanmaurya/mifos-x-actionhub-publish-apple-kmp/pull/4) | v2.0.6 |
| 3 | `publish-desktop-kmp` (preventive tests) | [#5](https://github.com/therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/pull/5) | (no tag) |
| 3 | `publish-web-kmp` (preventive tests) | [#5](https://github.com/therajanmaurya/mifos-x-actionhub-publish-web-kmp/pull/5) | (no tag) |
| 2 | `openMF/mifos-x-actionhub` | [#63](https://github.com/openMF/mifos-x-actionhub/pull/63) | v1.0.25 |
| 1 | `openMF/kmp-project-template` (consumer) | **this PR** | — |

## What the fixes do

| Action | Before | After |
|---|---|---|
| `publish-android-kmp/firebase-distribution` | `fastlane add_plugin firebase_app_distribution --version=1.0.0` | `bundle exec fastlane add_plugin firebase_app_distribution --version=1.0.0` |
| `publish-apple-kmp/ios-firebase-distribution` | same | same |
| `publish-apple-kmp/ios-build` | `gem install cocoapods -N` | `sudo gem install cocoapods -N` |

## Regression tests added across ALL 4 publish-* repos

Each Tier-3 PR shipped with new tests that **forever lock the bug class**:

- **T43/T47**: no bare `gem install` / `bundle install` / `fastlane add_plugin` / `gem update` in any action.yaml — must be prefixed with `sudo` or `bundle exec`
- **T44/T48**: every `ruby/setup-ruby` step has `bundler-cache: true`

Preventive equivalents (T38/T39 and T39/T40) also landed in publish-desktop-kmp + publish-web-kmp so the bug class can't be introduced in any future composite action.

**T43/T47 verified to catch the bug**: reverted each fix locally, T43/T47 FAILED with the exact `file:line` citation; restored, T43/T47 PASSED.

## Pre-merge verification

| Repo | Tests | CI |
|---|---|---|
| publish-android-kmp | 47/47 | 8/8 ✅ |
| publish-apple-kmp | 84/84 | 16/16 ✅ |
| publish-desktop-kmp | 45/45 | 8/8 ✅ |
| publish-web-kmp | 50/50 | 8/8 ✅ |
| mifos-x-actionhub (chain-contract) | 29/29 | 2/2 ✅ |

Total: **255 E2E assertions** running in CI across the chain. All publish-* @v2.0.6 tags verified to exist on remote via `gh api`.

## Diff

```diff
-uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.24
+uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.25
```

(plus the same bump in the file header comment)

## Test plan

- [ ] CI on this PR passes
- [ ] After merge: dispatch `Release · Multi-Platform` again with defaults
- [ ] Android Stage 0 firebase-distribution now completes the `fastlane add_plugin` step (previously failed at /var/lib/gems write permission)
- [ ] iOS firebase distribution similarly proceeds
- [ ] Desktop Windows will still halt at validate-secrets (AZURE_* not configured — documented in PR #199 § follow-ups; unrelated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release workflow version for platform compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->