### PR TITLE
ci(release): aligned Stage-N job names (actionhub v1.0.61)

### DIFF
--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -1,6 +1,6 @@
 # .github/workflows/release-multi-platform.yml
 #
-# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.60
+# Thin wrapper → openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.61
 #
 # All orchestration logic lives in the centralized reusable workflow.
 # This file just declares the dispatch inputs + passes secrets through.
@@ -225,11 +225,11 @@ jobs:
     # @v2.0.15, publish-desktop @v2.0.8, publish-web @v2.0.10 — all carry the flavor
     # dimension). The `with:` block below threads the single dispatched
     # `inputs.flavor` / `inputs.build_type` straight through.
-    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.60
+    uses: openMF/mifos-x-actionhub/.github/workflows/release-multi-platform-v2.yaml@v1.0.61
     with:
       version_tag:          ${{ inputs.version_tag }}
       android_package_name: cmp-android
-      # NOTE: applicationId is NOT threaded as an input — release-multi-platform-v2.yaml@v1.0.60
+      # NOTE: applicationId is NOT threaded as an input — release-multi-platform-v2.yaml@v1.0.61
       # (latest actionhub tag) declares no `application_id` input; it resolves the Android app-id
       # for the firebase preflight from `firebase_android_app_id` / `firebase_android_demo_app_id`
       # (inherited secrets) per flavor. Passing `application_id` made the whole workflow invalid at


### PR DESCRIPTION
Follow-up to #258: keeps the readable short names but restores the ladder-consistent `Stage N ·` prefix across all four platforms — so the graph is both legible and aligned by promotion stage.

`Stage 0 · Firebase` · `Stage 1 · Play Internal` · `Stage 2 · Play Beta` · `Stage 3 · Play Production` · `Stage 1 · TestFlight` · `Stage 2 · TF External` · `Stage 3 · App Store` · `Stage 1 · Prerelease/Preview` · `Stage 2 · Beta/Staging` · `Stage 3 · Stable/Production`

Chain: android v2.0.25 · apple v2.0.22 · desktop v2.0.12 · web v2.0.13 → orchestrator v1.0.61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)