### PR TITLE
ci(release): readable release-graph job names (actionhub v1.0.60)

### DIFF
--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -1,6 +1,6 @@
 # .github/workflows/release-multi-platform.yml
 #
-# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.59
+# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.60
 #
 # All orchestration logic lives in the centralized reusable workflow.
 # This file just declares the dispatch inputs + passes secrets through.
@@ -225,11 +225,11 @@ jobs:
     # @v2.0.15, publish-desktop @v2.0.8, publish-web @v2.0.10 — all carry the flavor
     # dimension). The `with:` block below threads the single dispatched
     # `inputs.flavor` / `inputs.build_type` straight through.
-    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.59
+    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.60
     with:
       version_tag:          ${{ inputs.version_tag }}
       android_package_name: cmp-android
-      # NOTE: applicationId is NOT threaded as an input — release-multi-platform-v2.yaml@v1.0.59
+      # NOTE: applicationId is NOT threaded as an input — release-multi-platform-v2.yaml@v1.0.60
       # (latest actionhub tag) declares no `application_id` input; it resolves the Android app-id
       # for the firebase preflight from `firebase_android_app_id` / `firebase_android_demo_app_id`
       # (inherited secrets) per flavor. Passing `application_id` made the whole workflow invalid at


### PR DESCRIPTION
The multi-platform release graph showed truncated, unreadable job names (`R.../ ... / Stage 1 — Play Intern...`). Shortened every job `name:` across the orchestrator + 4 tier-3 publish repos: e.g. `Stage 1 — Play Internal (approval required)` → `Play · Internal`, `Stage 1 — TestFlight Internal` → `TestFlight · Internal`, `GitHub Release · Finalize (…)` → `Release · Finalize`. Cosmetic only — no job ids, needs, environments, or logic changed.

Chain: android v2.0.24 · apple v2.0.21 · desktop v2.0.11 · web v2.0.12 → orchestrator v1.0.60 → this pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated release workflow to use the latest centralized multi-platform release process.
  * Existing release inputs and validation behavior remain unchanged.
  * This maintains consistent release handling across supported platforms without requiring changes to the release configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->