### PR TITLE
ci(release): actionhub v1.0.52 (desktop create-release active) + macOS runs by default

### DIFF
--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -1,6 +1,6 @@
 # .github/workflows/release-multi-platform.yml
 #
-# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.51
+# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.52
 #
 # All orchestration logic lives in the centralized reusable workflow.
 # This file just declares the dispatch inputs + passes secrets through.
@@ -77,7 +77,7 @@ on:
         required: false
         type: choice
         options: [skip, internal, beta, production]
-        default: skip
+        default: internal
 
       desktop_win_rung:
         description: 'Windows — top rung'
@@ -225,11 +225,11 @@ jobs:
     # @v2.0.15, publish-desktop @v2.0.8, publish-web @v2.0.10 — all carry the flavor
     # dimension). The `with:` block below threads the single dispatched
     # `inputs.flavor` / `inputs.build_type` straight through.
-    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.51
+    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.52
     with:
       version_tag:          ${{ inputs.version_tag }}
       android_package_name: cmp-android
-      # NOTE: applicationId is NOT threaded as an input — release-multi-platform-v2.yaml@v1.0.51
+      # NOTE: applicationId is NOT threaded as an input — release-multi-platform-v2.yaml@v1.0.52
       # (latest actionhub tag) declares no `application_id` input; it resolves the Android app-id
       # for the firebase preflight from `firebase_android_app_id` / `firebase_android_demo_app_id`
       # (inherited secrets) per flavor. Passing `application_id` made the whole workflow invalid at


### PR DESCRIPTION
Two audit fixes: (1) bump @v1.0.51→v1.0.52 which pins publish-desktop-kmp @v2.0.10 — activates create-release-if-missing (v2.0.9 added it to the composite actions but release.yaml still pinned @v2.0.8, so it never ran → desktop 'release not found'). (2) mac_rung default skip→internal so macOS runs by default with Android + iOS.