### PR TITLE
fix(cmp-ios): make iOS identity fully fork-derived — de-brand product label + parameterize legacy bundle-id

### DIFF
--- a/cmp-ios/iosApp.xcodeproj/project.pbxproj
+++ b/cmp-ios/iosApp.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 		2152FB032600AC8F00CF470E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
 		40C1101B5DAAA96D05219B22 /* Pods-iosApp.prodrelease.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.prodrelease.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.prodrelease.xcconfig"; sourceTree = "<group>"; };
 		658097A0E296A46682D0BF51 /* Pods-iosApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.release.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.release.xcconfig"; sourceTree = "<group>"; };
-		7555FF7B242A565900829871 /* LiteDo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LiteDo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		7555FF7B242A565900829871 /* iosApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iosApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FF82242A565900829871 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		79D3A3175F7E47BADE371A34 /* Pods-iosApp.demorelease.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.demorelease.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.demorelease.xcconfig"; sourceTree = "<group>"; };
@@ -83,7 +83,7 @@
 		7555FF7C242A565900829871 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				7555FF7B242A565900829871 /* LiteDo.app */,
+				7555FF7B242A565900829871 /* iosApp.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -156,7 +156,7 @@
 			);
 			name = iosApp;
 			productName = iosApp;
-			productReference = 7555FF7B242A565900829871 /* LiteDo.app */;
+			productReference = 7555FF7B242A565900829871 /* iosApp.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -406,7 +406,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 2026.1.20;
-				PRODUCT_BUNDLE_IDENTIFIER = org.mifos.kmp.template;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
 				PRODUCT_NAME = "${APP_NAME}";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -438,9 +438,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 2026.1.20;
-				PRODUCT_BUNDLE_IDENTIFIER = org.mifos.kmp.template;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
 				PRODUCT_NAME = "${APP_NAME}";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore org.mifos.kmp.template";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore $(APP_BUNDLE_ID)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/cmp-ios/iosApp.xcodeproj/xcshareddata/xcschemes/demoDebug.xcscheme
+++ b/cmp-ios/iosApp.xcodeproj/xcshareddata/xcschemes/demoDebug.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "7555FF7A242A565900829871"
-               BuildableName = "LiteDo.app"
+               BuildableName = "iosApp.app"
                BlueprintName = "iosApp"
                ReferencedContainer = "container:iosApp.xcodeproj">
             </BuildableReference>
@@ -45,7 +45,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7555FF7A242A565900829871"
-            BuildableName = "LiteDo.app"
+            BuildableName = "iosApp.app"
             BlueprintName = "iosApp"
             ReferencedContainer = "container:iosApp.xcodeproj">
          </BuildableReference>
@@ -62,7 +62,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7555FF7A242A565900829871"
-            BuildableName = "LiteDo.app"
+            BuildableName = "iosApp.app"
             BlueprintName = "iosApp"
             ReferencedContainer = "container:iosApp.xcodeproj">
          </BuildableReference>

--- a/cmp-ios/iosApp.xcodeproj/xcshareddata/xcschemes/demoRelease.xcscheme
+++ b/cmp-ios/iosApp.xcodeproj/xcshareddata/xcschemes/demoRelease.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "7555FF7A242A565900829871"
-               BuildableName = "LiteDo.app"
+               BuildableName = "iosApp.app"
                BlueprintName = "iosApp"
                ReferencedContainer = "container:iosApp.xcodeproj">
             </BuildableReference>
@@ -45,7 +45,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7555FF7A242A565900829871"
-            BuildableName = "LiteDo.app"
+            BuildableName = "iosApp.app"
             BlueprintName = "iosApp"
             ReferencedContainer = "container:iosApp.xcodeproj">
          </BuildableReference>
@@ -62,7 +62,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7555FF7A242A565900829871"
-            BuildableName = "LiteDo.app"
+            BuildableName = "iosApp.app"
             BlueprintName = "iosApp"
             ReferencedContainer = "container:iosApp.xcodeproj">
          </BuildableReference>

--- a/cmp-ios/iosApp.xcodeproj/xcshareddata/xcschemes/demoStaging.xcscheme
+++ b/cmp-ios/iosApp.xcodeproj/xcshareddata/xcschemes/demoStaging.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "7555FF7A242A565900829871"
-               BuildableName = "LiteDo.app"
+               BuildableName = "iosApp.app"
                BlueprintName = "iosApp"
                ReferencedContainer = "container:iosApp.xcodeproj">
             </BuildableReference>
@@ -45,7 +45,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7555FF7A242A565900829871"
-            BuildableName = "LiteDo.app"
+            BuildableName = "iosApp.app"
             BlueprintName = "iosApp"
             ReferencedContainer = "container:iosApp.xcodeproj">
          </BuildableReference>
@@ -62,7 +62,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7555FF7A242A565900829871"
-            BuildableName = "LiteDo.app"
+            BuildableName = "iosApp.app"
             BlueprintName = "iosApp"
             ReferencedContainer = "container:iosApp.xcodeproj">
          </BuildableReference>

--- a/cmp-ios/iosApp.xcodeproj/xcshareddata/xcschemes/prodDebug.xcscheme
+++ b/cmp-ios/iosApp.xcodeproj/xcshareddata/xcschemes/prodDebug.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "7555FF7A242A565900829871"
-               BuildableName = "LiteDo.app"
+               BuildableName = "iosApp.app"
                BlueprintName = "iosApp"
                ReferencedContainer = "container:iosApp.xcodeproj">
             </BuildableReference>
@@ -45,7 +45,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7555FF7A242A565900829871"
-            BuildableName = "LiteDo.app"
+            BuildableName = "iosApp.app"
             BlueprintName = "iosApp"
             ReferencedContainer = "container:iosApp.xcodeproj">
          </BuildableReference>
@@ -62,7 +62,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7555FF7A242A565900829871"
-            BuildableName = "LiteDo.app"
+            BuildableName = "iosApp.app"
             BlueprintName = "iosApp"
             ReferencedContainer = "container:iosApp.xcodeproj">
          </BuildableReference>

--- a/cmp-ios/iosApp.xcodeproj/xcshareddata/xcschemes/prodRelease.xcscheme
+++ b/cmp-ios/iosApp.xcodeproj/xcshareddata/xcschemes/prodRelease.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "7555FF7A242A565900829871"
-               BuildableName = "LiteDo.app"
+               BuildableName = "iosApp.app"
                BlueprintName = "iosApp"
                ReferencedContainer = "container:iosApp.xcodeproj">
             </BuildableReference>
@@ -45,7 +45,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7555FF7A242A565900829871"
-            BuildableName = "LiteDo.app"
+            BuildableName = "iosApp.app"
             BlueprintName = "iosApp"
             ReferencedContainer = "container:iosApp.xcodeproj">
          </BuildableReference>
@@ -62,7 +62,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7555FF7A242A565900829871"
-            BuildableName = "LiteDo.app"
+            BuildableName = "iosApp.app"
             BlueprintName = "iosApp"
             ReferencedContainer = "container:iosApp.xcodeproj">
          </BuildableReference>

--- a/cmp-ios/iosApp.xcodeproj/xcshareddata/xcschemes/prodStaging.xcscheme
+++ b/cmp-ios/iosApp.xcodeproj/xcshareddata/xcschemes/prodStaging.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "7555FF7A242A565900829871"
-               BuildableName = "LiteDo.app"
+               BuildableName = "iosApp.app"
                BlueprintName = "iosApp"
                ReferencedContainer = "container:iosApp.xcodeproj">
             </BuildableReference>
@@ -45,7 +45,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7555FF7A242A565900829871"
-            BuildableName = "LiteDo.app"
+            BuildableName = "iosApp.app"
             BlueprintName = "iosApp"
             ReferencedContainer = "container:iosApp.xcodeproj">
          </BuildableReference>
@@ -62,7 +62,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7555FF7A242A565900829871"
-            BuildableName = "LiteDo.app"
+            BuildableName = "iosApp.app"
             BlueprintName = "iosApp"
             ReferencedContainer = "container:iosApp.xcodeproj">
          </BuildableReference>


### PR DESCRIPTION
## Problem

iOS app identity is meant to derive from `gradle/libs.versions.toml` (`appId → APP_BUNDLE_ID`, `appDisplayName → APP_NAME`) via `syncForkConfig` → `cmp-ios/Configuration/Config.xcconfig` (the project-level base xcconfig). That derivation **works** — but two static residues survived it, so every fork still showed the template name in a couple of places.

## Root cause (two residues, not a broken derivation)

1. **`LiteDo.app` hardcode** — the built-product reference (`project.pbxproj`) and the `BuildableName` in all six app schemes were the literal `LiteDo.app` (an original template product name). The shipped `.app` is already named dynamically (`PRODUCT_NAME = $(APP_NAME)`), but the Xcode project navigator + schemes displayed the template name.
2. **Legacy Debug/Release configs** hardcoded `PRODUCT_BUNDLE_IDENTIFIER = org.mifos.kmp.template` + a matching `PROVISIONING_PROFILE_SPECIFIER`. The flavor configs the schemes build (`demoDebug`…`prodRelease`) were already `$(inherited)` → `$(APP_BUNDLE_ID)`; only the non-flavor legacy configs were stale.

## Fix

- `LiteDo.app` → neutral **`iosApp.app`** (pbxproj ×3 + 6 schemes). User-facing name stays dynamic via `CFBundleDisplayName` / `PRODUCT_NAME = $(APP_NAME)` — the label is now generic, so no fork inherits a stale name.
- Legacy `PRODUCT_BUNDLE_IDENTIFIER` + provisioning specifier → **`$(APP_BUNDLE_ID)`**, so the template carries zero hardcoded identity.

The `$(APP_NAME)` / `$(APP_BUNDLE_ID)` derivation path is **untouched** — this PR only removes static residue.

## Verification

- `grep -rE 'LiteDo|org\.mifos\.kmp\.template' cmp-ios/iosApp.xcodeproj` → **0 hits**
- `plutil -lint project.pbxproj` → **OK** (no corruption)
- Recommended CI canary (follow-up): `syncForkConfig` → `xcodebuild -showBuildSettings` asserts `PRODUCT_NAME` / `PRODUCT_BUNDLE_IDENTIFIER` equal the fork's `libs.toml` values, and a flip-`libs.toml` round-trip proves the values track dynamically.

7 files changed, 24 insertions(+), 24 deletions(-).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated iOS app build/run configurations to consistently reference `iosApp.app` across all scheme variants (demo/prod, debug/release/staging).
  * Improved bundle identifier handling by using `$(APP_BUNDLE_ID)` for both Debug and Release product settings.
  * Updated Release provisioning to align with the configured bundle identifier instead of a fixed value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->