### PR TITLE
fix(release): use vars.DEFAULT_CHAIN_REF for parse-time uses: ref

### DIFF
--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -131,21 +131,19 @@ on:
         required: false
         type: string
         default: '["macos-14"]'
-      actionhub_ref:
-        description: 'Git ref of openMF/mifos-x-actionhub (tag for prod, `dev` for local iteration).'
-        required: false
-        type: string
-        default: 'v1.0.31'
+      # Chain refs (publish_android_ref, publish_apple_ref) are still dispatch
+      # inputs because the orchestrator's `uses:` to publish-* CAN accept
+      # inputs.* (it's the consumer-to-orchestrator hop that's parse-time).
       publish_android_ref:
-        description: 'Git ref of publish-android-kmp release.yaml.'
+        description: 'Git ref of publish-android-kmp release.yaml. Default `dev` (per repo var) or tag.'
         required: false
         type: string
-        default: 'v2.0.12'
+        default: ''
       publish_apple_ref:
-        description: 'Git ref of publish-apple-kmp release.yaml.'
+        description: 'Git ref of publish-apple-kmp release.yaml. Default `dev` (per repo var) or tag.'
         required: false
         type: string
-        default: 'v2.0.12'
+        default: ''
 
 jobs:
   release:
@@ -162,7 +160,12 @@ jobs:
       contents: write
       pages:    write
       id-token: write
-    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@${{ inputs.actionhub_ref }}
+    # GHA doesn't allow `inputs.*` in workflow_call `uses:` refs (parse-time
+    # vs run-time). `vars.*` IS allowed — repo-level static config, perfect
+    # for flipping prod ↔ dev. Toggle via:
+    #   gh variable set DEFAULT_CHAIN_REF --body dev      # → use chain dev branches
+    #   gh variable set DEFAULT_CHAIN_REF --body v1.0.31  # → back to prod tag
+    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@${{ vars.DEFAULT_CHAIN_REF || 'v1.0.31' }}
     with:
       version_tag:          ${{ inputs.version_tag }}
       android_package_name: cmp-android
@@ -185,8 +188,9 @@ jobs:
       # local mode or dev branch doesn't require editing any chain file ===
       runner_pool_linux:    ${{ inputs.runner_pool_linux }}
       runner_pool_mac:      ${{ inputs.runner_pool_mac }}
-      publish_android_ref:  ${{ inputs.publish_android_ref }}
-      publish_apple_ref:    ${{ inputs.publish_apple_ref }}
+      # If dispatch input is empty, fall back to DEFAULT_CHAIN_REF var, then 'v2.0.12'.
+      publish_android_ref:  ${{ inputs.publish_android_ref != '' && inputs.publish_android_ref || (vars.DEFAULT_CHAIN_REF || 'v2.0.12') }}
+      publish_apple_ref:    ${{ inputs.publish_apple_ref != '' && inputs.publish_apple_ref || (vars.DEFAULT_CHAIN_REF || 'v2.0.12') }}
       # === FIX 2: opt into RULE-DEPLOYMENT-MANIFEST-001 deployment/<platform>/<target>/lane.rb layout ===
       # Our lanes live at deployment/Fastfile + deployment/<platform>/<target>/lane.rb,
       # not at root fastlane/Fastfile. The publish-* @v2.0.11 wrappers support this


### PR DESCRIPTION
GHA rejects inputs.* in workflow_call uses:. Switching to vars.DEFAULT_CHAIN_REF which IS parse-time-resolvable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)