### PR TITLE
ci(release): bump actionhub orchestrator pin v1.0.26 → v1.0.27 (composite-action self-pin fix — v2.0.7 fixes were silently ineffective)

### DIFF
--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -1,6 +1,6 @@
 # .github/workflows/release-multi-platform.yml
 #
-# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.26
+# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.27
 #
 # All orchestration logic lives in the centralized reusable workflow.
 # This file just declares the dispatch inputs + passes secrets through.
@@ -132,7 +132,7 @@ jobs:
       contents: write
       pages:    write
       id-token: write
-    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.26
+    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.27
     with:
       version_tag:          ${{ inputs.version_tag }}
       android_package_name: cmp-android


### PR DESCRIPTION
## TL;DR

The v1.0.26 fixes (publish-android-kmp@v2.0.7 + publish-apple-kmp@v2.0.7) were **silently ineffective** because of an architectural self-pinning bug. v1.0.27 + publish-*@v2.0.8 finally deliver them.

## What happened

When I tagged publish-android-kmp@v2.0.7 + publish-apple-kmp@v2.0.7, the action.yaml content was fixed. But the **release.yaml inside each repo was still calling its composite-action subdirs at @v2.0.0** — the OLDEST tag, frozen since the original (buggy) version:

```yaml
# publish-android-kmp release.yaml@v2.0.7 had:
- uses: therajanmaurya/.../firebase-distribution@v2.0.0  # ← OLD buggy version
```

So even when the orchestrator pinned `release.yaml@v2.0.7`, the actual composite action that ran was `firebase-distribution@v2.0.0` — completely bypassing every fix in v2.0.6 and v2.0.7.

## What's fixed in v2.0.8

| Repo | What |
|---|---|
| publish-android-kmp v2.0.8 | Bumps 4 composite-action refs `@v2.0.0` → `@v2.0.8` |
| publish-apple-kmp v2.0.8 | Bumps 7 composite-action refs `@v2.0.0` → `@v2.0.8` |
| **All 4 publish-* repos** | NEW Tier 12 regression test T46/T50/T38/T41 — catches the v2.0.0 freeze anti-pattern forever |
| mifos-x-actionhub v1.0.27 | Bumps both ref pins to @v2.0.8 |

## The bug-class test

```python
# T46/T50: all composite-action 'uses:' refs in release.yaml use the SAME tag
# (no v2.0.0 freeze). FAILs on:
#   - Inconsistent tags (mix of @v2.0.0 + @v2.0.8 etc.)
#   - All-refs-frozen-at-v2.0.0 (the original anti-pattern)
```

Future composite-action changes will now fail PR-check unless the release.yaml refs are bumped in lockstep.

## Mac still needs user setup

Mac stages require manual signing certs. Documented in KNOWN_GAPS allowlist of T49. **Dispatch with `mac_rung: skip`** until you wire up the Mac certs.

## Verification

| Repo | Tests | CI |
|---|---|---|
| publish-android-kmp v2.0.8 | 49/49 (T46 added) | 8/8 ✅ |
| publish-apple-kmp v2.0.8 | 86/86 (T50 added) | 16/16 ✅ |
| publish-desktop-kmp (preventive T38) | 46/46 | 8/8 ✅ |
| publish-web-kmp (preventive T41) | 51/51 | 8/8 ✅ |
| mifos-x-actionhub v1.0.27 | 29/29 chain-contract + 4 remote tag checks | 2/2 ✅ |

## Diff

```diff
-uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.26
+uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.27
```

## Test plan

- [ ] Merge this PR
- [ ] Dispatch `Release · Multi-Platform` with `mac_rung: skip`
- [ ] Android Stage 0 firebase-distribution should now ACTUALLY skip the redundant add_plugin step (won't hit the "no version found in package 1.0.0" error)
- [ ] iOS Stage 0 firebase-distribution should reach Fastlane successfully (no more "fastlane: command not found" exit 127)
- [ ] iOS TestFlight Internal: should pass match_git_private_key correctly