### PR TITLE
fix(web): reference skiko.mjs instead of legacy skiko.js

### DIFF
--- a/cmp-web/src/jsMain/resources/index.html
+++ b/cmp-web/src/jsMain/resources/index.html
@@ -32,7 +32,7 @@
     <meta property="og:image:height" content="321">
     <meta name="twitter:image" content="https://github.com/user-attachments/assets/2f70b317-51a4-4b1e-b48a-880adecbb323">
 
-    <script src="skiko.js"></script>
+    <script type="module" src="skiko.mjs"></script>
 </head>
 <body>
 <div id="ComposeTargetContainer">

--- a/cmp-web/src/wasmJsMain/resources/index.html
+++ b/cmp-web/src/wasmJsMain/resources/index.html
@@ -39,7 +39,7 @@
     <meta name="twitter:image"
           content="https://github.com/user-attachments/assets/2f70b317-51a4-4b1e-b48a-880adecbb323">
 
-    <script src="skiko.js"></script>
+    <script type="module" src="skiko.mjs"></script>
     <script type="module" src="cmp-wasm.js"></script>
 </head>
 <body>


### PR DESCRIPTION
Resolves the blank-page issue on https://openmf.github.io/kmp-project-template/. Modern Compose MP produces skiko.mjs; index.html was still pointing at the legacy skiko.js name → 404 → Compose canvas couldn't bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime script loading configuration across the application for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->