### PR TITLE
ci(release): bump actionhub v1.0.59 — gh-release-finalize GH_REPO fix

### DIFF
--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -1,6 +1,6 @@
 # .github/workflows/release-multi-platform.yml
 #
-# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.58
+# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.59
 #
 # All orchestration logic lives in the centralized reusable workflow.
 # This file just declares the dispatch inputs + passes secrets through.
@@ -225,11 +225,11 @@ jobs:
     # @v2.0.15, publish-desktop @v2.0.8, publish-web @v2.0.10 — all carry the flavor
     # dimension). The `with:` block below threads the single dispatched
     # `inputs.flavor` / `inputs.build_type` straight through.
-    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.58
+    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.59
     with:
       version_tag:          ${{ inputs.version_tag }}
       android_package_name: cmp-android
-      # NOTE: applicationId is NOT threaded as an input — release-multi-platform-v2.yaml@v1.0.58
+      # NOTE: applicationId is NOT threaded as an input — release-multi-platform-v2.yaml@v1.0.59
       # (latest actionhub tag) declares no `application_id` input; it resolves the Android app-id
       # for the firebase preflight from `firebase_android_app_id` / `firebase_android_demo_app_id`
       # (inherited secrets) per flavor. Passing `application_id` made the whole workflow invalid at


### PR DESCRIPTION
Fixes gh-release-finalize `fatal: not a git repository` — the job has no checkout, so gh needs GH_REPO to target the release. All 5 platform artifacts already downloaded correctly in the prior test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the multi-platform release workflow to use the latest release process version.
  * Preserved existing version and Android package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->