### PR TITLE
ci(release): bump actionhub pin to v1.0.48 (all-platform product-flavor release)

### DIFF
--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -1,6 +1,6 @@
 # .github/workflows/release-multi-platform.yml
 #
-# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.28
+# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.48
 #
 # All orchestration logic lives in the centralized reusable workflow.
 # This file just declares the dispatch inputs + passes secrets through.
@@ -227,11 +227,11 @@ jobs:
     # publish-apple @v2.0.15, which carry the flavor dimension). The `with:`
     # block below threads `matrix.flavor` / `matrix.build_type` from the
     # resolve-variants job.
-    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.47
+    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.48
     with:
       version_tag:          ${{ inputs.version_tag }}
       android_package_name: cmp-android
-      # NOTE: applicationId is NOT threaded as an input — release-multi-platform-v2.yaml@v1.0.47
+      # NOTE: applicationId is NOT threaded as an input — release-multi-platform-v2.yaml@v1.0.48
       # (latest actionhub tag) declares no `application_id` input; it resolves the Android app-id
       # for the firebase preflight from `firebase_android_app_id` / `firebase_android_demo_app_id`
       # (inherited secrets) per flavor. Passing `application_id` made the whole workflow invalid at


### PR DESCRIPTION
Follow-up to #235. Bumps the reusable-workflow pin `@v1.0.47`→`@v1.0.48`, which threads flavor/build_type to Desktop + Web publish calls (Android/iOS/macOS already wired). v1.0.48 pins publish-desktop-kmp @v2.0.8 (fixes -PflavorDimension→-PkmpFlavor) + publish-web-kmp @v2.0.9. Enables product-flavor releasing on all 5 platforms.