### PR TITLE
ci(release): firebase app-id↔package preflight — orchestrator @v1.0.46 + application_id

### DIFF
--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -145,10 +145,13 @@ jobs:
     # (parse-time literal only). For local-dev iteration use the companion
     # workflow `release-multi-platform-local.yml`, which pins @dev and is
     # dispatched by `/ci local-actions` against the fork.
-    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.45
+    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.46
     with:
       version_tag:          ${{ inputs.version_tag }}
       android_package_name: cmp-android
+      # applicationId (prod flavor) — feeds the firebase app-id↔package preflight (FB-PRE-3)
+      # in publish-android-kmp release-firebase.yaml@v2.0.21.
+      application_id:       org.mifos.kmp.template
       ios_package_name:     cmp-ios
       mac_package_name:     cmp-desktop
       shared_module:        cmp-shared


### PR DESCRIPTION
## What
- Bumps orchestrator pin `@v1.0.45 → @v1.0.46`
- Passes `application_id: org.mifos.kmp.template` to the orchestrator

## Why (Option A — consolidate validation in the actionhub)
The full Firebase preflight (SA validity + app-id format + **app-id↔package match**) now lives in the Tier-3 actionhub `release-firebase.yaml@v2.0.21` `validate-secrets` node, so **every consumer inherits it** (no per-consumer lane code). `application_id` feeds the FB-PRE-3 match that catches the 2026-06-24 stale-app-id/package-mismatch class at the preflight node, before the build.

Supersedes the consumer-side `FirebaseHelpers.preflight!` approach — PR #223 closed.

## Cascade (all merged/tagged)
- publish-android-kmp #13 → `v2.0.21` (full validate-secrets) ✅
- openMF/mifos-x-actionhub → `v1.0.46` (thread application_id + ref bump) ✅
- this PR → consumer pin + application_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)