### PR TITLE
fix(ci): drop unsupported application_id input breaking release-multi-platform.yml startup

### DIFF
--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -147,28 +147,6 @@ jobs:
   #     (metadata_path + skip_upload_{metadata,changelogs,images,screenshots}: false)
   # scripts/store/store-listing-preflight.sh stays as a LOCAL pre-push validation helper.
 
-  # Resolve the Android applicationId DYNAMICALLY from gradle/libs.versions.toml#appId so the
-  # firebase app-id↔package preflight (FB-PRE-3) stays correct as product flavors evolve.
-  # NEVER hardcode the applicationId here — multi-product-flavor support depends on this.
-  resolve-app-id:
-    name: Resolve applicationId
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      application_id: ${{ steps.appid.outputs.application_id }}
-    steps:
-      - uses: actions/checkout@v4
-      - id: appid
-        shell: bash
-        run: |
-          APP_ID="$(grep -E '^appId[[:space:]]*=' gradle/libs.versions.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')"
-          if [[ -z "$APP_ID" ]]; then
-            echo "❌ could not resolve appId from gradle/libs.versions.toml"; exit 1
-          fi
-          echo "application_id=$APP_ID" >> "$GITHUB_OUTPUT"
-          echo "✅ resolved applicationId = $APP_ID"
-
   # Resolve `(flavor, build_type)` against the DSL manifest — the single
   # derivation point that stays truthful even as flavors are added / renamed
   # in `kmpFlavors {}` (D9 zero-hardcode). Runs BEFORE any platform build so
@@ -220,7 +198,7 @@ jobs:
 
   release:
     name: Release
-    needs: [resolve-app-id, resolve-variants]
+    needs: [resolve-variants]
     strategy:
       # One deploy per (flavor, build_type) — populated by `resolve-variants`.
       # `flavor=all` fans out into every declared flavor; a single-flavor
@@ -253,9 +231,11 @@ jobs:
     with:
       version_tag:          ${{ inputs.version_tag }}
       android_package_name: cmp-android
-      # applicationId resolved dynamically (resolve-app-id job) — feeds the firebase
-      # app-id↔package preflight (FB-PRE-3). Stays correct across product flavors.
-      application_id:       ${{ needs.resolve-app-id.outputs.application_id }}
+      # NOTE: applicationId is NOT threaded as an input — release-multi-platform-v2.yaml@v1.0.47
+      # (latest actionhub tag) declares no `application_id` input; it resolves the Android app-id
+      # for the firebase preflight from `firebase_android_app_id` / `firebase_android_demo_app_id`
+      # (inherited secrets) per flavor. Passing `application_id` made the whole workflow invalid at
+      # startup ("Invalid workflow file"). Product-flavor selection flows via `flavor`/`build_type`.
       ios_package_name:     cmp-ios
       mac_package_name:     cmp-desktop
       shared_module:        cmp-shared


### PR DESCRIPTION
## Problem

`Release · Multi-Platform` failed at **startup** — GitHub rejected the workflow file:

> Invalid workflow file: .github/workflows/release-multi-platform.yml (Line 258)

## Root cause

The workflow passed an `application_id` input to the reusable workflow
`openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.47`.
That reusable workflow (v1.0.47 is the latest actionhub tag) **declares no `application_id` input** — GitHub rejects any `with:` key the called workflow does not accept, which invalidates the entire file at startup. `actionlint` cannot catch this class because it does not fetch the remote reusable workflow to validate inputs.

Verified by diffing v2@v1.0.47`s declared inputs against everything the caller passes — `application_id` was the **only** mismatch.

## Fix

- Remove the `resolve-app-id` job (its `application_id` output was consumed in exactly one place — the invalid input).
- Drop it from the `release` job`s `needs:` → `needs: [resolve-variants]`.
- Remove the `application_id:` input (with an explanatory comment).

The per-flavor firebase preflight is unaffected — the workflow already passes
`firebase_android_app_id` / `firebase_android_demo_app_id` (both valid v2 inputs),
which is how v2 resolves the Android app-id per flavor. Product-flavor releasing
continues via the `flavor` / `build_type` inputs + the `resolve-variants` matrix.

## Validation

- `actionlint` exit 0
- YAML parses
- Caller `with:` keys are now a strict subset of v2@v1.0.47`s accepted inputs

_Note: the startup-failure class is only fully re-confirmable by dispatching the workflow; the diagnosis is certain since the invalid input is provably absent from v2`s input list._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the multi-platform release workflow by removing redundant Android configuration steps.
  * Improved release configuration handling so Android application details are resolved automatically during the release process.
  * Simplified platform release setup without changing the app’s user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->