### PR TITLE
fix(macos): thread -PkmpFlavor into desktop build (prod built demo)

### DIFF
--- a/deployment/desktop/mac-app-store/lane.rb
+++ b/deployment/desktop/mac-app-store/lane.rb
@@ -438,10 +438,19 @@ platform :mac do
     saved_env = {}
     %w[MAC_SIGNING_IDENTITY MAC_KEYCHAIN_PATH MAC_PROVISIONING_PROFILE_PATH].each { |k| saved_env[k] = ENV.delete(k) }
 
+    # Thread the active flavor into the Compose Desktop build. cmp-desktop/build.gradle.kts
+    # resolves `findProperty("kmpFlavor")` → falls back to the DSL default (demo) when
+    # absent. Without -PkmpFlavor a prod-requested release silently builds the DEMO
+    # variant (bundle org.mifos.kmp.template.demo) → upload_to_testflight can't find the
+    # app on App Store Connect AND it misaligns with the prod Match provisioning profile.
+    flavor = (options[:flavor] || ENV["FLAVOR"]).to_s.strip
+    gradle_args = [gradlew, "-p", repo_root, ":cmp-desktop:createReleaseDistributable",
+                   "--no-daemon", "--no-configuration-cache"]
+    gradle_args << "-PkmpFlavor=#{flavor}" unless flavor.empty?
+
     begin
-      UI.message("Building unsigned .app bundle (createReleaseDistributable)...")
-      sh(gradlew, "-p", repo_root, ":cmp-desktop:createReleaseDistributable",
-         "--no-daemon", "--no-configuration-cache")
+      UI.message("Building unsigned .app bundle (createReleaseDistributable, flavor=#{flavor.empty? ? '(default)' : flavor})...")
+      sh(*gradle_args)
     ensure
       saved_env.each { |k, v| ENV[k] = v if v }
     end


### PR DESCRIPTION
Run [29132760551](https://github.com/openMF/kmp-project-template/actions/runs/29132760551): signing + packaging all succeeded (codesign hang fixed), but `upload_to_testflight` failed — the mac build produced the **demo** bundle (`org.mifos.kmp.template.demo`) even though flavor=prod was requested.

`build_mac_pkg` ran `:cmp-desktop:createReleaseDistributable` with no flavor property; `cmp-desktop/build.gradle.kts:51` falls back to the DSL default (demo) when `-PkmpFlavor` is absent. Now threads `-PkmpFlavor=<flavor>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)