### PR TITLE
ci(release): bump actionhub pin to @v1.0.28

### DIFF
--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -1,6 +1,6 @@
 # .github/workflows/release-multi-platform.yml
 #
-# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.27
+# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.28
 #
 # All orchestration logic lives in the centralized reusable workflow.
 # This file just declares the dispatch inputs + passes secrets through.
@@ -132,7 +132,7 @@ jobs:
       contents: write
       pages:    write
       id-token: write
-    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.27
+    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.28
     with:
       version_tag:          ${{ inputs.version_tag }}
       android_package_name: cmp-android


### PR DESCRIPTION
## Summary
- Bumps `openMF/mifos-x-actionhub` pin from `@v1.0.27` → `@v1.0.28`.
- Brings in the gh-pages deploy fix from `publish-web-kmp@v2.0.7`: deploy via Pages REST API (`actions/upload-pages-artifact@v3` + `actions/deploy-pages@v4`) instead of branch push to gh-pages*. Unblocks Web preview deploys under the Default Ruleset (GH013 was blocking the prior peaceiris-based push).

## Test plan
- [x] Workflow YAML still parses
- [ ] Re-dispatch `Release · Multi-Platform` with `web_rung: preview` → Stage 1 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal deployment infrastructure version.

---

**Note:** This release contains no user-visible changes or feature updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->