### PR TITLE
ci(release): firebase app-id↔package preflight — orchestrator @v1.0.46 + dynamic application_id

### DIFF
--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -127,8 +127,32 @@ jobs:
   #   • full sync (metadata + screenshots + feature graphic) → deployInternal's supply upload
   #     (metadata_path + skip_upload_{metadata,changelogs,images,screenshots}: false)
   # scripts/store/store-listing-preflight.sh stays as a LOCAL pre-push validation helper.
+
+  # Resolve the Android applicationId DYNAMICALLY from gradle/libs.versions.toml#appId so the
+  # firebase app-id↔package preflight (FB-PRE-3) stays correct as product flavors evolve.
+  # NEVER hardcode the applicationId here — multi-product-flavor support depends on this.
+  resolve-app-id:
+    name: Resolve applicationId
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      application_id: ${{ steps.appid.outputs.application_id }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: appid
+        shell: bash
+        run: |
+          APP_ID="$(grep -E '^appId[[:space:]]*=' gradle/libs.versions.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')"
+          if [[ -z "$APP_ID" ]]; then
+            echo "❌ could not resolve appId from gradle/libs.versions.toml"; exit 1
+          fi
+          echo "application_id=$APP_ID" >> "$GITHUB_OUTPUT"
+          echo "✅ resolved applicationId = $APP_ID"
+
   release:
     name: Release
+    needs: [resolve-app-id]
     # Permissions cascade through nested reusable workflows (this → orchestrator
     # → publish-*-kmp). Declare here at the caller boundary so the deepest jobs
     # — publish-web-kmp's gh-pages/cloudflare/netlify/vercel stages — can
@@ -149,9 +173,9 @@ jobs:
     with:
       version_tag:          ${{ inputs.version_tag }}
       android_package_name: cmp-android
-      # applicationId (prod flavor) — feeds the firebase app-id↔package preflight (FB-PRE-3)
-      # in publish-android-kmp release-firebase.yaml@v2.0.21.
-      application_id:       org.mifos.kmp.template
+      # applicationId resolved dynamically (resolve-app-id job) — feeds the firebase
+      # app-id↔package preflight (FB-PRE-3). Stays correct across product flavors.
+      application_id:       ${{ needs.resolve-app-id.outputs.application_id }}
       ios_package_name:     cmp-ios
       mac_package_name:     cmp-desktop
       shared_module:        cmp-shared

--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -145,10 +145,13 @@ jobs:
     # (parse-time literal only). For local-dev iteration use the companion
     # workflow `release-multi-platform-local.yml`, which pins @dev and is
     # dispatched by `/ci local-actions` against the fork.
-    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.45
+    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.46
     with:
       version_tag:          ${{ inputs.version_tag }}
       android_package_name: cmp-android
+      # applicationId (prod flavor) — feeds the firebase app-id↔package preflight (FB-PRE-3)
+      # in publish-android-kmp release-firebase.yaml@v2.0.21.
+      application_id:       org.mifos.kmp.template
       ios_package_name:     cmp-ios
       mac_package_name:     cmp-desktop
       shared_module:        cmp-shared


### PR DESCRIPTION
## What
- Bumps orchestrator pin `@v1.0.45 → @v1.0.46`
- Adds a `resolve-app-id` job that reads `gradle/libs.versions.toml#appId` at runtime and passes it as `application_id` to the orchestrator — **dynamic, not hardcoded** (multi-product-flavor ready)

## Why (Option A — validation consolidated in the actionhub)
The full Firebase preflight (SA validity + app-id format + **app-id↔package match**) lives in the Tier-3 actionhub `release-firebase.yaml@v2.0.21` `validate-secrets`, so every consumer inherits it. `application_id` feeds the FB-PRE-3 match that catches the 2026-06-24 stale-app-id/package-mismatch class at the preflight node, before the build. Resolved dynamically so it stays correct as product flavors evolve.

Supersedes the consumer-side `FirebaseHelpers.preflight!` (PR #223, closed).

## Cascade (merged/tagged)
- publish-android-kmp #13 → `v2.0.21` ✅
- openMF/mifos-x-actionhub → `v1.0.46` ✅
- this PR → consumer pin + dynamic application_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to automatically detect the Android app ID during deployment.
  * Passed the detected app ID into the multi-platform release workflow, alongside the existing release settings.
  * Bumped the reusable release workflow to the latest version for this pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->