### PR TITLE
ci(release): bump actionhub orchestrator pin v1.0.25 → v1.0.26 (gem CLI fix + match_ssh→match_git rename + tester_groups)

### DIFF
--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -1,6 +1,6 @@
 # .github/workflows/release-multi-platform.yml
 #
-# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.25
+# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.26
 #
 # All orchestration logic lives in the centralized reusable workflow.
 # This file just declares the dispatch inputs + passes secrets through.
@@ -132,7 +132,7 @@ jobs:
       contents: write
       pages:    write
       id-token: write
-    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.25
+    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.26
     with:
       version_tag:          ${{ inputs.version_tag }}
       android_package_name: cmp-android


### PR DESCRIPTION
## TL;DR

Final hop of a 4-PR cascade fixing the Android + iOS firebase distribution failures.

### Bug cascade (revealed sequentially as earlier fixes unblocked next layer)

| # | Bug | Fix repo | Tag |
|---|---|---|---|
| A | Bare `fastlane add_plugin` fails on root-owned `/var/lib/gems` | publish-android-kmp + publish-apple-kmp v2.0.6 | v2.0.6 |
| B | `bundle exec fastlane add_plugin --version=1.0.0` — fastlane CLI doesn't accept --version (treats 1.0.0 as plugin name) AND the entire step is redundant (Pluginfile + bundle install handle it) | publish-android-kmp + publish-apple-kmp v2.0.7 | v2.0.7 |
| C | iOS: `match_ssh_private_key` passed but action declares `match_git_private_key` (silent drop → empty key → exit 1) | publish-apple-kmp v2.0.7 | v2.0.7 |
| D | iOS firebase: `tester_groups` required input not declared in workflow_call | publish-apple-kmp v2.0.7 | v2.0.7 |

### NEW Tier 11 input-contract tests prevent recurrence

The tests added in publish-android-kmp + publish-apple-kmp v2.0.7 assert:

> **Every release.yaml `with:` block must pass inputs the called composite action DECLARES, AND all required inputs must be present.**

These tests catch the EXACT bug class (C+D) at PR-check time. Going forward, any new contract drift fails CI immediately.

### Mac still needs user-side cert setup

Mac stages require manual signing certs (NOT Match-based):

```
mac_signing_certificate          mac_installer_certificate
mac_signing_certificate_password mac_installer_certificate_password
mac_provisioning_profile_base64  keychain_password
bundle_identifier
```

Documented in publish-apple-kmp's `release.yaml` inline comments AND in the `KNOWN_GAPS` allowlist of T49. When you add the certs to GHA + extend the orchestrator's workflow_call to pass them, clear the allowlist entries — the test will then catch any future regressions.

**For now, dispatch with `mac_rung: skip`** to avoid the Mac code path.

## Pre-merge verification chain

| Repo | Tests | CI |
|---|---|---|
| publish-android-kmp v2.0.7 | 48/48 (incl. new T45 input-contract) | 8/8 ✅ |
| publish-apple-kmp v2.0.7 | 85/85 (incl. new T49 + flipped T45) | 16/16 ✅ |
| mifos-x-actionhub v1.0.26 (chain-contract) | 29/29 + 4 remote tags verified | 2/2 ✅ |

## Diff

```diff
-uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.25
+uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.26
```

## Test plan

- [ ] Merge this PR
- [ ] Dispatch `Release · Multi-Platform` with **`mac_rung: skip`** (to avoid the documented Mac gap)
- [ ] Android Stage 0 firebase-distribution should now complete past the add_plugin error
- [ ] iOS Stage 0 firebase-distribution should now have the right secret name (match_git_private_key) + tester_groups
- [ ] Other platforms should proceed per their normal flow