### PR TITLE
ci(release): bump prod pin to actionhub @v1.0.32

### DIFF
--- a/.github/workflows/release-multi-platform-local.yml
+++ b/.github/workflows/release-multi-platform-local.yml
@@ -100,9 +100,9 @@ jobs:
       # All jobs on the self-hosted Mac runner — single executor, all platforms.
       runner_pool_linux:    '["self-hosted","macOS"]'
       runner_pool_mac:      '["self-hosted","macOS"]'
-      # Chain refs all on dev.
-      publish_android_ref:  dev
-      publish_apple_ref:    dev
+      # Chain refs all pinned to @dev INSIDE the orchestrator's release-multi-platform-v2.yaml
+      # on the `dev` branch (publish-android-kmp@dev + publish-apple-kmp@dev). No
+      # input needed here — the dev branch's workflow file hardcodes them.
       # RULE-DEPLOYMENT-MANIFEST-001 layout — same as prod workflow.
       fastlane_mode:        pre-materialized
       fastlane_cwd:         deployment

--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -136,7 +136,7 @@ jobs:
     # (parse-time literal only). For local-dev iteration use the companion
     # workflow `release-multi-platform-local.yml`, which pins @dev and is
     # dispatched by `/ci local-actions` against the fork.
-    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.31
+    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.32
     with:
       version_tag:          ${{ inputs.version_tag }}
       android_package_name: cmp-android
@@ -155,12 +155,11 @@ jobs:
       web_target:           ${{ inputs.web_rung }}
       web_host:             ${{ inputs.web_host }}
       production_rollout:   ${{ inputs.production_rollout }}
-      # PROD pins — immutable, kept in lockstep with actionhub @v1.0.31.
+      # PROD pins kept in lockstep with actionhub @v1.0.32 (which hardcodes
+      # @v2.0.12 internally — GHA forbids expressions in workflow_call uses:).
       # Local dispatches override these via release-multi-platform-local.yml.
       runner_pool_linux:    '["ubuntu-latest"]'
       runner_pool_mac:      '["macos-14"]'
-      publish_android_ref:  v2.0.12
-      publish_apple_ref:    v2.0.12
       # === FIX 2: opt into RULE-DEPLOYMENT-MANIFEST-001 deployment/<platform>/<target>/lane.rb layout ===
       # Our lanes live at deployment/Fastfile + deployment/<platform>/<target>/lane.rb,
       # not at root fastlane/Fastfile. The publish-* @v2.0.11 wrappers support this


### PR DESCRIPTION
v1.0.31 had broken expressions in workflow_call uses:. v1.0.32 hardcodes refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)