### PR TITLE
feat(sync): 3-way merge for merge-owned files — close the fork permission-loss class

### DIFF
--- a/customization-surface.yaml
+++ b/customization-surface.yaml
@@ -1,0 +1,218 @@
+# customization-surface.yaml
+# ─────────────────────────────────────────────────────────────────────────────
+# Fork-ownership contract for kmp-project-template.
+#
+# A fork of this template runs `sync-dirs.sh` to pull template updates while
+# keeping its own branding + features. This file is the SINGLE declared source of
+# truth for "who owns this path?" — replacing the ownership knowledge previously
+# scattered across sync-dirs.sh (SYNC_DIRS + EXCLUSIONS), customizer.sh, and the
+# syncForkConfig copy map.
+#
+# Every path resolves to exactly one owner:
+#
+#   template — the template is the SOLE author. `sync-dirs.sh` OVERWRITES the fork's
+#              copy. A fork edit here is drift and will be clobbered — a genuine fix
+#              belongs UPSTREAM as a PR to openMF/kmp-project-template.
+#
+#   fork     — the fork is the SOLE author. sync NEVER touches it (branding, demo,
+#              the core/store seam, generated Config.xcconfig, local flavors, icons,
+#              store listings, fork identity).
+#
+#   merge    — BOTH author. sync must do a 3-way MERGE, never a blind copy. This is
+#              where the "fork permissions silently dropped on sync" class lives:
+#              AndroidManifest.xml is template-shipped AND fork-extended.
+#
+# Precedence: FIRST matching rule wins. Rules are ordered most-specific → most-
+# general, so the narrow `merge`/`fork` carve-outs win over the broad `template`
+# module globs that follow them.
+#
+# Glob syntax: `*` matches within one path segment; `**` matches across segments;
+# `**/x` matches `x` at any depth (including the root).
+#
+# Coverage is enforced by `scripts/customization-surface.sh --verify` (CI): every
+# tracked path must match a NON-default rule, so a new template file can never land
+# unclassified and silently clobber a fork later.
+# ─────────────────────────────────────────────────────────────────────────────
+
+version: 1
+
+rules:
+  # ── merge-required (declared FIRST — must win over the template module globs) ──
+  # AndroidManifest: template ships the base manifest; forks add permissions
+  # (RECORD_AUDIO, FOREGROUND_SERVICE_*, etc). A blind copy DROPS the fork's — the
+  # exact loss class this contract exists to close.
+  - glob: "**/AndroidManifest.xml"
+    owner: merge
+    strategy: manifest-union
+  # String resources: template base keys + fork-added keys must union.
+  - glob: "**/composeResources/**/strings.xml"
+    owner: merge
+    strategy: strings-union
+  # Version catalog: fork pins versions + adds libs; template adds/bumps. Already a
+  # 3-way merge in sync-dirs.sh STEP 4.5 — declared here so the ownership is explicit.
+  - glob: "gradle/libs.versions.toml"
+    owner: merge
+    strategy: catalog-3way
+  # Settings: fork includes its own :feature:* modules; template adds core modules.
+  - glob: "settings.gradle.kts"
+    owner: merge
+    strategy: include-union
+  # Root navigation host: template owns the scaffold; forks wire feature routes in.
+  - glob: "cmp-navigation/**/*Navigation*.kt"
+    owner: merge
+    strategy: kotlin-3way
+  - glob: "cmp-navigation/**/RootNav*.kt"
+    owner: merge
+    strategy: kotlin-3way
+
+  # ── fork-owned (carve-outs INSIDE otherwise-template dirs; declared before template) ──
+  - glob: "branding/**"
+    owner: fork
+  - glob: "feature/**"
+    owner: fork
+  - glob: "core/store/**"          # the store seam — fork-authored MutableStore wiring
+    owner: fork
+  - glob: "**/demo/**"             # demo data
+    owner: fork
+  - glob: "core/**/src/**/local/**"
+    owner: fork
+  - glob: "build-logic/**/kotlin/local/**"   # LocalFlavors.kt fork flavor extensions
+    owner: fork
+  - glob: "cmp-android/src/main/res/**"
+    owner: fork
+  - glob: "cmp-android/src/main/ic_launcher-playstore.png"
+    owner: fork
+  - glob: "cmp-android/**/google-services.json"
+    owner: fork
+  - glob: "cmp-android/dependencies/**"       # dependency-guard baseline
+    owner: fork
+  - glob: "cmp-ios/iosApp/Assets.xcassets/**" # app icon + colors
+    owner: fork
+  - glob: "cmp-ios/Configuration/Config.xcconfig"  # syncForkConfig-generated identity
+    owner: fork
+  - glob: "cmp-web/src/jsMain/resources/**"
+    owner: fork
+  - glob: "cmp-web/src/wasmJsMain/resources/**"
+    owner: fork
+  - glob: "cmp-desktop/icons/**"
+    owner: fork
+  - glob: "cmp-desktop/build.gradle.kts"      # fork desktop packaging (dock name, dmg)
+    owner: fork
+  - glob: "fastlane-config/project_config.rb"
+    owner: fork
+  - glob: "fastlane-config/extract_config.rb"
+    owner: fork
+  - glob: "deployment/**/metadata/**"         # store listings
+    owner: fork
+  - glob: "deployment/**/screenshots/**"
+    owner: fork
+  - glob: "deployment/**/DEPLOYMENT_MANIFEST.yaml"
+    owner: fork
+  - glob: "deployment/**/PROMOTION_LOG.yaml"  # append-only promotion history
+    owner: fork
+  - glob: "secrets/live/**"                   # real secrets (gitignored)
+    owner: fork
+  - glob: "secrets/**/.sync-meta.json"        # per-fork vault sync state (SV33)
+    owner: fork
+  - glob: ".github/workflows/sync-dirs.yaml"  # fork's own sync workflow
+    owner: fork
+  - glob: "gradle/fork.properties"            # filled-in identity (gitignored)
+    owner: fork
+  - glob: "local.properties"
+    owner: fork
+  - glob: "README.md"                         # rebranded per fork from the idea-plan
+    owner: fork
+  - glob: "CLAUDE.md"                          # fork project instructions
+    owner: fork
+
+  # ── template-owned (the broad sync surface — lowest precedence, declared LAST) ──
+  - glob: "build-logic/**"
+    owner: template
+  - glob: "cmp-android/**"
+    owner: template
+  - glob: "cmp-desktop/**"
+    owner: template
+  - glob: "cmp-ios/**"
+    owner: template
+  - glob: "cmp-web/**"
+    owner: template
+  - glob: "cmp-shared/**"
+    owner: template
+  - glob: "cmp-navigation/**"
+    owner: template
+  - glob: "sync/**"
+    owner: template
+  - glob: "core-base/**"
+    owner: template
+  - glob: "core/**"
+    owner: template
+  - glob: "deployment/**"
+    owner: template
+  - glob: "fastlane/**"
+    owner: template
+  - glob: "fastlane-config/**"
+    owner: template
+  - glob: "spotless/**"
+    owner: template
+  - glob: "gradle/wrapper/**"
+    owner: template
+  - glob: "maestro/screen-state/**"
+    owner: template
+  - glob: "scripts/**"
+    owner: template
+  - glob: "config/**"
+    owner: template
+  - glob: "secrets/sample/**"
+    owner: template
+  - glob: "secrets/**"                        # LAYOUT.yaml + scaffold (live/ is fork above)
+    owner: template
+  - glob: "docs/**"
+    owner: template
+  - glob: ".github/**"
+    owner: template
+  - glob: ".run/**"
+    owner: template
+  # root-level template files (mirror sync-dirs.sh SYNC_FILES)
+  - { glob: "Gemfile",                       owner: template }
+  - { glob: "Gemfile.lock",                  owner: template }
+  - { glob: "ci-prepush.sh",                 owner: template }
+  - { glob: "ci-prepush.bat",                owner: template }
+  - { glob: "gradlew",                       owner: template }
+  - { glob: "gradlew.bat",                   owner: template }
+  - { glob: "compose_compiler_config.conf",  owner: template }
+  - { glob: "sync-dirs.sh",                  owner: template }
+  - { glob: "customizer.sh",                 owner: template }
+  - { glob: "setup-project.sh",              owner: template }
+  - { glob: "keystore-manager.sh",           owner: template }
+  - { glob: "firebase-setup.sh",             owner: template }
+  - { glob: "generateModuleGraphs.sh",       owner: template }
+  - { glob: "gradle/fork.properties.template", owner: template }
+  - { glob: "gradle/gradle-daemon-jvm.properties", owner: template }
+  - { glob: ".editorconfig",                 owner: template }
+  - { glob: ".gitattributes",                owner: template }
+  - { glob: ".gitignore",                    owner: template }
+  - { glob: ".actrc",                        owner: template }
+  - { glob: ".ruby-version",                 owner: template }
+  - { glob: ".kover-floor.yml",              owner: template }
+  - { glob: ".claudeignore",                 owner: template }
+  - { glob: "customization-surface.yaml",    owner: template }  # this contract self-syncs
+  - { glob: "version.txt",                   owner: template }
+  - { glob: "lib-integrate.properties",      owner: template }
+  - { glob: "secrets-manifest.yaml",         owner: template }
+  - { glob: "gradle.properties",             owner: template }
+  - { glob: "build.gradle.kts",              owner: template }
+  - { glob: "kotlin-js-store/**",            owner: template }
+  - { glob: "legal/**",                      owner: template }
+  - { glob: "META-INF/**",                   owner: template }
+  - { glob: "config",                        owner: template }
+  - { glob: "CODE_OF_CONDUCT.md",            owner: template }
+  - { glob: "CONTRIBUTING.md",               owner: template }
+  - { glob: "LICENSE",                       owner: template }
+
+  # ── default: any path not matched above ──
+  # Runtime treats an unmatched path as fork-owned (SAFE — never clobber an unknown
+  # fork file). `--verify` flags anything that reaches this rule so a human classifies
+  # it explicitly (a new template file must not rely on the default).
+  - glob: "**"
+    owner: fork
+    default: true

--- a/docs/architecture/CUSTOMIZATION_SURFACE.md
+++ b/docs/architecture/CUSTOMIZATION_SURFACE.md
@@ -1,0 +1,102 @@
+# Customization Surface — the fork-ownership contract
+
+`customization-surface.yaml` (repo root) is the **single declared source of truth
+for who owns each path** when a fork syncs template updates. It replaces ownership
+knowledge that was previously implicit and scattered across `sync-dirs.sh`
+(`SYNC_DIRS` + `EXCLUSIONS`), `customizer.sh`, and the `syncForkConfig` copy map.
+
+## Why it exists
+
+A fork runs `sync-dirs.sh` to pull template updates while keeping its own branding
++ features. The hard question is *"which files may the sync overwrite?"* When that
+answer lives only in an ad-hoc `EXCLUSIONS` list, a path with no exclusion gets
+**blind-overwritten** — and that silently drops fork edits. The motivating case:
+
+> `cmp-android/src/main/AndroidManifest.xml` is template-shipped **and**
+> fork-extended (a fork adds `RECORD_AUDIO`, `FOREGROUND_SERVICE_MICROPHONE`, …).
+> The `EXCLUSIONS` map preserved only `src/main/res`, so a full sync overwrote the
+> manifest and **dropped the fork's permissions** — breaking the app.
+
+The contract makes ownership **explicit, single-source, and machine-checkable**, so
+that whole class of silent loss becomes impossible.
+
+## The three ownership modes
+
+| owner | meaning | sync behaviour |
+|---|---|---|
+| `template` | template is the sole author | **overwrite** the fork's copy. A fork edit here is drift — a genuine fix belongs **upstream** as a PR to `openMF/kmp-project-template`. |
+| `fork` | the fork is the sole author | **never touch** it (branding, demo, the `core/store` seam, generated `Config.xcconfig`, local flavors, icons, store listings, fork identity). |
+| `merge` | both author | **3-way merge**, never a blind copy (`AndroidManifest.xml`, `strings.xml`, `libs.versions.toml`, `settings.gradle.kts`, nav host). |
+
+## Precedence
+
+Rules are ordered **most-specific → most-general**, and the **first matching rule
+wins**. So the narrow `merge`/`fork` carve-outs are declared *before* the broad
+`template` module globs and correctly win over them. A trailing catch-all `**`
+rule (`owner: fork`, `default: true`) means the runtime never clobbers an unknown
+path — while `--verify` flags anything that reaches it so a human classifies it.
+
+Glob syntax: `*` matches within one path segment; `**` matches across segments;
+`**/x` matches `x` at any depth (including the repo root).
+
+## The reader / validator — `scripts/customization-surface.sh`
+
+Pure bash + awk (no `yq`/`jq`/`python` dependency — runs on any fork as-is).
+
+```bash
+# what owns this path?
+scripts/customization-surface.sh resolve cmp-android/src/main/AndroidManifest.xml
+#   → cmp-android/src/main/AndroidManifest.xml   merge  (strategy: manifest-union)
+
+# owner of every tracked path
+scripts/customization-surface.sh report
+
+# CI canary — fail if any tracked path is unclassified (only matches the default)
+scripts/customization-surface.sh verify
+#   → ── customization-surface coverage: 1587/1587 classified ──
+#   → ✅ every tracked path has an explicit owner
+```
+
+Source it as a library too:
+
+```bash
+source scripts/customization-surface.sh
+cs_resolve_owner    "gradle/libs.versions.toml"   # → merge
+cs_resolve_strategy "gradle/libs.versions.toml"   # → catalog-3way
+```
+
+## How `sync-dirs.sh` uses it (today)
+
+`sync-dirs.sh` sources the reader and, before the mechanical sync, prints the
+**`merge`-owned paths in the sync surface** as an advisory — so a maintainer can
+confirm the `EXCLUSIONS` map preserves fork edits. This step is fully guarded and
+**cannot abort a sync**. The mechanical `SYNC_DIRS` / `EXCLUSIONS` behaviour is
+**unchanged** in this step; the contract is the declared source of truth the merge
+engine adopts next.
+
+## Recommended CI wiring
+
+Add a coverage gate so a new template file can never land unclassified (and thus
+never silently clobber a fork later):
+
+```yaml
+- name: Verify customization-surface coverage
+  run: bash scripts/customization-surface.sh verify
+```
+
+## Roadmap (follow-ups)
+
+1. **Merge engine adoption** — `sync-dirs.sh` consults the contract per path
+   (template → copy, fork → skip, merge → 3-way) and retires the ad-hoc
+   `EXCLUSIONS` map. `merge` strategies (`manifest-union`, `strings-union`,
+   `catalog-3way`, `include-union`, `kotlin-3way`) become real merge drivers.
+2. **`syncForkConfig` alignment** — the plugin reads the same contract to know
+   which generated files it owns vs must not clobber.
+
+## Editing the contract
+
+- A new **template-owned** module → add a `template` rule (and, if forks extend a
+  specific file inside it, a narrower `merge`/`fork` rule *above* it).
+- A new **fork-branded** path → add a `fork` rule.
+- A file both sides edit → add a `merge` rule with a `strategy:`.
+- Always run `scripts/customization-surface.sh verify` after editing.

--- a/docs/architecture/CUSTOMIZATION_SURFACE.md
+++ b/docs/architecture/CUSTOMIZATION_SURFACE.md
@@ -65,14 +65,34 @@ cs_resolve_owner    "gradle/libs.versions.toml"   # → merge
 cs_resolve_strategy "gradle/libs.versions.toml"   # → catalog-3way
 ```
 
-## How `sync-dirs.sh` uses it (today)
+## How `sync-dirs.sh` uses it
 
-`sync-dirs.sh` sources the reader and, before the mechanical sync, prints the
-**`merge`-owned paths in the sync surface** as an advisory — so a maintainer can
-confirm the `EXCLUSIONS` map preserves fork edits. This step is fully guarded and
-**cannot abort a sync**. The mechanical `SYNC_DIRS` / `EXCLUSIONS` behaviour is
-**unchanged** in this step; the contract is the declared source of truth the merge
-engine adopts next.
+1. **Advisory report** — before the sync, `sync-dirs.sh` sources the reader and
+   prints the `merge`-owned paths in the sync surface (fully guarded, cannot abort).
+2. **3-way merge of `merge`-owned files** — after checking out the upstream copy of
+   a directory, for every file that changed between the fork base and upstream and
+   resolves to `owner: merge`, `sync-dirs.sh` runs `cs_merge <strategy> ours base
+   theirs` instead of taking the blind upstream copy:
+   - `ours` = fork's current file (`BASE_BRANCH`)
+   - `theirs` = upstream file (`temp_branch`)
+   - `base` = `git merge-base BASE_BRANCH temp_branch`
+
+   `manifest-union` runs a **semantic** union (union `<uses-permission>` /
+   `<uses-feature>` by `android:name`, keeping the template's structural update) so a
+   fork's `RECORD_AUDIO` survives a template manifest change. The other strategies
+   (`catalog-3way`, `include-union`, `kotlin-3way`, `strings-union`) run `git
+   merge-file`, which cleanly unions non-overlapping edits and emits conflict markers
+   **only on a true overlap** — surfaced with a `CONFLICT` warning for review, never
+   silently shipped.
+
+The `template`/`fork` mechanical behaviour (`SYNC_DIRS` + `EXCLUSIONS`) is unchanged;
+the contract adds the `merge` path handling that previously didn't exist. Guarded so
+forks that don't ship the reader are unaffected.
+
+Proof: `tests/customization-surface/merge-3way-test.sh` — a fork's `RECORD_AUDIO` +
+`FOREGROUND_SERVICE_MICROPHONE` survive a template update that adds
+`POST_NOTIFICATIONS`, clean, no markers; a true same-line conflict returns rc=1 with
+markers.
 
 ## Recommended CI wiring
 
@@ -86,10 +106,11 @@ never silently clobber a fork later):
 
 ## Roadmap (follow-ups)
 
-1. **Merge engine adoption** — `sync-dirs.sh` consults the contract per path
-   (template → copy, fork → skip, merge → 3-way) and retires the ad-hoc
-   `EXCLUSIONS` map. `merge` strategies (`manifest-union`, `strings-union`,
-   `catalog-3way`, `include-union`, `kotlin-3way`) become real merge drivers.
+1. ~~Merge engine adoption~~ — **done**: `sync-dirs.sh` 3-way merges `merge`-owned
+   files (`manifest-union` semantic + `git merge-file` for the rest). Remaining:
+   fold the `fork`/`template` decisions into the same contract lookup and retire the
+   hand-maintained `EXCLUSIONS` map (the reader can already answer `fork` → skip /
+   `template` → copy; `EXCLUSIONS` becomes redundant).
 2. **`syncForkConfig` alignment** — the plugin reads the same contract to know
    which generated files it owns vs must not clobber.
 

--- a/scripts/customization-surface.sh
+++ b/scripts/customization-surface.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# customization-surface.sh — reader + validator for customization-surface.yaml
+# ─────────────────────────────────────────────────────────────────────────────
+# The single consumer-facing API for the fork-ownership contract. Pure bash + awk
+# (no yq/python/jq dependency, so it runs on any fork out of the box).
+#
+# Library use (source it):
+#     source scripts/customization-surface.sh
+#     owner=$(cs_resolve_owner "cmp-android/src/main/AndroidManifest.xml")   # -> merge
+#     strat=$(cs_resolve_strategy "cmp-android/src/main/AndroidManifest.xml") # -> manifest-union
+#
+# CLI use:
+#     scripts/customization-surface.sh resolve <path>   # print owner (+ strategy)
+#     scripts/customization-surface.sh report           # owner of every tracked path
+#     scripts/customization-surface.sh verify            # CI: fail if any tracked
+#                                                        # path only matches the default
+# ─────────────────────────────────────────────────────────────────────────────
+# NOTE: shell options are set only on direct execution (bottom), NOT on source —
+# sourcing must not leak `set -u`/`pipefail` into a caller like sync-dirs.sh.
+
+CS_SELF="${BASH_SOURCE[0]}"
+CS_ROOT="$(cd "$(dirname "$CS_SELF")/.." && pwd)"
+CS_CONTRACT="${CS_CONTRACT:-$CS_ROOT/customization-surface.yaml}"
+
+# Parse the YAML into "glob<TAB>owner<TAB>strategy<TAB>default" rows, in file order.
+# Handles both block form (- glob:\n  owner:) and inline form (- { glob: x, owner: y }).
+cs_parse_rules() {
+  awk '
+    function emit() {
+      if (glob != "") printf "%s|%s|%s|%s\n", glob, owner, strat, def
+      glob=""; owner=""; strat=""; def="0"
+    }
+    # inline form:  - { glob: "x", owner: y, strategy: z }
+    /^[[:space:]]*-[[:space:]]*\{/ {
+      emit()               # flush any pending block-form rule first
+      line=$0
+      g=line; sub(/.*glob:[[:space:]]*"?/,"",g); sub(/"?[[:space:]]*,.*/,"",g); sub(/"?[[:space:]]*}.*/,"",g)
+      o=line; sub(/.*owner:[[:space:]]*/,"",o); sub(/[[:space:]]*,.*/,"",o); sub(/[[:space:]]*}.*/,"",o)
+      glob=g; owner=o; strat=""; def="0"
+      if (line ~ /default:[[:space:]]*true/) def="1"
+      emit(); next
+    }
+    # block form start — extract the QUOTED value (drops any trailing # comment)
+    /^[[:space:]]*-[[:space:]]*glob:/ {
+      emit()
+      g=$0; sub(/.*glob:[[:space:]]*"/,"",g); sub(/".*/,"",g)
+      glob=g; next
+    }
+    # owner/strategy are single tokens — take the first word (drops trailing comments)
+    /^[[:space:]]*owner:/    { o=$0; sub(/.*owner:[[:space:]]*/,"",o);    sub(/[[:space:]].*/,"",o); owner=o; next }
+    /^[[:space:]]*strategy:/ { s=$0; sub(/.*strategy:[[:space:]]*/,"",s); sub(/[[:space:]].*/,"",s); strat=s; next }
+    /^[[:space:]]*default:[[:space:]]*true/ { def="1"; next }
+    END { emit() }
+  ' "$CS_CONTRACT"
+}
+
+# Convert a contract glob to an anchored ERE.
+#   **/x -> (.*/)?x   |   ** -> .*   |   * -> [^/]*   |   . escaped
+cs_glob_to_regex() {
+  local g="$1"
+  local s1=$'\x01' s2=$'\x02'   # sentinels — never occur in a path glob
+  g="${g//./\\.}"
+  # Placeholder the multi-segment tokens FIRST so the single-`*` pass below can't
+  # re-clobber the `*` inside their `.*` expansions (globstar → sentinel → restore).
+  g="${g//\*\*\//$s1}"   # **/  (match zero+ segments)
+  g="${g//\*\*/$s2}"     # **   (match anything)
+  g="${g//\*/[^/]*}"     # *    (match within one segment)
+  g="${g//$s1/(.*/)?}"
+  g="${g//$s2/.*}"
+  printf '^%s$' "$g"
+}
+
+# Load + compile the rules ONCE into parallel arrays (parse is expensive; matching
+# is hot). Idempotent — safe to call before every resolve.
+CS_LOADED=0
+cs_load_rules() {
+  [ "$CS_LOADED" = 1 ] && return
+  CS_RX=(); CS_OWNER=(); CS_STRAT=(); CS_DEF=()
+  local glob owner strat def
+  while IFS='|' read -r glob owner strat def; do
+    [ -z "$glob" ] && continue
+    CS_RX+=("$(cs_glob_to_regex "$glob")")
+    CS_OWNER+=("$owner"); CS_STRAT+=("$strat"); CS_DEF+=("$def")
+  done < <(cs_parse_rules)
+  CS_LOADED=1
+}
+
+# First matching rule → set globals CS_M_OWNER / CS_M_STRAT / CS_M_DEFAULT.
+# No subshell / no print (hot path — called once per tracked file in `verify`).
+cs_match_g() {
+  cs_load_rules
+  local path="$1" i
+  for i in "${!CS_RX[@]}"; do
+    if [[ "$path" =~ ${CS_RX[$i]} ]]; then
+      CS_M_OWNER="${CS_OWNER[$i]}"; CS_M_STRAT="${CS_STRAT[$i]}"; CS_M_DEFAULT="${CS_DEF[$i]}"
+      return 0
+    fi
+  done
+  CS_M_OWNER="fork"; CS_M_STRAT=""; CS_M_DEFAULT="1"   # fallback = fork (never clobber unknown)
+}
+
+cs_resolve_owner()    { cs_match_g "$1"; printf '%s' "$CS_M_OWNER"; }
+cs_resolve_strategy() { cs_match_g "$1"; printf '%s' "$CS_M_STRAT"; }
+cs_is_default()       { cs_match_g "$1"; [ "$CS_M_DEFAULT" = "1" ]; }
+
+# ── CLI ──
+cs_main() {
+  local cmd="${1:-}"; shift || true
+  case "$cmd" in
+    resolve)
+      local p="${1:?usage: resolve <path>}"
+      cs_match_g "$p"
+      printf '%s\t%s%s\n' "$p" "$CS_M_OWNER" "${CS_M_STRAT:+  (strategy: $CS_M_STRAT)}"
+      ;;
+    report)
+      local f; declare -A cnt=()
+      while IFS= read -r f; do
+        cs_match_g "$f"; cnt[$CS_M_OWNER]=$(( ${cnt[$CS_M_OWNER]:-0} + 1 ))
+        printf '%s\t%s\n' "$CS_M_OWNER" "$f"
+      done < <(git -C "$CS_ROOT" ls-files) | sort
+      local k; for k in "${!cnt[@]}"; do printf '# %-9s %d files\n' "$k" "${cnt[$k]}" >&2; done
+      ;;
+    verify)
+      local unclassified=0 total=0 f
+      while IFS= read -r f; do
+        total=$((total+1))
+        cs_match_g "$f"
+        if [ "$CS_M_DEFAULT" = "1" ]; then
+          echo "UNCLASSIFIED (matches only the default rule): $f"
+          unclassified=$((unclassified+1))
+        fi
+      done < <(git -C "$CS_ROOT" ls-files)
+      echo "── customization-surface coverage: $((total-unclassified))/$total classified ──"
+      if [ "$unclassified" -gt 0 ]; then
+        echo "❌ $unclassified path(s) unclassified — add an explicit rule to customization-surface.yaml"
+        return 1
+      fi
+      echo "✅ every tracked path has an explicit owner"
+      ;;
+    *)
+      echo "usage: customization-surface.sh {resolve <path>|report|verify}" >&2
+      return 2
+      ;;
+  esac
+}
+
+# Run CLI only when executed directly (not when sourced as a library).
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  set -uo pipefail
+  cs_main "$@"
+fi

--- a/scripts/customization-surface.sh
+++ b/scripts/customization-surface.sh
@@ -103,6 +103,69 @@ cs_resolve_owner()    { cs_match_g "$1"; printf '%s' "$CS_M_OWNER"; }
 cs_resolve_strategy() { cs_match_g "$1"; printf '%s' "$CS_M_STRAT"; }
 cs_is_default()       { cs_match_g "$1"; [ "$CS_M_DEFAULT" = "1" ]; }
 
+# 3-way merge driver for a `merge`-owned file. This is the general merge strategy
+# behind manifest-union / catalog-3way / include-union / kotlin-3way / strings-union:
+# git merge-file cleanly unions non-overlapping additions (e.g. a fork's extra
+# <uses-permission> lines) and only emits conflict markers on a true overlap.
+#
+#   cs_merge_3way <ours> <base> <theirs> [<out>]
+#     ours   = the fork's current file        base = common ancestor
+#     theirs = the upstream/template file      out  = result (default: ours, in place)
+#   returns  0 clean · 1 merged WITH conflict markers (needs review) · 2 error
+cs_merge_3way() {
+  local ours="$1" base="$2" theirs="$3" out="${4:-$1}" rc tmp
+  [ -f "$ours" ] && [ -f "$base" ] && [ -f "$theirs" ] || {
+    echo "cs_merge_3way: need existing <ours> <base> <theirs>" >&2; return 2; }
+  tmp="$(mktemp)"
+  # -p prints the merged result (does not mutate inputs); exit = conflict count.
+  git merge-file -p "$ours" "$base" "$theirs" > "$tmp"; rc=$?
+  if [ "$rc" -ge 128 ]; then rm -f "$tmp"; echo "cs_merge_3way: git merge-file error ($rc)" >&2; return 2; fi
+  mv "$tmp" "$out"
+  [ "$rc" -eq 0 ] && return 0 || return 1
+}
+
+# Semantic AndroidManifest union — the `manifest-union` strategy. A textual 3-way
+# spurious-conflicts when fork + template both insert permission lines at the same
+# spot, so union by android:name instead: take THEIRS (the template's structurally
+# updated manifest) and inject every <uses-permission>/<uses-feature> line present
+# in OURS whose android:name theirs lacks. Always clean (returns 0).
+#
+#   cs_merge_manifest <ours> <theirs> [<out>]
+cs_merge_manifest() {
+  local ours="$1" theirs="$2" out="${3:-$1}" tmp add
+  [ -f "$ours" ] && [ -f "$theirs" ] || { echo "cs_merge_manifest: need <ours> <theirs>" >&2; return 2; }
+  local theirs_names; theirs_names="$(grep -oE 'android:name="[^"]*"' "$theirs" 2>/dev/null | sort -u)"
+  # Extract each uses-permission/uses-feature ELEMENT (robust to one-per-line AND
+  # multiple-per-line manifests); add the ones whose android:name theirs lacks.
+  add="$(grep -oE '<uses-(permission|feature)[^>]*/?>' "$ours" 2>/dev/null | while IFS= read -r el; do
+        nm="$(printf '%s' "$el" | grep -oE 'android:name="[^"]*"' | head -1)"
+        [ -n "$nm" ] || continue
+        printf '%s\n' "$theirs_names" | grep -qxF "$nm" || printf '    %s\n' "$el"
+      done)"
+  if [ -z "$add" ]; then cp "$theirs" "$out"; return 0; fi
+  local addf; addf="$(mktemp)"; printf '%s\n' "$add" > "$addf"
+  tmp="$(mktemp)"
+  # Read the injected lines from a file (awk -v cannot carry newlines).
+  awk -v addf="$addf" '
+    function dumpadd(   l) { while ((getline l < addf) > 0) print l; close(addf) }
+    /<application/ && !ins { dumpadd(); ins=1 }
+    /<\/manifest>/ && !ins { dumpadd(); ins=1 }
+    { print }
+  ' "$theirs" > "$tmp"
+  mv "$tmp" "$out"; rm -f "$addf"
+  return 0
+}
+
+# Strategy dispatcher used by sync-dirs.sh for a `merge`-owned file.
+#   cs_merge <strategy> <ours> <base> <theirs> [<out>]
+cs_merge() {
+  local strat="$1" ours="$2" base="$3" theirs="$4" out="${5:-$2}"
+  case "$strat" in
+    manifest-union) cs_merge_manifest "$ours" "$theirs" "$out" ;;
+    *)              cs_merge_3way "$ours" "$base" "$theirs" "$out" ;;
+  esac
+}
+
 # ── CLI ──
 cs_main() {
   local cmd="${1:-}"; shift || true
@@ -137,8 +200,11 @@ cs_main() {
       fi
       echo "✅ every tracked path has an explicit owner"
       ;;
+    merge)
+      cs_merge "$@"   # <strategy> <ours> <base> <theirs> [<out>]
+      ;;
     *)
-      echo "usage: customization-surface.sh {resolve <path>|report|verify}" >&2
+      echo "usage: customization-surface.sh {resolve <path>|report|verify|merge <strategy> <ours> <base> <theirs> [out]}" >&2
       return 2
       ;;
   esac

--- a/sync-dirs.sh
+++ b/sync-dirs.sh
@@ -612,6 +612,30 @@ if [ "$DRY_RUN" = false ]; then
     preserve_root_files
 fi
 
+# ── customization-surface advisory (fork-ownership contract) ──────────────────
+# Non-breaking: reports which about-to-be-synced paths are `merge`-owned per
+# customization-surface.yaml, so a maintainer can confirm the EXCLUSIONS map
+# preserves fork edits (e.g. AndroidManifest permissions). The mechanical sync
+# below is UNCHANGED — the contract is the declared source of truth the merge
+# engine adopts next. Fully guarded so it can never abort a sync.
+CS_READER="$(dirname "$0")/scripts/customization-surface.sh"
+if [ -f "$CS_READER" ] && [ -f "$(dirname "$0")/customization-surface.yaml" ]; then
+    # shellcheck source=/dev/null
+    source "$CS_READER" 2>/dev/null || true
+    if declare -F cs_match_g >/dev/null 2>&1; then
+        echo -e "\n${BLUE}${BOLD}Fork-ownership contract — merge-owned paths in the sync surface${NC}"
+        cs_merge_hits=0
+        while IFS= read -r _csf; do
+            cs_match_g "$_csf" || continue
+            if [ "${CS_M_OWNER:-}" = "merge" ]; then
+                echo -e "  ${YELLOW}merge${NC} $_csf ${YELLOW}(${CS_M_STRAT:-3way} — do NOT blind-overwrite)${NC}"
+                cs_merge_hits=$((cs_merge_hits + 1))
+            fi
+        done < <(git ls-files -- "${SYNC_DIRS[@]}" 2>/dev/null)
+        [ "$cs_merge_hits" -gt 0 ] && echo -e "  ${YELLOW}⚠ $cs_merge_hits merge-owned path(s) — verify EXCLUSIONS preserves fork edits (permissions, catalog, nav).${NC}"
+    fi
+fi
+
 # Sync directories
 echo -e "\n${BLUE}${BOLD}Syncing directories...${NC}"
 echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"

--- a/sync-dirs.sh
+++ b/sync-dirs.sh
@@ -373,6 +373,31 @@ sync_directory() {
                 fi
             done < <(git diff --name-only "$BASE_BRANCH" -- "$dir" 2>/dev/null)
 
+            # ── 3-way merge for merge-owned files (customization-surface contract) ──
+            # Replaces a blind upstream clobber with a real merge so fork edits (e.g.
+            # AndroidManifest permissions) survive a template update. ours=fork
+            # (BASE_BRANCH), theirs=upstream (temp_branch), base=merge-base. Guarded:
+            # no-op on forks that don't ship the reader.
+            if declare -F cs_match_g >/dev/null 2>&1 && declare -F cs_merge >/dev/null 2>&1; then
+                local _mbase; _mbase="$(git merge-base "$BASE_BRANCH" "$temp_branch" 2>/dev/null)"
+                while IFS= read -r _mf; do
+                    [ -z "$_mf" ] && continue
+                    cs_match_g "$_mf"; [ "${CS_M_OWNER:-}" = "merge" ] || continue
+                    local _o _b _t; _o="$(mktemp)"; _b="$(mktemp)"; _t="$(mktemp)"
+                    if git show "$BASE_BRANCH:$_mf" > "$_o" 2>/dev/null \
+                       && git show "$temp_branch:$_mf" > "$_t" 2>/dev/null; then
+                        git show "${_mbase}:$_mf" > "$_b" 2>/dev/null || cp "$_o" "$_b"
+                        mkdir -p "$(dirname "$_mf")"
+                        if cs_merge "${CS_M_STRAT:-3way}" "$_o" "$_b" "$_t" "$_mf"; then
+                            print_step "Merged (${CS_M_STRAT:-3way}) ${BOLD}$_mf${NC} — fork edits preserved"
+                        else
+                            print_warning "CONFLICT in ${BOLD}$_mf${NC} (${CS_M_STRAT:-3way}) — resolve markers before committing the sync"
+                        fi
+                    fi
+                    rm -f "$_o" "$_b" "$_t"
+                done < <(git diff --name-only "$BASE_BRANCH" "$temp_branch" -- "$dir" 2>/dev/null)
+            fi
+
             # Restore excluded files and directories
             if [ -n "${EXCLUSIONS[$dir]}" ]; then
                 local IFS=' '

--- a/tests/customization-surface/merge-3way-test.sh
+++ b/tests/customization-surface/merge-3way-test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Fixture test for cs_merge_3way — proves the AndroidManifest permission-loss class
+# is closed: a fork's added <uses-permission> survives a template manifest update.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+READER="$HERE/../../scripts/customization-surface.sh"
+# shellcheck source=/dev/null
+source "$READER"
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+fail=0; pass() { echo "  ✅ $1"; }; bad() { echo "  ❌ $1"; fail=1; }
+
+manifest() { # $1 = extra permission lines
+  cat <<XML
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+$1    <application android:label="@string/app_name" />
+</manifest>
+XML
+}
+
+echo "── Case A: additive union (fork perms + template perms) ──"
+manifest '' > "$WORK/base.xml"
+# ours = fork added RECORD_AUDIO + FOREGROUND_SERVICE_MICROPHONE
+manifest '    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+' > "$WORK/ours.xml"
+# theirs = template added POST_NOTIFICATIONS
+manifest '    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+' > "$WORK/theirs.xml"
+
+# The loss class: a BLIND copy of theirs would drop the fork's RECORD_AUDIO.
+if grep -q RECORD_AUDIO "$WORK/theirs.xml"; then
+  bad "precondition: theirs unexpectedly already has RECORD_AUDIO"
+else
+  pass "precondition: blind-copy(theirs) would DROP fork's RECORD_AUDIO (the loss class)"
+fi
+
+# manifest-union strategy (semantic union, not textual — additions at the same
+# insertion point must NOT spurious-conflict).
+cs_merge manifest-union "$WORK/ours.xml" "$WORK/base.xml" "$WORK/theirs.xml" "$WORK/out.xml"
+rc=$?
+[ "$rc" -eq 0 ] && pass "merge returned clean (rc=0)" || bad "merge rc=$rc (expected 0)"
+grep -q RECORD_AUDIO "$WORK/out.xml"                  && pass "fork RECORD_AUDIO preserved"            || bad "RECORD_AUDIO lost"
+grep -q FOREGROUND_SERVICE_MICROPHONE "$WORK/out.xml" && pass "fork FOREGROUND_SERVICE_MICROPHONE preserved" || bad "FOREGROUND_SERVICE_MICROPHONE lost"
+grep -q POST_NOTIFICATIONS "$WORK/out.xml"            && pass "template POST_NOTIFICATIONS picked up"  || bad "template POST_NOTIFICATIONS missing"
+grep -q '<<<<<<<' "$WORK/out.xml"                     && bad "unexpected conflict markers in clean merge" || pass "no conflict markers"
+
+echo "── Case B: true conflict surfaces (same line changed both sides) ──"
+printf '<application android:label="BASE" />\n'   > "$WORK/b2.xml"
+printf '<application android:label="FORK" />\n'   > "$WORK/o2.xml"
+printf '<application android:label="UPSTREAM" />\n'> "$WORK/t2.xml"
+cs_merge_3way "$WORK/o2.xml" "$WORK/b2.xml" "$WORK/t2.xml" "$WORK/out2.xml"
+rc=$?
+[ "$rc" -eq 1 ] && pass "conflict returned rc=1 (surfaced, not silently shipped)" || bad "conflict rc=$rc (expected 1)"
+grep -q '<<<<<<<' "$WORK/out2.xml" && pass "conflict markers present for review" || bad "conflict markers missing"
+
+echo
+if [ "$fail" -eq 0 ]; then echo "✅ merge-3way: all assertions passed"; exit 0
+else echo "❌ merge-3way: failures above"; exit 1; fi


### PR DESCRIPTION
> **Stacks on #267** (the fork-ownership contract + reader). Review/merge after #267;
> the diff below includes #267's files until it lands.

## Problem

#267 declared `merge`-owned paths (`AndroidManifest.xml`, `libs.versions.toml`,
`settings.gradle.kts`, `strings.xml`, nav host) but only **reported** them. They were
still **blind-overwritten** by the sync — so a fork's `AndroidManifest.xml` additions
(`RECORD_AUDIO`, `FOREGROUND_SERVICE_MICROPHONE`, …) were dropped on a template update.

## What this adds

Wire the contract's `merge` owner into `sync-dirs.sh`: after checking out the upstream
copy of a directory, every file that changed **both** in the fork and upstream and
resolves to `owner: merge` is **3-way merged** instead of taking the blind upstream copy.

- **`cs_merge_manifest`** — semantic AndroidManifest **union** (`<uses-permission>` /
  `<uses-feature>` by `android:name`, keeping the template's structural update). A
  purely textual 3-way spurious-conflicts here because fork + template both insert at
  the same spot — so the manifest gets a dedicated driver. Robust to one-per-line and
  multiple-per-line manifests.
- **`cs_merge_3way`** — `git merge-file` for the other strategies (`catalog-3way`,
  `include-union`, `kotlin-3way`, `strings-union`): clean union of non-overlapping
  edits; conflict markers **only on a true overlap**, surfaced as a `CONFLICT` warning
  (never silently shipped).
- **`cs_merge`** — strategy dispatcher + a `merge` CLI subcommand.
- **`sync-dirs.sh`** — the merge pass (`ours`=fork `BASE_BRANCH`, `theirs`=upstream
  `temp_branch`, `base`=`git merge-base`). Guarded — no-op on forks without the reader.
  The `template`/`fork` mechanical behaviour (`SYNC_DIRS` + `EXCLUSIONS`) is unchanged.

## Verification

`tests/customization-surface/merge-3way-test.sh`:
- A fork's `RECORD_AUDIO` + `FOREGROUND_SERVICE_MICROPHONE` **survive** a template
  update that adds `POST_NOTIFICATIONS` — clean, **no conflict markers**.
- A true same-line conflict returns **rc=1 with markers** (surfaced for review).
- Robustness: single-line + multi-line manifests both union correctly.
- `bash -n` clean on both scripts; contract coverage still 1587/1587.

## Remaining (roadmap)

Fold the `fork`/`template` decisions into the same contract lookup and retire the
hand-maintained `EXCLUSIONS` map (the reader can already answer `fork`→skip /
`template`→copy). Tracked in `docs/architecture/CUSTOMIZATION_SURFACE.md`.