### PR TITLE
fix(ci): wire correct macOS signing secret names (unblock Mac TF)

### DIFF
--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -361,12 +361,15 @@ jobs:
       match_password:               ${{ secrets.MATCH_PASSWORD }}
       match_ssh_private_key:        ${{ secrets.MATCH_SSH_PRIVATE_KEY }}
       SOPS_AGE_KEY:                 ${{ secrets.SOPS_AGE_KEY }}
-      # --- NEW: macOS .p12 signing (Tier-3, blocked-on-onboarding until certs provisioned) ---
-      mac_signing_certificate:            ${{ secrets.MAC_SIGNING_CERTIFICATE }}
+      # macOS .p12 signing (Tier-3). Certs are provisioned as base64 secrets (managed via the
+      # openMF/ios-provisioning-profile fastlane-match repo, exported for the manual mac keychain
+      # import). App-distribution cert + installer-distribution cert + the embedded provisioning
+      # profile. The p12s are password-less (the tier-3 import uses `-P ""`).
+      mac_signing_certificate:            ${{ secrets.MAC_APP_DISTRIBUTION_CERTIFICATE_B64 }}
       mac_signing_certificate_password:   ${{ secrets.MAC_SIGNING_CERTIFICATE_PASSWORD }}
-      mac_installer_certificate:          ${{ secrets.MAC_INSTALLER_CERTIFICATE }}
+      mac_installer_certificate:          ${{ secrets.MAC_INSTALLER_DISTRIBUTION_CERTIFICATE_B64 }}
       mac_installer_certificate_password: ${{ secrets.MAC_INSTALLER_CERTIFICATE_PASSWORD }}
-      mac_provisioning_profile_base64:    ${{ secrets.MAC_PROVISIONING_PROFILE_BASE64 }}
+      mac_provisioning_profile_base64:    ${{ secrets.MAC_EMBEDDED_PROVISION_B64 }}
       keychain_password:                  ${{ secrets.KEYCHAIN_PASSWORD }}
       # --- NEW: Web host tokens + Vercel project identity ---
       cloudflare_api_token:         ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
macOS Mac TF failed at '.p12 keychain sign' (security import: parameters not valid) because the referenced mac secrets don't exist → empty cert. Maps to the real provisioned names: mac_signing_certificate→MAC_APP_DISTRIBUTION_CERTIFICATE_B64, mac_installer_certificate→MAC_INSTALLER_DISTRIBUTION_CERTIFICATE_B64, mac_provisioning_profile_base64→MAC_EMBEDDED_PROVISION_B64. Android + iOS already pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS release signing configuration to use separate base64-encoded app and installer certificates, passwords, and embedded provisioning profiles.
  * Improved compatibility and reliability for macOS release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->