### PR TITLE
feat(release): centralized GitHub Release lifecycle (prerelease + changelog + artifacts + promote)

### DIFF
--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -1,6 +1,6 @@
 # .github/workflows/release-multi-platform.yml
 #
-# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.57
+# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.58
 #
 # All orchestration logic lives in the centralized reusable workflow.
 # This file just declares the dispatch inputs + passes secrets through.
@@ -225,11 +225,11 @@ jobs:
     # @v2.0.15, publish-desktop @v2.0.8, publish-web @v2.0.10 — all carry the flavor
     # dimension). The `with:` block below threads the single dispatched
     # `inputs.flavor` / `inputs.build_type` straight through.
-    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.57
+    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.58
     with:
       version_tag:          ${{ inputs.version_tag }}
       android_package_name: cmp-android
-      # NOTE: applicationId is NOT threaded as an input — release-multi-platform-v2.yaml@v1.0.57
+      # NOTE: applicationId is NOT threaded as an input — release-multi-platform-v2.yaml@v1.0.58
       # (latest actionhub tag) declares no `application_id` input; it resolves the Android app-id
       # for the firebase preflight from `firebase_android_app_id` / `firebase_android_demo_app_id`
       # (inherited secrets) per flavor. Passing `application_id` made the whole workflow invalid at


### PR DESCRIPTION
Implements the 3 requested GitHub Release behaviors for `release-multi-platform.yml`:

1. **Prerelease always created + changelog always current** — new orchestrator `gh-release-init` job creates the prerelease with a fresh conventional-commit changelog before any platform runs (previously the release only appeared if Desktop happened to run).
2. **All platform artifacts attached** — every tier-3 build now emits a `release-asset-*` workflow artifact (Android APK+AAB, iOS IPA, macOS .pkg, Web dist zip; Desktop installers self-attach). New `gh-release-finalize` job downloads them all and attaches via `--clobber`.
3. **Prerelease → stable on production** — `gh-release-finalize` owns the final flags: the release flips to a **stable latest** release the moment any store deployment reaches production (android/ios/mac=production, web=production, desktop=stable); otherwise it stays a prerelease accumulating artifacts.

Chain: android v2.0.23 · apple v2.0.20 · web v2.0.11 → orchestrator v1.0.58 → this pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the multi-platform release workflow to use the latest centralized release process.
  * Existing release settings and platform configuration remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->