### PR TITLE
feat(release): act-driven local release pipeline + Firebase App ID + VERSION_CODE override

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -13,3 +13,10 @@
 
 # Standard ubuntu runner image
 -P ubuntu-latest=catthehacker/ubuntu:act-latest
+
+# Self-hosted + macOS labels resolve to the host (native execution, like the
+# real GHA self-hosted runner setup). Required for release-multi-platform-local.yml
+# which uses runs-on: ["self-hosted","macOS"] — matches both labels.
+-P self-hosted=-self-hosted
+-P macOS=-self-hosted
+-P ARM64=-self-hosted

--- a/.github/workflows/release-multi-platform-local.yml
+++ b/.github/workflows/release-multi-platform-local.yml
@@ -130,20 +130,55 @@ jobs:
           echo "✅ Materialized Play SA"
         fi
         if [ -n "${APPSTORE_AUTH_KEY_B64:-}" ]; then
-          mkdir -p secrets
-          echo "$APPSTORE_AUTH_KEY_B64" | base64 -d > secrets/AuthKey.p8
+          mkdir -p secrets/appstore
+          # Write to both paths — Fastfile expects secrets/appstore/AuthKey.p8
+          # (deployment/_shared/config.rb appstore_helpers); legacy callers may
+          # still reference secrets/AuthKey.p8 (kept as backwards-compat).
+          echo "$APPSTORE_AUTH_KEY_B64" | base64 -d > secrets/appstore/AuthKey.p8
+          chmod 600 secrets/appstore/AuthKey.p8
+          cp secrets/appstore/AuthKey.p8 secrets/AuthKey.p8
           echo "✅ Materialized App Store Connect .p8"
         fi
         if [ -n "${MATCH_GIT_PRIVATE_KEY:-}" ]; then
-          mkdir -p secrets ~/.ssh
-          echo "$MATCH_GIT_PRIVATE_KEY" | base64 -d > secrets/match_ci_key
-          chmod 600 secrets/match_ci_key
-          echo "✅ Materialized Match SSH key"
+          mkdir -p secrets/match ~/.ssh
+          # match_ssh_private_key vault entry is the FULL match bundle (tar.gz):
+          #   match/git_url, match/git_branch, match/match_ci_key (SSH key),
+          #   match/.match_password, match/certificates_password, match/keychain_password
+          # Decode + extract; copy SSH key into secrets/match/ (Fastfile expects this path
+          # per deployment/_shared/config.rb match_ssh_key_path); export MATCH_GIT_URL/BRANCH.
+          BUNDLE_DIR=$(mktemp -d)
+          echo "$MATCH_GIT_PRIVATE_KEY" | base64 -d > "$BUNDLE_DIR/bundle.tgz"
+          if tar -xzf "$BUNDLE_DIR/bundle.tgz" -C "$BUNDLE_DIR" 2>/dev/null; then
+            # It's a tar.gz bundle — extract SSH key + env vars
+            cp "$BUNDLE_DIR/match/match_ci_key" secrets/match/match_ci_key
+            chmod 600 secrets/match/match_ci_key
+            # Also write to legacy path for any callers still using it
+            cp "$BUNDLE_DIR/match/match_ci_key" secrets/match_ci_key
+            chmod 600 secrets/match_ci_key
+            if [ -f "$BUNDLE_DIR/match/git_url" ]; then
+              echo "MATCH_GIT_URL=$(cat $BUNDLE_DIR/match/git_url | tr -d '\n\r ')" >> "$GITHUB_ENV"
+            fi
+            if [ -f "$BUNDLE_DIR/match/git_branch" ]; then
+              echo "MATCH_GIT_BRANCH=$(cat $BUNDLE_DIR/match/git_branch | tr -d '\n\r ')" >> "$GITHUB_ENV"
+            fi
+            echo "✅ Materialized Match bundle (SSH key + git_url + git_branch)"
+          else
+            # Plain SSH key (legacy single-file format)
+            mv "$BUNDLE_DIR/bundle.tgz" secrets/match/match_ci_key
+            chmod 600 secrets/match/match_ci_key
+            cp secrets/match/match_ci_key secrets/match_ci_key
+            chmod 600 secrets/match_ci_key
+            echo "✅ Materialized Match SSH key (legacy single-file)"
+          fi
+          rm -rf "$BUNDLE_DIR"
         fi
         if [ -n "${KEYSTORE_ALIAS:-}" ]; then echo "KEY_ALIAS=$KEYSTORE_ALIAS" >> "$GITHUB_ENV"; fi
         if [ -n "${KEYSTORE_ALIAS_PASSWORD:-}" ]; then echo "KEY_PASSWORD=$KEYSTORE_ALIAS_PASSWORD" >> "$GITHUB_ENV"; fi
         if [ -n "${KEYSTORE_PASSWORD:-}" ]; then
           echo "KEYSTORE_PATH=secrets/keystores/upload_keystore.keystore" >> "$GITHUB_ENV"
         fi
+        # Firebase App IDs are provided as direct env vars by the chain repo
+        # (publish-{android,apple}-kmp release.yaml env block) — no propagation
+        # needed here. For act, pass via --env-file.
         echo "✅ pre_fastlane_script complete"
     secrets: inherit

--- a/.github/workflows/release-multi-platform-local.yml
+++ b/.github/workflows/release-multi-platform-local.yml
@@ -100,9 +100,9 @@ jobs:
       # All jobs on the self-hosted Mac runner — single executor, all platforms.
       runner_pool_linux:    '["self-hosted","macOS"]'
       runner_pool_mac:      '["self-hosted","macOS"]'
-      # Chain refs all on dev.
-      publish_android_ref:  dev
-      publish_apple_ref:    dev
+      # Chain refs all pinned to @dev INSIDE the orchestrator's release-multi-platform-v2.yaml
+      # on the `dev` branch (publish-android-kmp@dev + publish-apple-kmp@dev). No
+      # input needed here — the dev branch's workflow file hardcodes them.
       # RULE-DEPLOYMENT-MANIFEST-001 layout — same as prod workflow.
       fastlane_mode:        pre-materialized
       fastlane_cwd:         deployment

--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -136,7 +136,7 @@ jobs:
     # (parse-time literal only). For local-dev iteration use the companion
     # workflow `release-multi-platform-local.yml`, which pins @dev and is
     # dispatched by `/ci local-actions` against the fork.
-    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.31
+    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.32
     with:
       version_tag:          ${{ inputs.version_tag }}
       android_package_name: cmp-android
@@ -155,12 +155,11 @@ jobs:
       web_target:           ${{ inputs.web_rung }}
       web_host:             ${{ inputs.web_host }}
       production_rollout:   ${{ inputs.production_rollout }}
-      # PROD pins — immutable, kept in lockstep with actionhub @v1.0.31.
+      # PROD pins kept in lockstep with actionhub @v1.0.32 (which hardcodes
+      # @v2.0.12 internally — GHA forbids expressions in workflow_call uses:).
       # Local dispatches override these via release-multi-platform-local.yml.
       runner_pool_linux:    '["ubuntu-latest"]'
       runner_pool_mac:      '["macos-14"]'
-      publish_android_ref:  v2.0.12
-      publish_apple_ref:    v2.0.12
       # === FIX 2: opt into RULE-DEPLOYMENT-MANIFEST-001 deployment/<platform>/<target>/lane.rb layout ===
       # Our lanes live at deployment/Fastfile + deployment/<platform>/<target>/lane.rb,
       # not at root fastlane/Fastfile. The publish-* @v2.0.11 wrappers support this

--- a/deployment/_shared/config.rb
+++ b/deployment/_shared/config.rb
@@ -637,7 +637,15 @@ end
 def generateVersion(platform: "firebase", **config)
   sh("#{DEPLOYMENT_REPO_ROOT}/gradlew versionFile 2>/dev/null || true") rescue nil
   version_name = VersionHelpers.gradle_version
-  version_code = sh("git rev-list --count HEAD 2>/dev/null || echo 1").strip.to_i rescue 1
+  # VERSION_CODE_OVERRIDE: pre-set ENV (e.g. by act --env-file) wins over
+  # git-rev-list. Lets iteration runs bump past the last successful upload
+  # without a real git commit on the source repo each time.
+  override = ENV["VERSION_CODE_OVERRIDE"].to_s.strip
+  version_code = if !override.empty?
+                   override.to_i
+                 else
+                   sh("git rev-list --count HEAD 2>/dev/null || echo 1").strip.to_i rescue 1
+                 end
 
   ENV["VERSION_NAME"] = version_name
   ENV["VERSION_CODE"] = version_code.to_s

--- a/secrets-manifest.yaml
+++ b/secrets-manifest.yaml
@@ -35,6 +35,57 @@ needs:
       mode: env-line
       env_var: KEYSTORE_PASSWORD
 
+  - alias: kmp_template_release_keystore_alias
+    materialize:
+      at: secrets/keystores/release.properties
+      mode: env-line
+      env_var: KEYSTORE_ALIAS
+
+  - alias: kmp_template_release_keystore_alias_password
+    materialize:
+      at: secrets/keystores/release.properties
+      mode: env-line
+      env_var: KEYSTORE_ALIAS_PASSWORD
+
+  # ── Firebase Android App IDs (ENV-only) ────────────────────────────────────
+  - alias: firebase_android_app_id
+    materialize:
+      at: secrets/firebase/android_app_id
+      mode: file
+      permissions: "0600"
+
+  - alias: firebase_android_demo_app_id
+    materialize:
+      at: secrets/firebase/android_demo_app_id
+      mode: file
+      permissions: "0600"
+
+  # ── Firebase iOS App IDs (ENV-only) ────────────────────────────────────────
+  - alias: firebase_ios_app_id
+    materialize:
+      at: secrets/firebase/ios_app_id
+      mode: file
+      permissions: "0600"
+
+  - alias: firebase_ios_demo_app_id
+    materialize:
+      at: secrets/firebase/ios_demo_app_id
+      mode: file
+      permissions: "0600"
+
+  - alias: firebase_ios_prod_app_id
+    materialize:
+      at: secrets/firebase/ios_prod_app_id
+      mode: file
+      permissions: "0600"
+
+  # ── Firebase google-services.json (cmp-android module) ────────────────────
+  - alias: google_services
+    materialize:
+      at: cmp-android/google-services.json
+      mode: file
+      permissions: "0644"
+
   # ── Firebase App Distribution ──────────────────────────────────────────────
   # Distinct SA (firebase-adminsdk-o8x4a@…) — Firebase Admin SDK creds, used
   # by the firebase_app_distribution Fastlane plugin.


### PR DESCRIPTION
## Summary

- **act-driven local release**: `.actrc` registers `self-hosted`/`macOS`/`ARM64` platform mappings so `release-multi-platform-local.yml` runs natively on the host (matches real GHA self-hosted runner shape).
- **Pre-fastlane materialization fix**: AuthKey.p8 now written to `secrets/appstore/AuthKey.p8` (path the Fastfile expects per `deployment/_shared/config.rb` appstore_helpers); legacy `secrets/AuthKey.p8` retained for back-compat. Match bundle (tar.gz) extracted in-script: SSH key into `secrets/match/match_ci_key`, `MATCH_GIT_URL` + `MATCH_GIT_BRANCH` exported to `$GITHUB_ENV`.
- **VERSION_CODE_OVERRIDE**: `deployment/_shared/config.rb` honors the env var when set so iteration runs can bump past the last successful Play Store upload without making a real git commit each time. Falls back to `git rev-list --count HEAD`.
- **secrets-manifest.yaml**: +8 aliases — `firebase_{android,ios}_{app_id,demo_app_id,prod_app_id}` + `google_services`. All materialize into the source-level `secrets/` tree where Fastlane/act find them.

## Verified end-to-end via `act`

- **Android Stage 1 (Play Internal)**: assembleProdRelease + signing + upload_to_play_store → "Successfully finished the upload to Google Play" (version 200) + AAB artifact upload via `--artifact-server-path`.
- **iOS Stage 1 (TestFlight Internal)**: Match SSH clone + decrypt + app_store_connect_api_key all green. Blocked at Apple Dev Portal step pending PLA acceptance by Edward Cable (external Apple-side, not pipeline).

## Test plan

- [ ] `/ci local-actions` against `release-multi-platform-local.yml` with `--input android_rung=internal` reproduces the Play Store upload path.
- [ ] After Apple PLA acceptance: same shape with `--input ios_rung=internal` proceeds to TestFlight upload.
- [ ] CI/Remote: `/ci local-actions --remote` dispatches the same workflow on the self-hosted runner and reaches Play Internal end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)