### PR TITLE
ci(release): bump actionhub v1.0.57 — macOS pre-materialized ASC .p8 fix

### DIFF
--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -1,6 +1,6 @@
 # .github/workflows/release-multi-platform.yml
 #
-# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.56
+# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.57
 #
 # All orchestration logic lives in the centralized reusable workflow.
 # This file just declares the dispatch inputs + passes secrets through.
@@ -225,11 +225,11 @@ jobs:
     # @v2.0.15, publish-desktop @v2.0.8, publish-web @v2.0.10 — all carry the flavor
     # dimension). The `with:` block below threads the single dispatched
     # `inputs.flavor` / `inputs.build_type` straight through.
-    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.56
+    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.57
     with:
       version_tag:          ${{ inputs.version_tag }}
       android_package_name: cmp-android
-      # NOTE: applicationId is NOT threaded as an input — release-multi-platform-v2.yaml@v1.0.56
+      # NOTE: applicationId is NOT threaded as an input — release-multi-platform-v2.yaml@v1.0.57
       # (latest actionhub tag) declares no `application_id` input; it resolves the Android app-id
       # for the firebase preflight from `firebase_android_app_id` / `firebase_android_demo_app_id`
       # (inherited secrets) per flavor. Passing `application_id` made the whole workflow invalid at


### PR DESCRIPTION
Fixes macOS TestFlight OpenSSL `invalid curve name` (OpenSSL::PKey::ECError).

Standard-mode self-materialization wrote `AuthKey.p8` to repo-root/secrets while `config.rb#load_api_key` reads a `deployment/`-relative `key_filepath`. v1.0.57 runs the mac job **pre-materialized** — forwarding `pre_fastlane_script` so the same proven consumer script iOS uses (shared apple secrets → LAYOUT.yaml path) materializes the .p8, and the composite just runs the mac lane.

Prior run [29112359165](https://github.com/openMF/kmp-project-template/actions/runs/29112359165) got past exit-127 (fastlane found) and failed at ASC key parse — this closes that.

Chain: apple `v2.0.19` → orchestrator `v1.0.57` → this pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)