### PR TITLE
ci(release): bump actionhub v1.0.56 — macOS setup-ruby working-directory fix

### DIFF
--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -1,6 +1,6 @@
 # .github/workflows/release-multi-platform.yml
 #
-# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.55
+# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.56
 #
 # All orchestration logic lives in the centralized reusable workflow.
 # This file just declares the dispatch inputs + passes secrets through.
@@ -225,11 +225,11 @@ jobs:
     # @v2.0.15, publish-desktop @v2.0.8, publish-web @v2.0.10 — all carry the flavor
     # dimension). The `with:` block below threads the single dispatched
     # `inputs.flavor` / `inputs.build_type` straight through.
-    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.55
+    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.56
     with:
       version_tag:          ${{ inputs.version_tag }}
       android_package_name: cmp-android
-      # NOTE: applicationId is NOT threaded as an input — release-multi-platform-v2.yaml@v1.0.55
+      # NOTE: applicationId is NOT threaded as an input — release-multi-platform-v2.yaml@v1.0.56
       # (latest actionhub tag) declares no `application_id` input; it resolves the Android app-id
       # for the firebase preflight from `firebase_android_app_id` / `firebase_android_demo_app_id`
       # (inherited secrets) per flavor. Passing `application_id` made the whole workflow invalid at


### PR DESCRIPTION
Fixes macOS TestFlight exit 127 `bundler: command not found: fastlane`.

The `macos-signing` composite now runs `ruby/setup-ruby` with `working-directory: deployment/` so bundler-cache installs the `deployment/Gemfile` (which has fastlane) instead of the repo-root Gemfile — mirroring the working `ios-testflight-internal`. Split into standard + pre-materialized mode branches; forwards flavor/build_type to the mac lane.

Chain: apple `v2.0.18` → orchestrator `v1.0.56` → this consumer pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)