### PR TITLE
feat(secrets): build-secrets resolver + LAYOUT.yaml — decouple seam (Phase 7 T1-T3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,8 +81,14 @@ secrets/android/playStorePublishServiceCredentialsFile.json
 # Secrets and Configuration - NEVER COMMIT THESE!
 # secrets.env — REMOVED: that file is retired (2026-06-23). Keystore passwords
 # now live in secrets/android/keystores/ (covered by secrets/ below).
-secrets/
+# Ignore secret CONTENTS (every subdir: android/ apple/ desktop/ _env/ …) but allow
+# re-including the layout contract. `secrets/*` (not `secrets/`) leaves the dir itself
+# un-excluded so a child can be re-included (git rule). Phase 7 restructure later
+# narrows this to `/secrets/live/` once sample/ is committed.
+secrets/*
 !secrets/.gitkeep
+# The secrets LAYOUT contract is the SoT for PATHS — it holds NO secret values.
+!secrets/LAYOUT.yaml
 .env.local
 !.env.local.example
 

--- a/deployment/_shared/lib/build_secrets.rb
+++ b/deployment/_shared/lib/build_secrets.rb
@@ -1,0 +1,171 @@
+# deployment/_shared/lib/build_secrets.rb
+#
+# The ONE implementation of the secrets resolver. Reads secrets/LAYOUT.yaml (the
+# single source of truth for the secrets layout) and answers, for any secret key:
+#   - path(key)          → where the file is / will be (live wins, else sample)
+#   - value(key)         → the string value (env-first, file fallback)
+#   - exists?(key)       → is it materialized?
+#   - materialize!(key)  → decode the env/literal into its on-disk path
+#   - application_id     → flavor-aware applicationId (libs.versions.toml#appId + suffix)
+#
+# Exposed two ways from this one file: a Ruby API (BuildSecrets.for(...)) used by
+# config.rb + the Fastlane lanes, and a CLI (the `if __FILE__ == $0` block) used by
+# the GitHub Actions pre_fastlane_script via deployment/scripts/build-secrets.
+#
+# Stdlib-only (yaml/json/fileutils/base64) so it runs on the runner's SYSTEM Ruby,
+# BEFORE Fastlane's Bundler is set up (pre_fastlane_script timing).
+require "yaml"
+require "fileutils"
+require "base64"
+
+module BuildSecrets
+  # LAYOUT lives at <repo>/secrets/LAYOUT.yaml. This file is at
+  # <repo>/deployment/_shared/lib/build_secrets.rb → three dirs up to the repo root.
+  REPO_ROOT = File.expand_path("../../..", __dir__)
+  LAYOUT    = File.join(REPO_ROOT, "secrets", "LAYOUT.yaml")
+
+  # Product-flavor → applicationId suffix. Mirrors org.convention.AppFlavor.
+  FLAVOR_SUFFIX = { "prod" => "", "demo" => ".demo" }.freeze
+
+  def self.for(flavor: :prod, variant: :release)
+    Accessor.new(flavor.to_s, variant.to_s)
+  end
+
+  class Accessor
+    def initialize(flavor, variant)
+      @flavor  = flavor
+      @variant = variant
+      @doc     = YAML.load_file(LAYOUT)
+    end
+
+    # Spec for a secret, with any `by_flavor[<flavor>]` override merged on top.
+    def spec(key)
+      base = @doc.fetch("secrets").fetch(key.to_s) { raise "unknown secret '#{key}'" }
+      ov   = base["by_flavor"] && base["by_flavor"][@flavor]
+      ov ? base.merge(ov) : base
+    end
+
+    # Interpolate {flavor}/{variant} into a relative path.
+    def rel(key)
+      (spec(key)["rel"] || "").gsub("{flavor}", @flavor).gsub("{variant}", @variant)
+    end
+
+    # Candidate on-disk locations, in precedence order. `consume_at` (out-of-tree,
+    # e.g. cmp-android/google-services.json) short-circuits the root search.
+    def candidate_paths(key)
+      s = spec(key)
+      if s["consume_at"]
+        [s["consume_at"].gsub("{flavor}", @flavor).gsub("{variant}", @variant)]
+      else
+        @doc.fetch("precedence").map { |root| File.join(@doc["roots"].fetch(root), rel(key)) }
+      end
+    end
+
+    # Resolved read path: first existing candidate, else the highest-precedence one.
+    def path(key)
+      candidate_paths(key).find { |p| File.exist?(p) } || candidate_paths(key).last
+    end
+
+    def exists?(key)
+      candidate_paths(key).any? { |p| File.exist?(p) }
+    end
+
+    # String value: env var first (CI), then the on-disk file (local fallback).
+    def value(key)
+      env = ENV[spec(key)["source_env"].to_s]
+      return env unless env.to_s.empty?
+      p = path(key)
+      File.exist?(p) ? File.read(p).strip : nil
+    end
+
+    # Flavor-aware applicationId — feeds the FB-PRE-3 app-id↔package preflight.
+    def application_id
+      toml = File.join(REPO_ROOT, "gradle", "libs.versions.toml")
+      base = File.read(toml)[/^appId\s*=\s*"([^"]+)"/, 1]
+      raise "appId not found in #{toml}" if base.nil? || base.empty?
+      "#{base}#{FLAVOR_SUFFIX.fetch(@flavor, '')}"
+    end
+
+    # Write a secret to its on-disk path. Returns the path, or nil if the source is empty.
+    def materialize!(key, from_env: nil)
+      s    = spec(key)
+      kind = s.fetch("kind")
+      dest = materialize_dest(key, s)
+      body = materialize_body(key, s, kind, from_env)
+      return nil if body.nil? || body.empty?
+
+      FileUtils.mkdir_p(File.dirname(dest))
+      # Files keep their bytes verbatim; line-oriented values get a trailing newline.
+      File.write(dest, kind == "file" ? body : "#{body.chomp}\n")
+      File.chmod(s["mode"].to_i(8), dest) if s["mode"]
+      dest
+    end
+
+    # Materialize every secret whose source is present (used by `materialize-all`).
+    def materialize_all!
+      @doc.fetch("secrets").keys.filter_map { |k| materialize!(k) }
+    end
+
+    private
+
+    def materialize_dest(key, s)
+      live = @doc["roots"].fetch("live")
+      return s["consume_at"].gsub("{flavor}", @flavor).gsub("{variant}", @variant) if s["consume_at"]
+      return File.join(live, "_env", s.fetch("source_env")) if s["kind"] == "env_var"
+      File.join(live, rel(key))
+    end
+
+    def materialize_body(_key, s, kind, from_env)
+      case kind
+      when "literal"
+        s["value"]
+      when "value", "env_var"
+        ENV[s["source_env"].to_s]
+      when "file"
+        raw = ENV[(from_env || s["source_env"]).to_s]
+        return nil if raw.to_s.empty?
+        decode_file(raw, s["encoding"])
+      else
+        raise "unknown kind '#{kind}'"
+      end
+    end
+
+    # base64 → decode; pem-or-base64 → raw PEM passthrough else decode; plain → verbatim.
+    def decode_file(raw, encoding)
+      case encoding
+      when "pem-or-base64"
+        raw.lstrip.start_with?("-----BEGIN") ? raw : Base64.decode64(raw)
+      when "base64"
+        Base64.decode64(raw)
+      else
+        raw
+      end
+    end
+  end
+end
+
+# ── CLI ─────────────────────────────────────────────────────────────────────
+if __FILE__ == $PROGRAM_NAME
+  cmd, *rest = ARGV
+  # keyless commands (application-id, materialize-all) have no positional <key>;
+  # a leading "--flag" means the key was omitted.
+  key = (rest.first && !rest.first.start_with?("--")) ? rest.shift : nil
+  opts = {}
+  rest.each_slice(2) { |flag, val| opts[flag.sub(/\A--/, "")] = val }
+  acc = BuildSecrets.for(flavor: (opts["flavor"] || "prod"), variant: (opts["variant"] || "release"))
+
+  case cmd
+  when "path"            then puts acc.path(key)
+  when "value"           then puts acc.value(key)
+  when "application-id"  then puts acc.application_id
+  when "exists"          then exit(acc.exists?(key) ? 0 : 1)
+  when "materialize"
+    dest = acc.materialize!(key, from_env: opts["from-env"])
+    warn(dest ? "✓ materialized #{key} → #{dest}" : "· skip #{key} (source empty)")
+  when "materialize-all"
+    acc.materialize_all!.each { |d| warn "✓ #{d}" }
+  else
+    abort "usage: build-secrets {path|value|application-id|exists|materialize|materialize-all} " \
+          "[key] [--flavor f] [--variant v] [--from-env VAR]"
+  end
+end

--- a/deployment/scripts/build-secrets
+++ b/deployment/scripts/build-secrets
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Thin CLI over BuildSecrets (deployment/_shared/lib/build_secrets.rb).
+# Used by the GitHub Actions pre_fastlane_script + any bash step that needs a
+# resolved secrets path/value. Runs on the runner's system Ruby (stdlib-only).
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec ruby "$HERE/../_shared/lib/build_secrets.rb" "$@"

--- a/secrets/LAYOUT.yaml
+++ b/secrets/LAYOUT.yaml
@@ -1,0 +1,127 @@
+# secrets/LAYOUT.yaml — SINGLE SOURCE OF TRUTH for the secrets *layout/contract*.
+#
+# This is the ONLY place the on-disk secrets structure is declared. Every reader
+# (config.rb, Fastlane lanes, firebase_helpers.rb) and every writer (the GitHub
+# Actions pre_fastlane_script, `/secrets pull`) resolves through `build-secrets`,
+# which reads this file. Reorganize secrets/ → edit THIS file; code + workflows
+# never change.
+#
+# Values are NOT here — those live in the vault (mirrored to GitHub Secrets +
+# materialized into secrets/live/ at runtime). This file only declares WHERE/HOW.
+#
+# Resolution: `precedence` roots are tried in order; the first existing file wins
+# (live real secrets beat committed sample fakes). Phase 7 decouple step keeps
+# both roots = `secrets` (today's flat layout); the restructure step flips them
+# to secrets/live + secrets/sample.
+#
+# Secret kinds:
+#   file   + encoding base64|pem-or-base64|plain → decoded to a file
+#   value                                         → env-first string, file fallback
+#   literal (value:)                              → constant string written to a file
+#   env_var                                       → env-line; materialized to _env/<VAR>
+# Optional per-secret keys: consume_at (out-of-tree read path), mode (chmod octal),
+#   by_flavor (per-flavor source_env/rel override), {flavor}/{variant} in rel/consume_at.
+version: 1
+roots:
+  live: secrets       # restructure step → secrets/live
+  sample: secrets     # restructure step → secrets/sample
+precedence: [live, sample]
+
+secrets:
+  # ── kind: file / base64 ────────────────────────────────────────────────────
+  firebase_service_account:
+    kind: file
+    encoding: base64
+    source_env: FIREBASE_CREDS_B64
+    rel: android/firebase/service-account.json
+    mode: "0600"
+  play_service_account:
+    kind: file
+    encoding: base64
+    source_env: PLAYSTORE_CREDS_B64
+    rel: android/play/service-account.json
+    mode: "0600"
+  upload_keystore:
+    kind: file
+    encoding: base64
+    source_env: UPLOAD_KEYSTORE_B64
+    rel: android/keystores/upload_keystore.keystore
+    mode: "0600"
+  google_services:
+    kind: file
+    encoding: base64
+    source_env: GOOGLE_SERVICES_B64
+    rel: android/google-services.json
+    consume_at: cmp-android/google-services.json   # gradle google-services plugin reads it here
+  mac_app_store_cert:
+    kind: file
+    encoding: base64
+    source_env: MAC_APP_STORE_CERT_P12_B64
+    rel: desktop/macos/app_store.p12
+    mode: "0600"
+  mac_installer_cert:
+    kind: file
+    encoding: base64
+    source_env: MAC_INSTALLER_CERT_P12_B64
+    rel: desktop/macos/installer.p12
+    mode: "0600"
+
+  # ── kind: file / pem-or-base64 (raw PEM passthrough OR base64 decode) ───────
+  appstore_auth_key:
+    kind: file
+    encoding: pem-or-base64
+    source_env: APPSTORE_AUTH_KEY_B64
+    rel: apple/appstore/AuthKey.p8
+    mode: "0600"
+  match_ssh_key:
+    kind: file
+    encoding: pem-or-base64
+    source_env: MATCH_GIT_PRIVATE_KEY
+    rel: apple/match/match_ci_key
+    mode: "0600"
+
+  # ── kind: literal (constant → file) ────────────────────────────────────────
+  match_git_url:
+    kind: literal
+    value: "git@github.com:openMF/ios-provisioning-profile.git"
+    rel: apple/match/git_url
+  match_git_branch:
+    kind: literal
+    value: "master"
+    rel: apple/match/git_branch
+
+  # ── kind: value (env-first, file fallback) ─────────────────────────────────
+  # FLAVOR-AWARE: prod vs demo diverge today (different Firebase App IDs) → by_flavor.
+  firebase_android_app_id:
+    kind: value
+    by_flavor:
+      prod: { source_env: FIREBASE_ANDROID_APP_ID,      rel: android/firebase/android_app_id }
+      demo: { source_env: FIREBASE_ANDROID_DEMO_APP_ID, rel: android/firebase/android_demo_app_id }
+  appstore_key_id:
+    kind: value
+    source_env: APPSTORE_KEY_ID
+    rel: apple/appstore/key_id
+  appstore_issuer_id:
+    kind: value
+    source_env: APPSTORE_ISSUER_ID
+    rel: apple/appstore/issuer_id
+
+  # ── kind: env_var (env-line → _env/<VAR>; consumed as env on CI) ────────────
+  match_password:               { kind: env_var, source_env: MATCH_PASSWORD }
+  azure_ts_account_name:        { kind: env_var, source_env: AZURE_TS_ACCOUNT_NAME }
+  azure_ts_cert_profile_name:   { kind: env_var, source_env: AZURE_TS_CERT_PROFILE_NAME }
+  azure_ts_client_id:           { kind: env_var, source_env: AZURE_TS_CLIENT_ID }
+  azure_ts_subscription_id:     { kind: env_var, source_env: AZURE_TS_SUBSCRIPTION_ID }
+  azure_ts_tenant_id:           { kind: env_var, source_env: AZURE_TS_TENANT_ID }
+  cloudflare_account_id:        { kind: env_var, source_env: CLOUDFLARE_ACCOUNT_ID }
+  cloudflare_pages_api_token:   { kind: env_var, source_env: CLOUDFLARE_PAGES_API_TOKEN }
+  github_release_upload_token:  { kind: env_var, source_env: GH_TOKEN }
+  ms_app_id:                    { kind: env_var, source_env: MS_APP_ID }
+  ms_partner_center_client_id:     { kind: env_var, source_env: MS_PARTNER_CENTER_CLIENT_ID }
+  ms_partner_center_client_secret: { kind: env_var, source_env: MS_PARTNER_CENTER_CLIENT_SECRET }
+  ms_partner_center_tenant_id:     { kind: env_var, source_env: MS_PARTNER_CENTER_TENANT_ID }
+  netlify_auth_token:           { kind: env_var, source_env: NETLIFY_AUTH_TOKEN }
+  netlify_site_id:              { kind: env_var, source_env: NETLIFY_SITE_ID }
+  vercel_org_id:                { kind: env_var, source_env: VERCEL_ORG_ID }
+  vercel_project_id:            { kind: env_var, source_env: VERCEL_PROJECT_ID }
+  vercel_token:                 { kind: env_var, source_env: VERCEL_TOKEN }


### PR DESCRIPTION
## What (Phase 7, T1-T3 — decouple-first seam)
Single-source-of-truth secrets resolver. **Pure addition — nothing consumes it yet**, so zero behavior change.

- `secrets/LAYOUT.yaml` — the SoT for the secrets *layout* (31 secrets; kinds file/value/literal/env_var; base64 + pem-or-base64; `by_flavor` + `consume_at`)
- `deployment/_shared/lib/build_secrets.rb` — the one implementation (Ruby API + CLI), stdlib-only (runs on system Ruby before Fastlane bundler)
- `deployment/scripts/build-secrets` — bash CLI wrapper (committed +x)

## Verified
resolution · `consume_at`→cmp-android/google-services.json · pem-passthrough · base64-decode · **by_flavor** (prod vs demo App ID) · **application_id** (`…template` / `…template.demo`). A verify caught + fixed a keyless-CLI flavor-parsing bug.

## Next (follow-up PR)
T4-T12: repoint readers (config.rb + 6 Play lanes + firebase_helpers.rb) + the workflow `pre_fastlane_script`, then `secrets_demo→sample`/`live` restructure, manifest repoint, CI guard, live green-verify.

Plan: `multi-platform-release-completion / 07-secrets-resolver-restructure`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new secrets management command for resolving, checking, and materializing app secrets.
  * Supports using environment values first, with file-based fallbacks and automatic selection between live and sample secrets.
  * Added options to generate secret files, apply file permissions, and look up the app identifier for a given build variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->