### PR TITLE
feat(ios/mac): auto-sync + verify TestFlight store config before release

### DIFF
--- a/deployment/_shared/config.rb
+++ b/deployment/_shared/config.rb
@@ -548,6 +548,77 @@ def latest_tf_build_number_resilient(max_attempts: 3, sleep_seconds: 20, **opts)
   end
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# ensure_testflight_store_config — auto-sync + verify App Store Connect store
+# config from fastlane config BEFORE any TestFlight upload/promotion.
+# ─────────────────────────────────────────────────────────────────────────────
+# Makes the whole TestFlight release fully automatic: no manual App Store Connect
+# setup is ever required. Runs as a preflight in every TF lane (internal upload +
+# external promotion, iOS + macOS):
+#   1. VERIFIES the app record exists on ASC (fail-fast with a clear message instead
+#      of dying deep in `pilot`/`deliver` — the "app not found" class).
+#   2. SYNCS the app-level "Test Information" (BetaAppLocalization: description,
+#      feedback email, marketing / privacy URLs) from TESTFLIGHT_CONFIG — creating it
+#      when the app record has none (the `betaAppLocalizations not found` class) and
+#      updating it to match config otherwise. External beta review REQUIRES this, and
+#      pre-creating it means an external promotion never fails for a fresh app.
+# Requires load_api_key to have run first (populates Spaceship::ConnectAPI.token).
+# Idempotent + config-driven; opt out per-run with SKIP_TESTFLIGHT_STORE_SYNC=1.
+def ensure_testflight_store_config(app_identifier:, config: nil, locale: nil)
+  return UI.important("⏭  TestFlight store-config sync skipped (SKIP_TESTFLIGHT_STORE_SYNC=1).") \
+    if ENV["SKIP_TESTFLIGHT_STORE_SYNC"].to_s == "1"
+
+  require "spaceship"
+  config ||= FastlaneConfig::IosConfig::TESTFLIGHT_CONFIG
+  locale ||= (FastlaneConfig::IosConfig::BUILD_CONFIG[:primary_locale] rescue nil) || "en-US"
+  UI.user_error!("No ASC API token — call load_api_key before ensure_testflight_store_config") unless Spaceship::ConnectAPI.token
+
+  # ── 1. Verify the app record exists (fail-fast, clear guidance) ──
+  app = begin
+    Spaceship::ConnectAPI::App.find(app_identifier)
+  rescue => e
+    UI.important("⚠️  ASC app lookup flaked: #{e.message.to_s.lines.first&.strip}")
+    nil
+  end
+  UI.user_error!(
+    "App '#{app_identifier}' not found on App Store Connect. Create the app record " \
+    "(same bundle id) in App Store Connect → My Apps → + → New App, or fix the " \
+    "bundle id in gradle/libs.versions.toml, then re-run.",
+  ) unless app
+
+  # ── 2. Sync app-level Test Information (BetaAppLocalization) from config ──
+  li        = (config[:localized_app_info] || {})[locale] || {}
+  attrs     = {}
+  desc      = (config[:beta_app_description]   || li[:description]).to_s
+  email     = (config[:beta_app_feedback_email] || li[:feedback_email]).to_s
+  marketing = (li[:marketing_url]      || li[:marketingUrl]).to_s
+  privacy   = (li[:privacy_policy_url] || li[:privacyPolicyUrl]).to_s
+  attrs[:description]      = desc      unless desc.empty?
+  attrs[:feedbackEmail]    = email     unless email.empty?
+  attrs[:marketingUrl]     = marketing unless marketing.empty?
+  attrs[:privacyPolicyUrl] = privacy   unless privacy.empty?
+
+  if attrs.empty?
+    return UI.message("ℹ️  No TestFlight Test Information in config to sync for #{app_identifier}.")
+  end
+
+  begin
+    existing = (app.get_beta_app_localizations || []).find { |l| l.locale == locale }
+    if existing
+      existing.update(attributes: attrs)
+      UI.success("🔄 Synced TestFlight Test Information (#{locale}) for #{app_identifier}.")
+    else
+      Spaceship::ConnectAPI::BetaAppLocalization.create(app_id: app.id, attributes: attrs.merge(locale: locale))
+      UI.success("🆕 Created TestFlight Test Information (#{locale}) for #{app_identifier} — external beta review is now unblocked.")
+    end
+  rescue => e
+    # Never let a Test-Information sync hiccup block an internal upload; surface loudly.
+    UI.important("⚠️  Could not sync TestFlight Test Information for #{app_identifier}: " \
+                 "#{e.message.to_s.lines.first&.strip}. Internal upload continues; " \
+                 "external promotion may need it set on App Store Connect.")
+  end
+end
+
 # Revoke iOS Distribution certificates from Apple Developer Portal to free slots for
 # a fresh cert. Strategy (in order):
 #   1. Revoke all truly expired certs first (safe, they're already unusable).

--- a/deployment/desktop/mac-app-store/lane.rb
+++ b/deployment/desktop/mac-app-store/lane.rb
@@ -51,6 +51,12 @@ platform :mac do
     mac_bundle_id = ENV["MAC_APP_IDENTIFIER"] || ENV["MAC_BUNDLE_ID"] || ForkIdentity::APP_ID
 
     load_api_key(options)
+
+    # Auto-sync + verify ASC store config before the build (see config.rb) — fail fast
+    # on a missing app record + create/update TestFlight Test Information so a later
+    # Mac external-beta promotion never hits `betaAppLocalizations not found`.
+    ensure_testflight_store_config(app_identifier: mac_bundle_id)
+
     with_ios_preamble(options)
     setup_mac_signing_keychain(options, mac_bundle_id)
 
@@ -97,6 +103,9 @@ platform :mac do
     mac_bundle_id = ENV["MAC_APP_IDENTIFIER"] || ENV["MAC_BUNDLE_ID"] || ForkIdentity::APP_ID
 
     load_api_key(options)
+
+    # External beta review requires app-level Test Information — sync from config first.
+    ensure_testflight_store_config(app_identifier: mac_bundle_id)
 
     build_number = options[:build_number]&.to_s || latest_tf_build_number_resilient(
       app_identifier: mac_bundle_id,
@@ -178,6 +187,12 @@ platform :mac do
     mac_bundle_id = ENV["MAC_APP_IDENTIFIER"] || ENV["MAC_BUNDLE_ID"] || ForkIdentity::APP_ID
 
     load_api_key(options)
+
+    # Auto-sync + verify ASC store config before the build (see config.rb) — fail fast
+    # on a missing app record + create/update TestFlight Test Information so a later
+    # Mac external-beta promotion never hits `betaAppLocalizations not found`.
+    ensure_testflight_store_config(app_identifier: mac_bundle_id)
+
     with_ios_preamble(options)
     setup_mac_signing_keychain(options, mac_bundle_id)
 

--- a/deployment/ios/testflight/lane.rb
+++ b/deployment/ios/testflight/lane.rb
@@ -76,6 +76,14 @@ platform :ios do
     with_ios_preamble(options)
     setup_ci_if_needed
     load_api_key(options)
+
+    # Auto-sync + verify App Store Connect store config BEFORE the ~15-min build:
+    # fail fast if the app record is missing, and create/update the TestFlight "Test
+    # Information" (BetaAppLocalization) from TESTFLIGHT_CONFIG so the external-beta
+    # promotion never fails with `betaAppLocalizations not found`. Fully automatic —
+    # the TestFlight parallel to the Play Store listing sync that runs with the AAB.
+    ensure_testflight_store_config(app_identifier: ios_config[:app_identifier])
+
     fetch_certificates_with_match(options.merge(match_type: "appstore"))
 
     # Switch project from whatever signing state the previous lane left it in
@@ -163,6 +171,10 @@ platform :ios do
       app_identifier: ios_config[:app_identifier],
       api_key:        Actions.lane_context[SharedValues::APP_STORE_CONNECT_API_KEY],
     ).to_s
+
+    # External beta review REQUIRES the app-level Test Information — sync it from
+    # config first so this promotion never fails for a fresh app record.
+    ensure_testflight_store_config(app_identifier: ios_config[:app_identifier])
 
     external_groups = options[:groups] ||
                       testflight_config[:external_groups] ||


### PR DESCRIPTION
TestFlight parallel to the existing Play Store listing sync. New `ensure_testflight_store_config` preflight runs before every TF upload/promotion:
1. **Verifies** the ASC app record exists (fail-fast, clear guidance).
2. **Syncs** app-level Test Information (BetaAppLocalization) from `TESTFLIGHT_CONFIG` via Spaceship — create-if-missing + update. Pre-creating it means external beta review never fails `betaAppLocalizations not found`.

Fully automatic + config-driven; `SKIP_TESTFLIGHT_STORE_SYNC=1` opt-out. Wired into iOS beta + promoteToExternalBeta and macOS desktop_testflight + promoteMacToExternalBeta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)