### PR TITLE
feat(kmp): watchOS + iosX64 targets, Kotlin 2.4.20-Beta1 / CMP 1.12.0-beta02

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,19 @@ country-level macro indicators. Fork to brand and extend.</p>
 - **Sync Capabilities**: Tools to stay in sync with upstream template changes
 - **Secrets Management**: Secure handling of keystores and sensitive information
 
+### Target matrix
+
+Every module gets `android` / `desktop` / `iosArm64` / `iosSimulatorArm64` / `js` / `wasmJs` from
+the shared KMP-library convention. `iosX64` (Intel simulator) and `watchosArm64` /
+`watchosSimulatorArm64` are opt-in on top of that — Compose Multiplatform ships no `iosX64`/watchOS
+UI target, so any module pulling in Compose (directly or transitively) can't add them.
+
+| Target                                | Availability                                                                         |
+|----------------------------------------|---------------------------------------------------------------------------------------|
+| `android`, `desktop`, `iosArm64`, `iosSimulatorArm64`, `js`, `wasmJs` | Every `kmp.library` / `kmp.core.base.library` module |
+| `iosX64` (Intel simulator)            | Opt-in via `kmp.library.iosx64` — `core-base:common`, `core-base:observability`, `core-base:store`, `core:auth`, `core:common`, `core:model` (Compose- and Room-free, no transitive dependency on either) |
+| `watchosArm64`, `watchosSimulatorArm64` | Opt-in via `kmp.library.watchos` — `core-base:common`, `core-base:observability` |
+
 ## 🚀 Getting Started
 
 ### Prerequisites

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -108,6 +108,12 @@ gradlePlugin {
             description = "Adds watchosArm64/watchosSimulatorArm64 on top of a kmp.library(.core.base) module. Opt-in only — see plugin kdoc."
         }
 
+        register("kmpLibraryIosX64") {
+            id = "org.convention.kmp.library.iosx64"
+            implementationClass = "KMPLibraryIosX64ConventionPlugin"
+            description = "Adds the iosX64 (Intel simulator) target on top of a kmp.library(.core.base) module. Opt-in only — Compose Multiplatform modules must not apply it, see plugin kdoc."
+        }
+
         // Static Analysis & Formatting Plugins
         register("detekt") {
             id = "org.convention.detekt.plugin"

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -102,6 +102,12 @@ gradlePlugin {
             implementationClass = "KMPCoreBaseLibraryConventionPlugin"
         }
 
+        register("kmpLibraryWatchos") {
+            id = "org.convention.kmp.library.watchos"
+            implementationClass = "KMPLibraryWatchosConventionPlugin"
+            description = "Adds watchosArm64/watchosSimulatorArm64 on top of a kmp.library(.core.base) module. Opt-in only — see plugin kdoc."
+        }
+
         // Static Analysis & Formatting Plugins
         register("detekt") {
             id = "org.convention.detekt.plugin"

--- a/build-logic/convention/src/main/kotlin/KMPLibraryIosX64ConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KMPLibraryIosX64ConventionPlugin.kt
@@ -1,0 +1,24 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+/**
+ * Adds the `iosX64` (Intel simulator) target on top of the shared KMP-library base
+ * (`org.convention.kmp.library` / `org.convention.kmp.core.base.library`, which already register
+ * iosArm64/iosSimulatorArm64 via `configureKotlinMultiplatform()`).
+ *
+ * A separate opt-in plugin, not a flag on the base convention, because Compose Multiplatform
+ * 1.12.0-beta02 publishes no `ios_x64` klib for `compose.runtime`/`compose.ui`/`compose.foundation`
+ * (Xcode dropped the Intel simulator; JetBrains has been retiring the target release over release)
+ * — any module resolving those artifacts fails `compileKotlinIosX64` outright. Apply only to
+ * Compose-free modules; Compose Multiplatform modules (anything aliasing `jetbrainsCompose`) must
+ * NOT apply this plugin.
+ */
+class KMPLibraryIosX64ConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.extensions.configure<KotlinMultiplatformExtension> {
+            iosX64()
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/KMPLibraryWatchosConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KMPLibraryWatchosConventionPlugin.kt
@@ -1,0 +1,26 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+/**
+ * Adds `watchosArm64` + `watchosSimulatorArm64` targets on top of the shared KMP-library base
+ * (`org.convention.kmp.library` / `org.convention.kmp.core.base.library`, which already register
+ * iosArm64/iosSimulatorArm64/iosX64 + the default hierarchy template via
+ * `configureKotlinMultiplatform()`).
+ *
+ * A separate opt-in plugin, not a flag on the base convention, so watchOS stays an explicit
+ * per-module choice — mirroring how the Mileway/kmp-toolkit family gates watchOS behind its own
+ * `mileway.kmp.library.watchos` plugin rather than the shared base. Compose Multiplatform modules
+ * (no watchOS UI target exists) and modules pulling in platform SDKs without watchOS artifacts
+ * (e.g. GitLive Firebase in `core-base:analytics`) must NOT apply this plugin. Apply only to
+ * Compose-free "shared" logic modules, e.g. `core-base:common`, `core-base:observability`.
+ */
+class KMPLibraryWatchosConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.extensions.configure<KotlinMultiplatformExtension> {
+            watchosArm64()
+            watchosSimulatorArm64()
+        }
+    }
+}

--- a/core-base/common/build.gradle.kts
+++ b/core-base/common/build.gradle.kts
@@ -9,6 +9,8 @@
  */
 plugins {
     alias(libs.plugins.kmp.core.base.library.convention)
+    // Compose-free, no platform-SDK deps — safe for watchOS (see plugin kdoc).
+    alias(libs.plugins.kmp.library.watchos.convention)
 }
 
 kotlin {

--- a/core-base/common/build.gradle.kts
+++ b/core-base/common/build.gradle.kts
@@ -11,6 +11,8 @@ plugins {
     alias(libs.plugins.kmp.core.base.library.convention)
     // Compose-free, no platform-SDK deps — safe for watchOS (see plugin kdoc).
     alias(libs.plugins.kmp.library.watchos.convention)
+    // Compose-free — safe for the Intel simulator target (see plugin kdoc).
+    alias(libs.plugins.kmp.library.iosx64.convention)
 }
 
 kotlin {

--- a/core-base/database/build.gradle.kts
+++ b/core-base/database/build.gradle.kts
@@ -11,6 +11,8 @@ import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
 plugins {
     alias(libs.plugins.kmp.core.base.library.convention)
+    // NOT applying kmp.library.iosx64.convention: androidx.room3:room3-runtime:3.0.0 publishes no
+    // iosX64 klib (see KMPLibraryIosX64ConventionPlugin kdoc).
 }
 
 kotlin {

--- a/core-base/datastore/build.gradle.kts
+++ b/core-base/datastore/build.gradle.kts
@@ -9,6 +9,10 @@
  */
 plugins {
     alias(libs.plugins.kmp.core.base.library.convention)
+    // NOT applying kmp.library.iosx64.convention: depends on core-base:security, a Compose
+    // Multiplatform module with no iosX64 klib (see KMPLibraryIosX64ConventionPlugin kdoc) — the
+    // project() dependency itself fails variant matching for iosX64, independent of this module's
+    // own deps.
     // Explicit for local-visibility; also applied by KMPCoreBaseLibraryConventionPlugin.
     // Applying twice is idempotent (Gradle no-ops the second apply via hasPlugin gate).
     alias(libs.plugins.kotlin.serialization)

--- a/core-base/network/build.gradle.kts
+++ b/core-base/network/build.gradle.kts
@@ -9,6 +9,8 @@
  */
 plugins {
     alias(libs.plugins.kmp.core.base.library.convention)
+    // NOT applying kmp.library.iosx64.convention: depends on core-base:security, a Compose
+    // Multiplatform module with no iosX64 klib (see KMPLibraryIosX64ConventionPlugin kdoc).
 }
 
 kotlin {

--- a/core-base/observability/build.gradle.kts
+++ b/core-base/observability/build.gradle.kts
@@ -9,6 +9,8 @@
  */
 plugins {
     alias(libs.plugins.kmp.core.base.library.convention)
+    // Compose-free, no platform-SDK deps — safe for watchOS (see plugin kdoc).
+    alias(libs.plugins.kmp.library.watchos.convention)
 }
 
 kotlin {

--- a/core-base/observability/build.gradle.kts
+++ b/core-base/observability/build.gradle.kts
@@ -11,6 +11,8 @@ plugins {
     alias(libs.plugins.kmp.core.base.library.convention)
     // Compose-free, no platform-SDK deps — safe for watchOS (see plugin kdoc).
     alias(libs.plugins.kmp.library.watchos.convention)
+    // Compose-free — safe for the Intel simulator target (see plugin kdoc).
+    alias(libs.plugins.kmp.library.iosx64.convention)
 }
 
 kotlin {

--- a/core-base/store/build.gradle.kts
+++ b/core-base/store/build.gradle.kts
@@ -9,6 +9,8 @@
  */
 plugins {
     alias(libs.plugins.kmp.core.base.library.convention)
+    // Compose-free — safe for the Intel simulator target (see plugin kdoc).
+    alias(libs.plugins.kmp.library.iosx64.convention)
 }
 
 kotlin {

--- a/core/auth/build.gradle.kts
+++ b/core/auth/build.gradle.kts
@@ -9,6 +9,8 @@
  */
 plugins {
     alias(libs.plugins.kmp.library.convention)
+    // Compose-free — safe for the Intel simulator target (see plugin kdoc).
+    alias(libs.plugins.kmp.library.iosx64.convention)
 }
 
 kotlin {

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -9,6 +9,8 @@
  */
 plugins {
     alias(libs.plugins.kmp.library.convention)
+    // Compose-free — safe for the Intel simulator target (see plugin kdoc).
+    alias(libs.plugins.kmp.library.iosx64.convention)
     alias(libs.plugins.kotlin.parcelize)
 }
 

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -9,6 +9,8 @@
  */
 plugins {
     alias(libs.plugins.kmp.library.convention)
+    // NOT applying kmp.library.iosx64.convention: depends on core:analytics + core:store, both
+    // Compose Multiplatform modules with no iosX64 klib (see KMPLibraryIosX64ConventionPlugin kdoc).
 }
 
 androidComponents {

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -9,6 +9,8 @@
  */
 plugins {
     alias(libs.plugins.kmp.library.convention)
+    // NOT applying kmp.library.iosx64.convention: depends on core-base:security, a Compose
+    // Multiplatform module with no iosX64 klib (see KMPLibraryIosX64ConventionPlugin kdoc).
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.mifos.kmp.room)

--- a/core/datastore/build.gradle.kts
+++ b/core/datastore/build.gradle.kts
@@ -9,6 +9,9 @@
  */
 plugins {
     alias(libs.plugins.kmp.library.convention)
+    // NOT applying kmp.library.iosx64.convention: depends on core-base:datastore, which is itself
+    // excluded (transitively depends on core-base:security, a Compose Multiplatform module with no
+    // iosX64 klib — see KMPLibraryIosX64ConventionPlugin kdoc).
 }
 
 androidComponents {

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -9,6 +9,9 @@
  */
 plugins {
     alias(libs.plugins.kmp.library.convention)
+    // NOT applying kmp.library.iosx64.convention: depends on core:data, which is itself excluded
+    // (transitively depends on Compose Multiplatform modules — see
+    // KMPLibraryIosX64ConventionPlugin kdoc).
 }
 
 kotlin {

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -9,6 +9,8 @@
  */
 plugins {
     alias(libs.plugins.kmp.library.convention)
+    // Compose-free — safe for the Intel simulator target (see plugin kdoc).
+    alias(libs.plugins.kmp.library.iosx64.convention)
     alias(libs.plugins.kotlin.parcelize)
     id("kotlinx-serialization")
 }

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -12,6 +12,9 @@ import java.util.Properties
 
 plugins {
     alias(libs.plugins.kmp.library.convention)
+    // NOT applying kmp.library.iosx64.convention: depends on core-base:network, which is itself
+    // excluded (transitively depends on core-base:security, a Compose Multiplatform module with no
+    // iosX64 klib — see KMPLibraryIosX64ConventionPlugin kdoc).
     alias(libs.plugins.ktrofit)
     alias(libs.plugins.buildkonfig)
     alias(libs.plugins.kmp.supabase.config)

--- a/core/platform/build.gradle.kts
+++ b/core/platform/build.gradle.kts
@@ -9,6 +9,8 @@
  */
 plugins {
     alias(libs.plugins.kmp.library.convention)
+    // NOT applying kmp.library.iosx64.convention: depends on core-base:platform, a Compose
+    // Multiplatform module with no iosX64 klib (see KMPLibraryIosX64ConventionPlugin kdoc).
 }
 
 kotlin {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -444,6 +444,7 @@ kmp-koin-convention = { id = "org.convention.kmp.koin" }
 kmp-library-convention = { id = "org.convention.kmp.library" }
 kmp-core-base-library-convention = { id = "org.convention.kmp.core.base.library" }
 kmp-library-watchos-convention = { id = "org.convention.kmp.library.watchos" }
+kmp-library-iosx64-convention = { id = "org.convention.kmp.library.iosx64" }
 
 android-application-firebase = { id = "org.convention.android.application.firebase" }
 android-lint = { id = "org.convention.android.application.lint" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -80,7 +80,7 @@ moduleGraph = "2.9.0"
 typesafeConventions = "0.5.0"
 
 # Kotlin KMP Dependencies
-kotlin = "2.4.0"
+kotlin = "2.4.20-Beta1"
 kover = "0.9.8"
 kotlinInject = "0.9.0"
 kotlinxBrowser = "0.5.0"
@@ -88,7 +88,7 @@ kotlinxCoroutines = "1.11.0"
 kotlinxDatetime = "0.8.0"
 kotlinxImmutable = "0.5.1"
 kotlinxSerializationJson = "1.11.0"
-ksp = "2.3.9"
+ksp = "2.3.10"
 
 # Ktor & Ktorfit
 ktorVersion = "3.5.1"
@@ -106,7 +106,7 @@ koinAnnotationsVersion = "4.2.2"
 kmptoolkit = "3.5.3"
 
 # CMP Libraries
-compose-plugin = "1.11.1"
+compose-plugin = "1.12.0-beta02"
 coil = "3.5.0"
 backHandlerVersion = "2.5.0"
 constraintLayout = "0.8.0"
@@ -121,7 +121,7 @@ wire = "6.2.0"
 compottie = "2.2.4"
 
 # Jetbrains CMP
-composeJB = "1.11.1"
+composeJB = "1.12.0-beta02"
 composeLifecycle = "2.11.0-beta01"
 composeNavigation = "2.9.2"
 jbCoreBundle = "1.0.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -443,6 +443,7 @@ cmp-feature-convention = { id = "org.convention.cmp.feature" }
 kmp-koin-convention = { id = "org.convention.kmp.koin" }
 kmp-library-convention = { id = "org.convention.kmp.library" }
 kmp-core-base-library-convention = { id = "org.convention.kmp.core.base.library" }
+kmp-library-watchos-convention = { id = "org.convention.kmp.library.watchos" }
 
 android-application-firebase = { id = "org.convention.android.application.firebase" }
 android-lint = { id = "org.convention.android.application.lint" }


### PR DESCRIPTION
PLAN_V34 P4 target expansion for the template family:

- chore(deps): Kotlin 2.4.0 → 2.4.20-Beta1, Compose Multiplatform 1.11.1 → 1.12.0-beta02 (family convention, matches Mileway/kmp-app-template).
- feat(kmp): opt-in watchOS targets (arm64 + simulatorArm64) on Compose-free shared modules.
- feat(kmp): opt-in iosX64 on Compose- and Room-free modules. NOTE: CMP 1.12.0-beta02 publishes no iosX64/watchOS artifacts, so Compose-UI modules can't declare these yet — logic modules only, same constraint documented in kmp-app-template #1.
- docs(readme): target matrix.

Verified: compileKotlinIosSimulatorArm64 / compileKotlinIosX64 / compileKotlinWatchosSimulatorArm64, testDemoDebugUnitTest + jvmTest — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in Kotlin Multiplatform support for watchOS and the Intel iOS (iosX64) simulator target.
  * Enabled additional compose-free shared modules to include these targets where applicable.

* **Documentation**
  * Added a “Target matrix” explaining default targets and required opt-in targets.
  * Clarified platform limitations and why certain modules don’t enable iosX64/watchOS.

* **Chores**
  * Updated Kotlin, KSP, and Compose Multiplatform plugin/tooling versions.
  * Registered new build conventions for watchOS and iosX64.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->