### PR TITLE
ci(release): bump actionhub to v1.0.53 (macOS Fastlane Match signing)

### DIFF
--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -1,6 +1,6 @@
 # .github/workflows/release-multi-platform.yml
 #
-# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.52
+# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.53
 #
 # All orchestration logic lives in the centralized reusable workflow.
 # This file just declares the dispatch inputs + passes secrets through.
@@ -225,11 +225,11 @@ jobs:
     # @v2.0.15, publish-desktop @v2.0.8, publish-web @v2.0.10 — all carry the flavor
     # dimension). The `with:` block below threads the single dispatched
     # `inputs.flavor` / `inputs.build_type` straight through.
-    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.52
+    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.53
     with:
       version_tag:          ${{ inputs.version_tag }}
       android_package_name: cmp-android
-      # NOTE: applicationId is NOT threaded as an input — release-multi-platform-v2.yaml@v1.0.52
+      # NOTE: applicationId is NOT threaded as an input — release-multi-platform-v2.yaml@v1.0.53
       # (latest actionhub tag) declares no `application_id` input; it resolves the Android app-id
       # for the firebase preflight from `firebase_android_app_id` / `firebase_android_demo_app_id`
       # (inherited secrets) per flavor. Passing `application_id` made the whole workflow invalid at


### PR DESCRIPTION
Pins publish-apple-kmp @v2.0.16 — Mac TF now signs via Fastlane Match (like iOS) instead of the broken manual .p12 import. Completes the macOS Match migration.