### PR TITLE
ci(release): multi-platform secret-sweep + macOS wiring (epic multi-platform-release-completion)

### DIFF
--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -77,14 +77,14 @@ on:
         required: false
         type: choice
         options: [skip, internal, beta, production]
-        default: internal
+        default: skip
 
       desktop_win_rung:
         description: 'Windows — top rung'
         required: false
         type: choice
         options: [skip, prerelease, beta, stable]
-        default: prerelease
+        default: skip
 
       desktop_win_artifact:
         description: 'Windows artifact format'
@@ -139,7 +139,7 @@ jobs:
     # (parse-time literal only). For local-dev iteration use the companion
     # workflow `release-multi-platform-local.yml`, which pins @dev and is
     # dispatched by `/ci local-actions` against the fork.
-    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.37
+    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.38
     with:
       version_tag:          ${{ inputs.version_tag }}
       android_package_name: cmp-android
@@ -257,3 +257,25 @@ jobs:
       match_password:               ${{ secrets.MATCH_PASSWORD }}
       match_ssh_private_key:        ${{ secrets.MATCH_SSH_PRIVATE_KEY }}
       SOPS_AGE_KEY:                 ${{ secrets.SOPS_AGE_KEY }}
+      # --- NEW: macOS .p12 signing (Tier-3, blocked-on-onboarding until certs provisioned) ---
+      mac_signing_certificate:            ${{ secrets.MAC_SIGNING_CERTIFICATE }}
+      mac_signing_certificate_password:   ${{ secrets.MAC_SIGNING_CERTIFICATE_PASSWORD }}
+      mac_installer_certificate:          ${{ secrets.MAC_INSTALLER_CERTIFICATE }}
+      mac_installer_certificate_password: ${{ secrets.MAC_INSTALLER_CERTIFICATE_PASSWORD }}
+      mac_provisioning_profile_base64:    ${{ secrets.MAC_PROVISIONING_PROFILE_BASE64 }}
+      keychain_password:                  ${{ secrets.KEYCHAIN_PASSWORD }}
+      # --- NEW: Web host tokens + Vercel project identity ---
+      cloudflare_api_token:         ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      netlify_auth_token:           ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      vercel_token:                 ${{ secrets.VERCEL_TOKEN }}
+      vercel_org_id:                ${{ secrets.VERCEL_ORG_ID }}
+      vercel_project_id:            ${{ secrets.VERCEL_PROJECT_ID }}
+      # --- NEW: Windows Azure Trusted Signing + Partner Center (Tier-3, blocked-on-onboarding) ---
+      azure_client_id:                ${{ secrets.AZURE_CLIENT_ID }}
+      azure_tenant_id:                ${{ secrets.AZURE_TENANT_ID }}
+      azure_subscription_id:          ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      azure_trusted_signing_endpoint: ${{ secrets.AZURE_TRUSTED_SIGNING_ENDPOINT }}
+      azure_trusted_signing_account:  ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT }}
+      azure_cert_profile_name:        ${{ secrets.AZURE_CERT_PROFILE_NAME }}
+      microsoft_store_client_id:      ${{ secrets.MICROSOFT_STORE_CLIENT_ID }}
+      microsoft_store_client_secret:  ${{ secrets.MICROSOFT_STORE_CLIENT_SECRET }}

--- a/docs/release/ONBOARDING_CHECKLIST.md
+++ b/docs/release/ONBOARDING_CHECKLIST.md
@@ -1,0 +1,63 @@
+# Release Onboarding Checklist — blocked rungs
+
+The multi-platform release chain is **fully wired**. The rungs below are blocked only because they
+need real store/cert assets that cannot be generated in CI. Each is `skip`/inert by default so a
+plain dispatch never dead-ends. Provide the asset via GitHub Secrets (never commit secrets to code —
+CI reads them at runtime), then the rung lights up.
+
+> All secrets live in GitHub Actions secrets (Settings → Secrets and variables → Actions). CI
+> materializes them to ephemeral runner temp at runtime; nothing is stored in the repo.
+
+## 🍎 macOS (TestFlight / Mac App Store) — needs `.p12` signing assets
+
+Wired: `macos-signing` composite (keychain `.p12` import + Fastlane), 6 secrets forwarded across the
+chain, `mac-testflight-internal/external` + `mac-app-store` environments (reviewer-gated).
+
+To unblock, set these GitHub secrets on the consumer fork:
+- [ ] `MAC_SIGNING_CERTIFICATE` — base64 of the Apple Distribution `.p12`
+- [ ] `MAC_SIGNING_CERTIFICATE_PASSWORD`
+- [ ] `MAC_INSTALLER_CERTIFICATE` — base64 of the Mac Installer Distribution `.p12`
+- [ ] `MAC_INSTALLER_CERTIFICATE_PASSWORD`
+- [ ] `MAC_PROVISIONING_PROFILE_BASE64` — base64 of the macOS App Store `.provisionprofile`
+- [ ] `KEYCHAIN_PASSWORD` — any throwaway password for the ephemeral CI keychain
+- [ ] A macOS app record in App Store Connect (separate from iOS)
+Then dispatch with `mac_rung: internal` (or higher).
+
+## 🪟 Windows signed (MSI / Microsoft Store) — needs Azure Trusted Signing
+
+Wired: 8 `azure_*` secrets forwarded to `desktop-win`; the desktop publish repo validates them.
+**Note:** `windows-exe` is NOT unsigned in this chain — it requires the same `azure_*` set as
+`windows-msi-signed`. Only `linux-deb` is secret-free. Windows defaults to `skip`.
+
+To unblock, set:
+- [ ] `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`
+- [ ] `AZURE_TRUSTED_SIGNING_ENDPOINT`, `AZURE_TRUSTED_SIGNING_ACCOUNT`, `AZURE_CERT_PROFILE_NAME`
+- [ ] (Microsoft Store only) `MICROSOFT_STORE_CLIENT_ID`, `MICROSOFT_STORE_CLIENT_SECRET`
+Then dispatch with `desktop_win_rung: prerelease` (or higher).
+
+## 🤖 Android Play promotion (internal → beta → production) — needs Play Console
+
+Wired: `PLAYSTORE_CREDS` forwarded; `android-play-internal/beta/production` environments
+(reviewer-gated → the "Approve and deploy" promote button appears).
+
+To unblock:
+- [ ] Publish the app to the Play Console **internal track at least once** (the API rejects promotion
+      from an empty track)
+- [ ] Ensure the `PLAYSTORE_CREDS` service account has **Release Manager** permission
+Then dispatch with `android_rung: internal` (or `firebase+internal`); approve each gate to promote.
+
+## 🍏 iOS TestFlight / App Store — needs ASC app record + Match
+
+Wired: `APPSTORE_*` + `MATCH_*` secrets forwarded; `ios-testflight-internal/external` + `ios-app-store`
+environments (reviewer-gated). iOS **Firebase** works today (dev distribution).
+
+To unblock TestFlight/App Store:
+- [ ] An iOS app record in App Store Connect for the bundle id
+- [ ] A Fastlane **Match** repo populated with `appstore` certificates + profiles, reachable via
+      `MATCH_SSH_PRIVATE_KEY` + `MATCH_PASSWORD`
+Then dispatch with `ios_rung: internal` (or higher); approve each gate.
+
+---
+
+**Deployable today (no onboarding):** Android Firebase, iOS Firebase (if Match exists), Linux DEB,
+Web gh-pages. **Promote gates** (store/prod rungs) pause for maintainer approval by design.


### PR DESCRIPTION
Extends the green Android-Firebase chain to all platforms' secret conduit + macOS signing.

**Chain re-tags (bottom-up):** publish-apple `v2.0.13` (macOS .p12 keychain composite) · publish-web `v2.0.8` (vercel ids) · publish-desktop `v2.0.7` (contents:write) · orchestrator `v1.0.38` (explicit cross-org secrets all platforms + validate-secrets unconditional) · consumer pin `@v1.0.38`.

**Secrets:** all materialized from GitHub Secrets at runtime (RUNNER_TEMP, nothing in code).

**Safe defaults:** `mac_rung=skip` (blocked on .p12 certs), `desktop_win_rung=skip` (blocked on Azure) — no default-dispatch dead-ends.

Tier-3 (macOS certs, Windows Azure, Play publish) wired + blocked-on-onboarding per epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release and deployment infrastructure to version 1.0.38.
  * Enhanced security by adding additional signing and authentication credentials for multi-platform deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->