### PR TITLE
chore(ci): sync-dirs workflow syncs secrets/ scaffold (except live/)

### DIFF
--- a/.github/workflows/sync-dirs.yaml
+++ b/.github/workflows/sync-dirs.yaml
@@ -70,6 +70,7 @@ jobs:
             "fastlane-config"
             "scripts"
             "config"
+            "secrets"
             ".github"
             ".run"
           )
@@ -91,7 +92,12 @@ jobs:
             ["fastlane-config"]="project_config.rb extract_config.rb"
             [".github"]="workflows/sync-dirs.yaml"
             ["build-logic"]="convention/src/main/kotlin/local"
-            ["root"]="secrets.env"
+            # Secrets: sync the SCAFFOLD only (secrets/sample/** + LAYOUT.yaml) so
+            # forks inherit the canonical layout, but NEVER real values —
+            # secrets/live/ is gitignored + fork-local (real secrets), and
+            # .sync-meta.json is per-fork sync state. Matches sync-dirs.sh.
+            # (secrets.env removed — that file was retired 2026-06-23.)
+            ["secrets"]="live .sync-meta.json"
           )
 
           # Function to check if path should be excluded
@@ -410,6 +416,7 @@ jobs:
             - fastlane-config (excluding project_config.rb, extract_config.rb)
             - scripts
             - config
+            - secrets (scaffold only — excludes secrets/live/ real values + .sync-meta.json)
             - .github (excluding workflows/sync-dirs.yaml — self-overwrite guard)
             - .run
 
@@ -419,8 +426,8 @@ jobs:
             - ci-prepush.bat
             - ci-prepush.sh
 
-            **Root-level exclusions:**
-            - secrets.env
+            **Secrets:** scaffold only — secrets/sample/ + secrets/LAYOUT.yaml sync;
+            secrets/live/ (real values) and .sync-meta.json are never synced.
 
             ---
             Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
The scheduled sync-dirs.yaml kept its own inline DIRS list that drifted from sync-dirs.sh: it never synced the secrets/ scaffold (LAYOUT.yaml + sample/) and still referenced the retired secrets.env. Adds 'secrets' to DIRS with a [secrets]='live .sync-meta.json' exclusion so forks inherit the canonical secrets layout while real values (secrets/live/) are never synced. Aligns the workflow with sync-dirs.sh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Directory synchronization now includes the `secrets` scaffold while preserving environment-specific secret values and synchronization metadata.

* **Documentation**
  * Updated synchronization documentation to clarify how the `secrets` directory is handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->