### PR TITLE
fix(secrets): consolidate to single play SA for both Play + Firebase

### DIFF
--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -171,13 +171,21 @@ jobs:
           echo "$GOOGLE_SERVICES_B64" | base64 -d > cmp-android/google-services.json
           echo "✅ Materialized google-services.json"
         fi
-        # Materialize Firebase service-account JSON (Android + iOS share this)
-        if [ -n "${FIREBASE_CREDS_B64:-}" ]; then
-          mkdir -p secrets/firebase
-          # Lane reads it under both filenames depending on the platform/flavor:
-          echo "$FIREBASE_CREDS_B64" | base64 -d > secrets/firebaseAppDistributionServiceCredentialsFile.json
-          echo "$FIREBASE_CREDS_B64" | base64 -d > secrets/firebase/service-account.json
-          echo "✅ Materialized Firebase SA JSON"
+        # Materialize Play SA — single SoT serving BOTH Play Console publish
+        # AND Firebase App Distribution (2026-06-19 consolidation: the legacy
+        # separate firebase SA was retired; the play SA needs
+        # `Firebase App Distribution Admin` role on the Firebase project).
+        # GHA stores the same SA blob in PLAYSTORECREDS (canonical) — Android
+        # publish-* exposes it as PLAYSTORE_CREDS_B64.
+        if [ -n "${PLAYSTORE_CREDS_B64:-}" ]; then
+          mkdir -p secrets/play secrets/firebase
+          echo "$PLAYSTORE_CREDS_B64" | base64 -d > secrets/play/service-account.json
+          # Mirror to the legacy paths the lane / firebase plugin look up, so
+          # we don't have to patch every lane reader:
+          echo "$PLAYSTORE_CREDS_B64" | base64 -d > secrets/firebase/service-account.json
+          echo "$PLAYSTORE_CREDS_B64" | base64 -d > secrets/firebaseAppDistributionServiceCredentialsFile.json
+          echo "$PLAYSTORE_CREDS_B64" | base64 -d > secrets/playStorePublishServiceCredentialsFile.json
+          echo "✅ Materialized Play SA (used for Play + Firebase distribution)"
         fi
         # Materialize iOS App Store Connect API .p8 key
         if [ -n "${APPSTORE_AUTH_KEY_B64:-}" ]; then

--- a/secrets-manifest.yaml
+++ b/secrets-manifest.yaml
@@ -35,14 +35,13 @@ needs:
       mode: env-line
       env_var: KEYSTORE_PASSWORD
 
-  # ── Firebase App Distribution ──────────────────────────────────────────────
-  - alias: firebase_service_account_json
-    materialize:
-      at: secrets/firebase/service-account.json
-      mode: file
-      permissions: "0600"
-
-  # ── Google Play Console publish ────────────────────────────────────────────
+  # ── Google Play Console publish + Firebase App Distribution ───────────────
+  # SINGLE SA at secrets/play/service-account.json serves BOTH purposes
+  # (Play Console upload AND Firebase App Distribution). The legacy
+  # `firebase_service_account_json` alias + separate file at
+  # secrets/firebase/service-account.json was retired 2026-06-19 per
+  # consolidation directive. The play SA needs `Firebase App Distribution
+  # Admin` role added in IAM for the Firebase project.
   - alias: play_publisher_service_account_json
     materialize:
       at: secrets/play/service-account.json


### PR DESCRIPTION
Per 2026-06-19 directive: retire the separate Firebase Admin SDK SA and use the Play Console SA (`fatslane-supply@mifos-mobile-apps`) as the single source of truth for both Play Store publish AND Firebase App Distribution upload.

**Prerequisite:** the play SA must have `Firebase App Distribution Admin` role added in IAM for project `mifos-mobile-apps` — without that role, the Firebase upload will still 400 (permission-denied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)