### PR TITLE
fix(core-database): wasmJs Room invalidation bridge for Alerts/Watchlist/SubmitOutbox

### DIFF
--- a/core/data/src/commonMain/kotlin/kpt/core/data/demo/alerts/impl/AlertsRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/kpt/core/data/demo/alerts/impl/AlertsRepositoryImpl.kt
@@ -12,6 +12,7 @@ package kpt.core.data.demo.alerts.impl
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.map
+import kpt.core.base.database.invalidation.notifyingWrite
 import kpt.core.data.demo.alerts.AlertsRepository
 import kpt.core.database.demo.alerts.AlertDao
 import kpt.core.database.demo.alerts.AlertEntity
@@ -32,12 +33,21 @@ internal class AlertsRepositoryImpl(
             .map { response -> response.value.map { it.toPriceAlert() } }
 
     override suspend fun submitAlert(alert: PriceAlert): PriceAlert {
-        alertDao.upsert(alert.toAlertEntity())
+        notifyingWrite(ALERTS_TABLE) {
+            alertDao.upsert(alert.toAlertEntity())
+        }
         return alert
     }
 
     override suspend fun deleteAlert(id: String) {
-        alertDao.deleteById(id)
+        notifyingWrite(ALERTS_TABLE) {
+            alertDao.deleteById(id)
+        }
+    }
+
+    private companion object {
+        /** Room `@Entity(tableName = …)` for [AlertEntity]. Shared with [provideAlertsStore]'s reader. */
+        const val ALERTS_TABLE = "alerts"
     }
 }
 

--- a/core/data/src/commonMain/kotlin/kpt/core/data/demo/watchlist/impl/WatchlistRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/kpt/core/data/demo/watchlist/impl/WatchlistRepositoryImpl.kt
@@ -11,27 +11,47 @@ package kpt.core.data.demo.watchlist.impl
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kpt.core.base.database.invalidation.daoFlow
+import kpt.core.base.database.invalidation.notifyingWrite
 import kpt.core.data.demo.watchlist.WatchlistItem
 import kpt.core.data.demo.watchlist.WatchlistRepository
 import kpt.core.database.demo.watchlist.dao.WatchlistDao
 import kpt.core.database.demo.watchlist.entity.WatchlistEntity
 import kotlin.time.Clock
 
+/**
+ * Local-only impl of [WatchlistRepository].
+ *
+ * Direct-DAO `Flow` reads are wrapped with [daoFlow] and writes with [notifyingWrite] so the
+ * wasmJs target's long-lived collectors re-emit after add/remove even when Room 3 alpha05's
+ * async InvalidationTracker fails to fan out. On Android/Desktop/iOS the wraps are a
+ * microsecond-cost no-op alongside Room's native invalidation. See
+ * `core-base/database/.../invalidation/README.md`.
+ */
 internal class WatchlistRepositoryImpl(
     private val dao: WatchlistDao,
 ) : WatchlistRepository {
 
-    override fun watchlist(): Flow<List<WatchlistItem>> = dao.observeAll().map { rows ->
+    override fun watchlist(): Flow<List<WatchlistItem>> = daoFlow(WATCHLIST_TABLE) { dao.observeAll() }.map { rows ->
         rows.map { WatchlistItem(coinId = it.coinId, addedAtMs = it.addedAtMs) }
     }
 
-    override fun contains(coinId: String): Flow<Boolean> = dao.observeContains(coinId)
+    override fun contains(coinId: String): Flow<Boolean> = daoFlow(WATCHLIST_TABLE) { dao.observeContains(coinId) }
 
     override suspend fun add(coinId: String) {
-        dao.insert(WatchlistEntity(coinId = coinId, addedAtMs = Clock.System.now().toEpochMilliseconds()))
+        notifyingWrite(WATCHLIST_TABLE) {
+            dao.insert(WatchlistEntity(coinId = coinId, addedAtMs = Clock.System.now().toEpochMilliseconds()))
+        }
     }
 
     override suspend fun remove(coinId: String) {
-        dao.delete(coinId)
+        notifyingWrite(WATCHLIST_TABLE) {
+            dao.delete(coinId)
+        }
+    }
+
+    private companion object {
+        /** Room `@Entity(tableName = …)` for [WatchlistEntity]. */
+        const val WATCHLIST_TABLE = "personal_watchlist"
     }
 }

--- a/core/data/src/commonMain/kotlin/kpt/core/data/infra/impl/RoomSubmitOutbox.kt
+++ b/core/data/src/commonMain/kotlin/kpt/core/data/infra/impl/RoomSubmitOutbox.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
+import kpt.core.base.database.invalidation.daoFlow
+import kpt.core.base.database.invalidation.notifyingWrite
 import kpt.core.base.store.submit.SubmitOutbox
 import kpt.core.base.store.submit.SubmitOutboxEntry
 import kpt.core.base.store.submit.SubmitOutboxStatus
@@ -43,41 +45,44 @@ class RoomSubmitOutbox<P>(
 
     private val json = Json { ignoreUnknownKeys = true }
 
-    override suspend fun save(formKey: String, payload: P): Long {
+    override suspend fun save(formKey: String, payload: P): Long = notifyingWrite(DRAFTS_TABLE) {
         val nowMs = currentTimeMillis()
         val existing = dao.getPendingByFormKey(formKey)
         if (existing != null) {
             dao.updatePayload(existing.id, json.encodeToString(serializer, payload), nowMs)
-            return existing.id
+            existing.id
+        } else {
+            val entity = DraftEntity(
+                formKey = formKey,
+                uniqueKey = null,
+                payloadJson = json.encodeToString(serializer, payload),
+                status = SubmitOutboxStatus.PENDING.name,
+                createdAtMs = nowMs,
+                updatedAtMs = nowMs,
+            )
+            dao.insert(entity)
         }
-        val entity = DraftEntity(
-            formKey = formKey,
-            uniqueKey = null,
-            payloadJson = json.encodeToString(serializer, payload),
-            status = SubmitOutboxStatus.PENDING.name,
-            createdAtMs = nowMs,
-            updatedAtMs = nowMs,
-        )
-        return dao.insert(entity)
     }
 
-    override suspend fun saveByUniqueKey(formKey: String, uniqueKey: String, payload: P): Long {
-        val nowMs = currentTimeMillis()
-        val existing = dao.getPendingByUniqueKey(formKey, uniqueKey)
-        if (existing != null) {
-            dao.updatePayload(existing.id, json.encodeToString(serializer, payload), nowMs)
-            return existing.id
+    override suspend fun saveByUniqueKey(formKey: String, uniqueKey: String, payload: P): Long =
+        notifyingWrite(DRAFTS_TABLE) {
+            val nowMs = currentTimeMillis()
+            val existing = dao.getPendingByUniqueKey(formKey, uniqueKey)
+            if (existing != null) {
+                dao.updatePayload(existing.id, json.encodeToString(serializer, payload), nowMs)
+                existing.id
+            } else {
+                val entity = DraftEntity(
+                    formKey = formKey,
+                    uniqueKey = uniqueKey,
+                    payloadJson = json.encodeToString(serializer, payload),
+                    status = SubmitOutboxStatus.PENDING.name,
+                    createdAtMs = nowMs,
+                    updatedAtMs = nowMs,
+                )
+                dao.insert(entity)
+            }
         }
-        val entity = DraftEntity(
-            formKey = formKey,
-            uniqueKey = uniqueKey,
-            payloadJson = json.encodeToString(serializer, payload),
-            status = SubmitOutboxStatus.PENDING.name,
-            createdAtMs = nowMs,
-            updatedAtMs = nowMs,
-        )
-        return dao.insert(entity)
-    }
 
     override suspend fun getPending(formKey: String): SubmitOutboxEntry<P>? =
         dao.getPendingByFormKey(formKey)?.toEntry()
@@ -86,28 +91,32 @@ class RoomSubmitOutbox<P>(
         dao.getPendingByUniqueKey(formKey, uniqueKey)?.toEntry()
 
     override fun observePending(formKey: String): Flow<SubmitOutboxEntry<P>?> =
-        dao.observePendingByFormKey(formKey).map { it?.toEntry() }
+        daoFlow(DRAFTS_TABLE) { dao.observePendingByFormKey(formKey) }.map { it?.toEntry() }
 
     override fun observePendingByUniqueKey(formKey: String, uniqueKey: String): Flow<SubmitOutboxEntry<P>?> =
-        dao.observePendingByUniqueKey(formKey, uniqueKey).map { it?.toEntry() }
+        daoFlow(DRAFTS_TABLE) { dao.observePendingByUniqueKey(formKey, uniqueKey) }.map { it?.toEntry() }
 
     override fun observeAllByFormKey(formKey: String): Flow<List<SubmitOutboxEntry<P>>> =
-        dao.observeAllByFormKey(formKey).map { rows -> rows.mapNotNull { it.toEntry() } }
+        daoFlow(DRAFTS_TABLE) { dao.observeAllByFormKey(formKey) }.map { rows -> rows.mapNotNull { it.toEntry() } }
 
     override suspend fun getAllPending(): List<SubmitOutboxEntry<P>> = dao.getAllPending().mapNotNull { it.toEntry() }
 
-    override suspend fun markRetrying(id: Long) = dao.markRetrying(id, currentTimeMillis())
+    override suspend fun markRetrying(id: Long) =
+        notifyingWrite(DRAFTS_TABLE) { dao.markRetrying(id, currentTimeMillis()) }
 
-    override suspend fun markSubmitted(id: Long) = dao.markSubmitted(id, currentTimeMillis())
+    override suspend fun markSubmitted(id: Long) =
+        notifyingWrite(DRAFTS_TABLE) { dao.markSubmitted(id, currentTimeMillis()) }
 
-    override suspend fun markFailed(id: Long, error: String?) = dao.markFailed(id, currentTimeMillis(), error)
+    override suspend fun markFailed(id: Long, error: String?) =
+        notifyingWrite(DRAFTS_TABLE) { dao.markFailed(id, currentTimeMillis(), error) }
 
-    override suspend fun deleteByFormKey(formKey: String) = dao.deleteByFormKey(formKey)
+    override suspend fun deleteByFormKey(formKey: String) =
+        notifyingWrite(DRAFTS_TABLE) { dao.deleteByFormKey(formKey) }
 
     override suspend fun deleteByUniqueKey(formKey: String, uniqueKey: String) =
-        dao.deleteByUniqueKey(formKey, uniqueKey)
+        notifyingWrite(DRAFTS_TABLE) { dao.deleteByUniqueKey(formKey, uniqueKey) }
 
-    override suspend fun deleteAll() = dao.deleteAll()
+    override suspend fun deleteAll() = notifyingWrite(DRAFTS_TABLE) { dao.deleteAll() }
 
     private fun DraftEntity.toEntry(): SubmitOutboxEntry<P>? = runCatching {
         SubmitOutboxEntry(
@@ -123,3 +132,6 @@ class RoomSubmitOutbox<P>(
 }
 
 private fun currentTimeMillis(): Long = kotlin.time.Clock.System.now().toEpochMilliseconds()
+
+/** Room `@Entity(tableName = …)` for [DraftEntity] — drives the wasmJs invalidation bridge. */
+private const val DRAFTS_TABLE = "framework_submit_drafts"

--- a/core/data/src/commonTest/kotlin/kpt/core/data/demo/alerts/AlertsReactiveInvalidationTest.kt
+++ b/core/data/src/commonTest/kotlin/kpt/core/data/demo/alerts/AlertsReactiveInvalidationTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package kpt.core.data.demo.alerts
+
+import app.cash.turbine.test
+import kotlinx.coroutines.test.runTest
+import kpt.core.data.demo.alerts.impl.AlertsRepositoryImpl
+import kpt.core.model.demo.alerts.AlertDirection
+import kpt.core.model.demo.alerts.PriceAlert
+import kpt.core.store.demo.alerts.impl.provideAlertsStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Locks the wasmJs invalidation-bridge wiring for the alerts surface — the ONE fixed surface
+ * whose reactive read flows through a Store5 `SourceOfTruth` (`alertsStream()` →
+ * `alertsStore.stream(...)`), not a direct DAO flow.
+ *
+ * [FakeAlertDao] returns a **cold snapshot** [kpt.core.database.demo.alerts.AlertDao.observeAll]
+ * that never self-re-emits (modelling Room 3 alpha05 on wasmJs). These assertions can only pass
+ * because:
+ *  - `provideAlertsStore` wraps its SoT reader in `daoFlow(ALERTS_TABLE) { dao.observeAll() }`, and
+ *  - `AlertsRepositoryImpl.submitAlert` / `deleteAlert` wrap their writes in
+ *    `notifyingWrite(ALERTS_TABLE) { ... }`.
+ *
+ * The store reader and the repository writes must agree on the exact `"alerts"` table name — a
+ * mismatch would leave the live collector stuck on its first emission. Regression guard proving
+ * the fix propagates a re-emit all the way through Store5 to a long-lived dashboard collector.
+ *
+ * (Uses a cold fake + live Turbine collector — the combination that is race-free where the
+ * banking hot-`MutableStateFlow` reactive tests are `@Ignore`d.)
+ */
+class AlertsReactiveInvalidationTest {
+
+    private val dao = FakeAlertDao()
+    private val repo: AlertsRepository = AlertsRepositoryImpl(
+        alertsStore = provideAlertsStore(dao),
+        alertDao = dao,
+    )
+
+    @Test
+    fun alertsStreamReEmitsAcrossSubmitAndDelete() = runTest {
+        repo.alertsStream().test {
+            assertEquals(emptySet(), awaitItem().map { it.id }.toSet())
+            repo.submitAlert(sampleAlert("a1"))
+            assertEquals(setOf("a1"), awaitItem().map { it.id }.toSet())
+            repo.submitAlert(sampleAlert("a2"))
+            assertEquals(setOf("a1", "a2"), awaitItem().map { it.id }.toSet())
+            repo.deleteAlert("a1")
+            assertEquals(setOf("a2"), awaitItem().map { it.id }.toSet())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private fun sampleAlert(id: String): PriceAlert = PriceAlert(
+        id = id,
+        coinId = "coin-$id",
+        direction = AlertDirection.ABOVE,
+        targetValue = 100.0,
+        createdAtMs = 1_700_000_000_000L,
+    )
+}

--- a/core/data/src/commonTest/kotlin/kpt/core/data/demo/alerts/FakeAlertDao.kt
+++ b/core/data/src/commonTest/kotlin/kpt/core/data/demo/alerts/FakeAlertDao.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package kpt.core.data.demo.alerts
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kpt.core.database.demo.alerts.AlertDao
+import kpt.core.database.demo.alerts.AlertEntity
+
+/**
+ * In-memory fake of [AlertDao] whose [observeAll] is a **cold snapshot** — each subscription
+ * emits the current rows once, then completes.
+ *
+ * Models the wasmJs failure mode the invalidation bridge absorbs (Room 3 alpha05's
+ * `InvalidationTracker` does not fan out to a live collector after a write), so the ONLY
+ * re-emit source is `daoFlow(ALERTS_TABLE) { }` re-subscribing on the `RoomChangeBus` signal
+ * published by `notifyingWrite(ALERTS_TABLE) { }`. Cold — not a hot `MutableStateFlow` — so
+ * there is no Turbine race (the reason the banking hot-fake reactive tests are `@Ignore`d).
+ */
+internal class FakeAlertDao : AlertDao {
+
+    private val rows = mutableListOf<AlertEntity>()
+
+    override fun observeAll(): Flow<List<AlertEntity>> =
+        flow { emit(rows.sortedByDescending { it.createdAt }) }
+
+    override suspend fun upsert(alert: AlertEntity) {
+        rows.removeAll { it.id == alert.id }
+        rows.add(alert)
+    }
+
+    override suspend fun upsertAll(alerts: List<AlertEntity>) {
+        alerts.forEach { a -> rows.removeAll { it.id == a.id } }
+        rows.addAll(alerts)
+    }
+
+    override suspend fun deleteById(id: String) {
+        rows.removeAll { it.id == id }
+    }
+
+    override suspend fun deleteAll() {
+        rows.clear()
+    }
+}

--- a/core/data/src/commonTest/kotlin/kpt/core/data/demo/watchlist/FakeWatchlistDao.kt
+++ b/core/data/src/commonTest/kotlin/kpt/core/data/demo/watchlist/FakeWatchlistDao.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package kpt.core.data.demo.watchlist
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kpt.core.database.demo.watchlist.dao.WatchlistDao
+import kpt.core.database.demo.watchlist.entity.WatchlistEntity
+
+/**
+ * In-memory fake of [WatchlistDao] whose reactive reads are **cold snapshots** — each
+ * subscription emits the current rows exactly once, then completes.
+ *
+ * This deliberately models the wasmJs failure mode the invalidation bridge exists to
+ * absorb: Room 3 alpha05's `InvalidationTracker` does NOT fan out to a live collector
+ * after a write on the single-threaded JS event loop, so the DAO `Flow` never re-emits
+ * on its own. A correct repository therefore MUST re-emit via `daoFlow { }` re-subscribing
+ * on the `RoomChangeBus` signal published by `notifyingWrite { }`.
+ *
+ * Contrast with [kpt.core.data.demo.banking.FakeLoanDao], which uses a hot
+ * `MutableStateFlow` — that self-emits and RACES the `daoFlow` re-collect, which is why
+ * the banking reactive tests are `@Ignore`d. A cold snapshot has exactly one re-emit
+ * source (the bridge), so the assertion is deterministic.
+ */
+internal class FakeWatchlistDao : WatchlistDao {
+
+    private val rows = mutableListOf<WatchlistEntity>()
+
+    override fun observeAll(): Flow<List<WatchlistEntity>> =
+        flow { emit(rows.sortedByDescending { it.addedAtMs }) }
+
+    override fun observeContains(coinId: String): Flow<Boolean> =
+        flow { emit(rows.any { it.coinId == coinId }) }
+
+    override suspend fun insert(entry: WatchlistEntity) {
+        rows.removeAll { it.coinId == entry.coinId }
+        rows.add(entry)
+    }
+
+    override suspend fun delete(coinId: String) {
+        rows.removeAll { it.coinId == coinId }
+    }
+}

--- a/core/data/src/commonTest/kotlin/kpt/core/data/demo/watchlist/WatchlistReactiveInvalidationTest.kt
+++ b/core/data/src/commonTest/kotlin/kpt/core/data/demo/watchlist/WatchlistReactiveInvalidationTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package kpt.core.data.demo.watchlist
+
+import app.cash.turbine.test
+import kotlinx.coroutines.test.runTest
+import kpt.core.data.demo.watchlist.impl.WatchlistRepositoryImpl
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Locks the wasmJs invalidation-bridge wiring for [WatchlistRepositoryImpl].
+ *
+ * [FakeWatchlistDao] returns **cold snapshot** flows that never self-re-emit, faithfully
+ * modelling Room 3 alpha05 on wasmJs (the `InvalidationTracker` does not fan out to a live
+ * collector after a write). The ONLY way these assertions can pass is if:
+ *  - reads are wrapped in `daoFlow(WATCHLIST_TABLE) { ... }` (re-subscribes on the bus), AND
+ *  - writes are wrapped in `notifyingWrite(WATCHLIST_TABLE) { ... }` (publishes the bus signal).
+ *
+ * On the pre-fix code — raw `dao.observeAll()` reads + raw `dao.insert()`/`dao.delete()`
+ * writes — the collector would see only the initial emission and every `awaitItem()` after
+ * a mutation would time out. This is the regression guard for that defect class.
+ */
+class WatchlistReactiveInvalidationTest {
+
+    private val dao = FakeWatchlistDao()
+    private val repo: WatchlistRepository = WatchlistRepositoryImpl(dao)
+
+    @Test
+    fun watchlistReEmitsAfterAdd() = runTest {
+        repo.watchlist().test {
+            assertEquals(emptyList(), awaitItem().map { it.coinId })
+            repo.add("btc")
+            assertEquals(setOf("btc"), awaitItem().map { it.coinId }.toSet())
+            repo.add("eth")
+            assertEquals(setOf("btc", "eth"), awaitItem().map { it.coinId }.toSet())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun watchlistReEmitsAfterRemove() = runTest {
+        repo.add("btc")
+        repo.watchlist().test {
+            assertEquals(setOf("btc"), awaitItem().map { it.coinId }.toSet())
+            repo.remove("btc")
+            assertEquals(emptySet(), awaitItem().map { it.coinId }.toSet())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun containsReEmitsWhenCoinAddedThenRemoved() = runTest {
+        repo.contains("btc").test {
+            assertEquals(false, awaitItem())
+            repo.add("btc")
+            assertEquals(true, awaitItem())
+            repo.remove("btc")
+            assertEquals(false, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/core/data/src/commonTest/kotlin/kpt/core/data/infra/FakeDraftDao.kt
+++ b/core/data/src/commonTest/kotlin/kpt/core/data/infra/FakeDraftDao.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package kpt.core.data.infra
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kpt.core.database.infra.dao.DraftDao
+import kpt.core.database.infra.entity.DraftEntity
+
+/**
+ * In-memory fake of [DraftDao] whose reactive reads are **cold snapshots** — each
+ * subscription emits the current rows exactly once, then completes.
+ *
+ * Models the wasmJs failure mode the invalidation bridge absorbs: Room 3 alpha05's
+ * `InvalidationTracker` does not fan out to a live collector after a write, so the DAO
+ * `Flow` never re-emits on its own. Re-emission must come from `daoFlow { }` re-subscribing
+ * on the `RoomChangeBus` signal that `notifyingWrite { }` publishes. Deliberately cold (not
+ * a hot `MutableStateFlow`) so there is exactly one re-emit source and no Turbine race —
+ * see [kpt.core.data.demo.watchlist.FakeWatchlistDao] for the same rationale.
+ */
+internal class FakeDraftDao : DraftDao {
+
+    private val rows = mutableListOf<DraftEntity>()
+    private var nextId = 1L
+
+    private val nonTerminal = setOf("PENDING", "RETRYING", "FAILED")
+
+    override suspend fun insert(entity: DraftEntity): Long {
+        val id = nextId++
+        rows.add(entity.copy(id = id))
+        return id
+    }
+
+    override suspend fun getById(id: Long): DraftEntity? = rows.firstOrNull { it.id == id }
+
+    override suspend fun getPendingByFormKey(formKey: String): DraftEntity? =
+        rows.firstOrNull { it.formKey == formKey && it.uniqueKey == null && it.status == "PENDING" }
+
+    override fun observePendingByFormKey(formKey: String): Flow<DraftEntity?> =
+        flow { emit(rows.firstOrNull { it.formKey == formKey && it.uniqueKey == null && it.status == "PENDING" }) }
+
+    override suspend fun getPendingByUniqueKey(formKey: String, uniqueKey: String): DraftEntity? =
+        rows.firstOrNull { it.formKey == formKey && it.uniqueKey == uniqueKey && it.status == "PENDING" }
+
+    override fun observePendingByUniqueKey(formKey: String, uniqueKey: String): Flow<DraftEntity?> =
+        flow { emit(rows.firstOrNull { it.formKey == formKey && it.uniqueKey == uniqueKey && it.status == "PENDING" }) }
+
+    override fun observeAllByFormKey(formKey: String): Flow<List<DraftEntity>> =
+        flow {
+            emit(
+                rows.filter { it.formKey == formKey && it.status in nonTerminal }
+                    .sortedByDescending { it.createdAtMs },
+            )
+        }
+
+    override suspend fun getAllPending(): List<DraftEntity> = rows.filter { it.status == "PENDING" }
+
+    override suspend fun markRetrying(id: Long, nowMs: Long) =
+        updateRow(id) { it.copy(status = "RETRYING", updatedAtMs = nowMs) }
+
+    override suspend fun markSubmitted(id: Long, nowMs: Long) =
+        updateRow(id) { it.copy(status = "SUBMITTED", updatedAtMs = nowMs) }
+
+    override suspend fun markFailed(id: Long, nowMs: Long, error: String?) =
+        updateRow(id) { it.copy(status = "FAILED", updatedAtMs = nowMs, errorMessage = error) }
+
+    override suspend fun updatePayload(id: Long, payloadJson: String, nowMs: Long) =
+        updateRow(id) { it.copy(payloadJson = payloadJson, updatedAtMs = nowMs) }
+
+    override suspend fun deleteByFormKey(formKey: String) {
+        rows.removeAll { it.formKey == formKey }
+    }
+
+    override suspend fun deleteByUniqueKey(formKey: String, uniqueKey: String) {
+        rows.removeAll { it.formKey == formKey && it.uniqueKey == uniqueKey }
+    }
+
+    override suspend fun deleteAll() {
+        rows.clear()
+    }
+
+    override suspend fun deleteOlderThan(thresholdMs: Long) {
+        rows.removeAll { it.createdAtMs < thresholdMs && (it.status == "SUBMITTED" || it.status == "FAILED") }
+    }
+
+    private fun updateRow(id: Long, block: (DraftEntity) -> DraftEntity) {
+        val idx = rows.indexOfFirst { it.id == id }
+        if (idx >= 0) rows[idx] = block(rows[idx])
+    }
+}

--- a/core/data/src/commonTest/kotlin/kpt/core/data/infra/RoomSubmitOutboxReactiveInvalidationTest.kt
+++ b/core/data/src/commonTest/kotlin/kpt/core/data/infra/RoomSubmitOutboxReactiveInvalidationTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
+ */
+package kpt.core.data.infra
+
+import app.cash.turbine.test
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.builtins.serializer
+import kpt.core.data.infra.impl.RoomSubmitOutbox
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Locks the wasmJs invalidation-bridge wiring for [RoomSubmitOutbox] — the framework-owned
+ * `DraftSubmitHandler` backing store used by every offline-resilient form.
+ *
+ * [FakeDraftDao] returns **cold snapshot** flows that never self-re-emit, modelling Room 3
+ * alpha05 on wasmJs (the `InvalidationTracker` does not fan out to a live collector after a
+ * write). These assertions can only pass because the outbox now:
+ *  - wraps `observePending*` / `observeAllByFormKey` reads in `daoFlow(DRAFTS_TABLE) { ... }`, and
+ *  - wraps every write (`save`, `saveByUniqueKey`, `mark*`, `delete*`) in
+ *    `notifyingWrite(DRAFTS_TABLE) { ... }`.
+ *
+ * On the pre-fix code — raw `dao.observePending*` reads + raw writes — the draft-status badge
+ * on web would never advance past its first emission. Regression guard for that defect class.
+ */
+class RoomSubmitOutboxReactiveInvalidationTest {
+
+    private val dao = FakeDraftDao()
+    private val outbox = RoomSubmitOutbox(dao, String.serializer())
+
+    @Test
+    fun observePendingReEmitsAcrossSaveThenSubmit() = runTest {
+        outbox.observePending(FORM).test {
+            assertNull(awaitItem())
+            outbox.save(FORM, "draft-1")
+            assertEquals("draft-1", awaitItem()?.payload)
+            val id = outbox.getPending(FORM)!!.id
+            outbox.markSubmitted(id)
+            assertNull(awaitItem()) // no longer PENDING → filtered out
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun observeAllByFormKeyReEmitsOnSaveThenDelete() = runTest {
+        outbox.observeAllByFormKey(FORM).test {
+            assertEquals(emptyList(), awaitItem().map { it.payload })
+            outbox.save(FORM, "d1")
+            assertEquals(listOf("d1"), awaitItem().map { it.payload })
+            outbox.deleteByFormKey(FORM)
+            assertEquals(emptyList(), awaitItem().map { it.payload })
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun observePendingByUniqueKeyReEmitsAcrossSaveThenDelete() = runTest {
+        outbox.observePendingByUniqueKey(FORM, UNIQUE).test {
+            assertNull(awaitItem())
+            outbox.saveByUniqueKey(FORM, UNIQUE, "draft-u1")
+            assertEquals("draft-u1", awaitItem()?.payload)
+            outbox.deleteByUniqueKey(FORM, UNIQUE)
+            assertNull(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private companion object {
+        const val FORM = "loan_application"
+        const val UNIQUE = "loan_42"
+    }
+}

--- a/core/store/src/commonMain/kotlin/kpt/core/store/demo/alerts/impl/AlertsStore.kt
+++ b/core/store/src/commonMain/kotlin/kpt/core/store/demo/alerts/impl/AlertsStore.kt
@@ -9,6 +9,7 @@
  */
 package kpt.core.store.demo.alerts.impl
 
+import kpt.core.base.database.invalidation.daoFlow
 import kpt.core.base.store.infra.StoreFactory
 import kpt.core.database.demo.alerts.AlertDao
 import kpt.core.database.demo.alerts.AlertEntity
@@ -25,12 +26,22 @@ import org.mobilenativefoundation.store.store5.Store
  *
  * Key: [Unit] — always returns all alerts (no per-alert keyed filter here;
  * per-id lookup goes through the repository directly).
+ *
+ * The DAO reader is wrapped with [daoFlow] so wasmJs collectors re-emit after writes
+ * even when Room 3 alpha05's async InvalidationTracker fails to fan out (see
+ * `core-base/database/.../invalidation/README.md`). The paired write notification is
+ * emitted by `AlertsRepositoryImpl`'s [kpt.core.base.database.invalidation.notifyingWrite]
+ * on `alertDao.upsert` / `deleteById`. On Android/Desktop/iOS the wrap is a microsecond
+ * no-op alongside Room's native invalidation.
  */
 fun provideAlertsStore(dao: AlertDao): Store<Unit, List<AlertEntity>> = StoreFactory.createOfflineStore(
     sourceOfTruth = SourceOfTruth.of(
-        reader = { _: Unit -> dao.observeAll() },
+        reader = { _: Unit -> daoFlow(ALERTS_TABLE) { dao.observeAll() } },
         writer = { _: Unit, alerts: List<AlertEntity> -> dao.upsertAll(alerts) },
         delete = { _: Unit -> dao.deleteAll() },
         deleteAll = { dao.deleteAll() },
     ),
 )
+
+/** Room `@Entity(tableName = …)` for [AlertEntity]. Shared with the repository's writes. */
+private const val ALERTS_TABLE = "alerts"

--- a/maestro/screen-state/list-back.behavior.yaml
+++ b/maestro/screen-state/list-back.behavior.yaml
@@ -1,0 +1,8 @@
+schema_version: "1.0"
+flow: list-back
+flow_category: ui_navigation
+assertions:
+  - assert_network_call:
+      url_pattern: "*"
+      method: GET
+      count: 0

--- a/maestro/screen-state/paging-restore.behavior.yaml
+++ b/maestro/screen-state/paging-restore.behavior.yaml
@@ -1,0 +1,8 @@
+schema_version: "1.0"
+flow: paging-restore
+flow_category: ui_navigation
+assertions:
+  - assert_network_call:
+      url_pattern: "*"
+      method: GET
+      count: 0

--- a/maestro/screen-state/scroll-appkill.behavior.yaml
+++ b/maestro/screen-state/scroll-appkill.behavior.yaml
@@ -1,0 +1,8 @@
+schema_version: "1.0"
+flow: scroll-appkill
+flow_category: ui_navigation
+assertions:
+  - assert_network_call:
+      url_pattern: "*"
+      method: GET
+      count: 0

--- a/maestro/screen-state/tab-switch.behavior.yaml
+++ b/maestro/screen-state/tab-switch.behavior.yaml
@@ -1,0 +1,8 @@
+schema_version: "1.0"
+flow: tab-switch
+flow_category: ui_navigation
+assertions:
+  - assert_network_call:
+      url_pattern: "*"
+      method: GET
+      count: 0


### PR DESCRIPTION
## Context
Audit of `core/database` + `core-base/database` (Room 3.0.0 KMP) found the infra complete end-to-end across all 6 targets, with one wasmJs reactive-consistency gap: the shipped `RoomChangeBus` + `daoFlow{}` + `notifyingWrite{}` invalidation bridge is adopted only by the banking feature. Three other local-only Room-backed surfaces bypass it, so their `Flow` reads do not re-emit after writes on **wasmJs**.

## Scope
- `AlertsStore` (OFFLINE_LOCAL_ONLY) — SoT reader `dao.observeAll()` + writes unwrapped
- `WatchlistRepositoryImpl` (local-only) — `observeAll`/`observeContains` reads + `insert`/`delete` writes unwrapped
- `RoomSubmitOutbox` (framework infra, DraftSubmitHandler) — `observePending*` reads unwrapped → web draft-status badges

## Plan
1. Add a failing wasmJs test reproducing the stale-read (RED)
2. Wrap the 3 surfaces in `daoFlow{}` / `notifyingWrite{}` to match the banking pattern (GREEN)

Impact scoped to wasmJs; Android/iOS/desktop/JS(OPFS) use the native invalidation tracker and are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reactive updates for alerts, watchlists, and saved form submissions after adding, editing, submitting, or deleting items.
  - Ensured local data changes are reflected immediately across supported app flows, including WebAssembly.

- **Tests**
  - Added coverage for reactive updates and local-only screen-state behavior, including navigation, paging, scrolling, and tab switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->