### PR TITLE
fix(secrets): complete Phase-7 secrets/live migration — resolve consumers to secrets/live/

### DIFF
--- a/.github/workflows/release-multi-platform-local.yml
+++ b/.github/workflows/release-multi-platform-local.yml
@@ -182,8 +182,8 @@ jobs:
       pre_fastlane_script: |
         set -euo pipefail
         if [ -n "${UPLOAD_KEYSTORE_B64:-}" ]; then
-          mkdir -p secrets/android/keystores
-          echo "$UPLOAD_KEYSTORE_B64" | base64 -d > secrets/android/keystores/upload_keystore.keystore
+          mkdir -p secrets/live/android/keystores
+          echo "$UPLOAD_KEYSTORE_B64" | base64 -d > secrets/live/android/keystores/upload_keystore.keystore
           echo "✅ Materialized Android keystore"
         fi
         if [ -n "${GOOGLE_SERVICES_B64:-}" ]; then
@@ -199,31 +199,31 @@ jobs:
           echo "✅ Materialized Play SA"
         fi
         if [ -n "${APPSTORE_AUTH_KEY_B64:-}" ]; then
-          mkdir -p secrets/apple/appstore
-          # Write to both paths — Fastfile expects secrets/apple/appstore/AuthKey.p8
+          mkdir -p secrets/live/apple/appstore
+          # Write to both paths — Fastfile expects secrets/live/apple/appstore/AuthKey.p8
           # (deployment/_shared/config.rb appstore_helpers); legacy callers may
-          # still reference secrets/apple/appstore/AuthKey.p8 (kept as backwards-compat).
-          echo "$APPSTORE_AUTH_KEY_B64" | base64 -d > secrets/apple/appstore/AuthKey.p8
-          chmod 600 secrets/apple/appstore/AuthKey.p8
-          cp secrets/apple/appstore/AuthKey.p8 secrets/apple/appstore/AuthKey.p8
+          # still reference secrets/live/apple/appstore/AuthKey.p8 (kept as backwards-compat).
+          echo "$APPSTORE_AUTH_KEY_B64" | base64 -d > secrets/live/apple/appstore/AuthKey.p8
+          chmod 600 secrets/live/apple/appstore/AuthKey.p8
+          cp secrets/live/apple/appstore/AuthKey.p8 secrets/live/apple/appstore/AuthKey.p8
           echo "✅ Materialized App Store Connect .p8"
         fi
         if [ -n "${MATCH_GIT_PRIVATE_KEY:-}" ]; then
-          mkdir -p secrets/apple/match ~/.ssh
+          mkdir -p secrets/live/apple/match ~/.ssh
           # match_ssh_private_key vault entry is the FULL match bundle (tar.gz):
           #   match/git_url, match/git_branch, match/match_ci_key (SSH key),
           #   match/.match_password, match/certificates_password, match/keychain_password
-          # Decode + extract; copy SSH key into secrets/apple/match/ (Fastfile expects this path
+          # Decode + extract; copy SSH key into secrets/live/apple/match/ (Fastfile expects this path
           # per deployment/_shared/config.rb match_ssh_key_path); export MATCH_GIT_URL/BRANCH.
           BUNDLE_DIR=$(mktemp -d)
           echo "$MATCH_GIT_PRIVATE_KEY" | base64 -d > "$BUNDLE_DIR/bundle.tgz"
           if tar -xzf "$BUNDLE_DIR/bundle.tgz" -C "$BUNDLE_DIR" 2>/dev/null; then
             # It's a tar.gz bundle — extract SSH key + env vars
-            cp "$BUNDLE_DIR/match/match_ci_key" secrets/apple/match/match_ci_key
-            chmod 600 secrets/apple/match/match_ci_key
+            cp "$BUNDLE_DIR/match/match_ci_key" secrets/live/apple/match/match_ci_key
+            chmod 600 secrets/live/apple/match/match_ci_key
             # Also write to legacy path for any callers still using it
-            cp "$BUNDLE_DIR/match/match_ci_key" secrets/apple/match/match_ci_key
-            chmod 600 secrets/apple/match/match_ci_key
+            cp "$BUNDLE_DIR/match/match_ci_key" secrets/live/apple/match/match_ci_key
+            chmod 600 secrets/live/apple/match/match_ci_key
             if [ -f "$BUNDLE_DIR/match/git_url" ]; then
               echo "MATCH_GIT_URL=$(cat $BUNDLE_DIR/match/git_url | tr -d '\n\r ')" >> "$GITHUB_ENV"
             fi
@@ -233,10 +233,10 @@ jobs:
             echo "✅ Materialized Match bundle (SSH key + git_url + git_branch)"
           else
             # Plain SSH key (legacy single-file format)
-            mv "$BUNDLE_DIR/bundle.tgz" secrets/apple/match/match_ci_key
-            chmod 600 secrets/apple/match/match_ci_key
-            cp secrets/apple/match/match_ci_key secrets/apple/match/match_ci_key
-            chmod 600 secrets/apple/match/match_ci_key
+            mv "$BUNDLE_DIR/bundle.tgz" secrets/live/apple/match/match_ci_key
+            chmod 600 secrets/live/apple/match/match_ci_key
+            cp secrets/live/apple/match/match_ci_key secrets/live/apple/match/match_ci_key
+            chmod 600 secrets/live/apple/match/match_ci_key
             echo "✅ Materialized Match SSH key (legacy single-file)"
           fi
           rm -rf "$BUNDLE_DIR"
@@ -244,7 +244,7 @@ jobs:
         if [ -n "${KEYSTORE_ALIAS:-}" ]; then echo "KEY_ALIAS=$KEYSTORE_ALIAS" >> "$GITHUB_ENV"; fi
         if [ -n "${KEYSTORE_ALIAS_PASSWORD:-}" ]; then echo "KEY_PASSWORD=$KEYSTORE_ALIAS_PASSWORD" >> "$GITHUB_ENV"; fi
         if [ -n "${KEYSTORE_PASSWORD:-}" ]; then
-          echo "KEYSTORE_PATH=secrets/android/keystores/upload_keystore.keystore" >> "$GITHUB_ENV"
+          echo "KEYSTORE_PATH=secrets/live/android/keystores/upload_keystore.keystore" >> "$GITHUB_ENV"
         fi
         # Firebase App IDs are provided as direct env vars by the chain repo
         # (publish-{android,apple}-kmp release.yaml env block) — no propagation

--- a/.github/workflows/release-multi-platform.yml
+++ b/.github/workflows/release-multi-platform.yml
@@ -282,8 +282,8 @@ jobs:
           fi
         fi
         # ── Secrets are materialized into PLATFORM-NAMESPACED dirs (2026-06-22) ──
-        #   secrets/android/  secrets/apple/  secrets/apple/  secrets/web/  secrets/shared/
-        # Apple ASC key + Match are SHARED by iOS and macOS-desktop → secrets/apple/.
+        #   secrets/live/android/  secrets/live/apple/  secrets/live/apple/  secrets/web/  secrets/shared/
+        # Apple ASC key + Match are SHARED by iOS and macOS-desktop → secrets/live/apple/.
         # ── Materialize secrets via the resolver (secrets/LAYOUT.yaml is the SoT) ──
         # Every path + encoding (base64, raw-PEM-or-base64, literals) is declared in
         # LAYOUT.yaml; `build-secrets` owns decode + destination. NO inline paths here —

--- a/cmp-android/build.gradle.kts
+++ b/cmp-android/build.gradle.kts
@@ -38,11 +38,15 @@ android {
     signingConfigs {
         create("release") {
             // v2 Play App Signing model — Gradle signs release AABs with the UPLOAD key.
-            // Single source of truth: secrets/android/keystores/upload_keystore.keystore
-            // - Local-dev: developer drops their real upload_keystore.keystore into secrets/android/keystores/
+            // Single source of truth: secrets/live/android/keystores/upload_keystore.keystore
+            // - Local-dev: developer drops their real upload_keystore.keystore into secrets/live/android/keystores/
             // - CI: materialize-android-secrets.sh decodes UPLOAD_KEYSTORE_FILE GHA secret to the same path
             // - KEYSTORE_PATH env var overrides (advanced use)
-            storeFile = file(System.getenv("KEYSTORE_PATH") ?: "../secrets/android/keystores/upload_keystore.keystore")
+            storeFile = file(System.getenv("KEYSTORE_PATH") ?: run {
+                val live = "../secrets/live/android/keystores/upload_keystore.keystore"
+                val sample = "../secrets/sample/android/keystores/upload_keystore.keystore"
+                if (file(live).exists()) live else sample
+            })
             storePassword = System.getenv("KEYSTORE_PASSWORD") ?: "Wizard@123"
             keyAlias = System.getenv("KEYSTORE_ALIAS") ?: "kmp-project-template"
             keyPassword = System.getenv("KEYSTORE_ALIAS_PASSWORD") ?: "Wizard@123"

--- a/deployment/_shared/config.rb
+++ b/deployment/_shared/config.rb
@@ -129,7 +129,7 @@ module FastlaneConfig
     ANDROID = {
       package_name:        ForkIdentity::APP_ID,
       # DRIFT FIX: was "secrets/play/service-account.json" (wrong — lanes/script use
-      # secrets/android/play/…). Resolver returns the canonical path from LAYOUT.yaml.
+      # secrets/live/android/play/…). Resolver returns the canonical path from LAYOUT.yaml.
       play_store_json_key: BuildSecrets.for.path(:play_service_account),
     }.freeze
 
@@ -442,7 +442,7 @@ def fetch_certificates_with_match(options = {})
   ssh_key = File.join(DEPLOYMENT_REPO_ROOT, cfg[:match_ssh_key_path])
 
   # Match reads MATCH_PASSWORD automatically to decrypt the git-stored certs.
-  # Priority: call option → ENV → BUILD_CONFIG (file-backed via secrets/apple/match/).
+  # Priority: call option → ENV → BUILD_CONFIG (file-backed via secrets/live/apple/match/).
   match_pass = options[:match_password] || ENV["MATCH_PASSWORD"] || cfg[:match_password]
   ENV["MATCH_PASSWORD"] = match_pass.to_s if match_pass && ENV["MATCH_PASSWORD"].to_s.empty?
 
@@ -689,14 +689,14 @@ end
 # Distribution certificate via the ASC API.
 #
 # PERSISTENT CLONE STRATEGY
-#   The clone lives at secrets/apple/match/ios-provisioning-profile/ (gitignored).
+#   The clone lives at secrets/live/apple/match/ios-provisioning-profile/ (gitignored).
 #   • Local / colleagues: clone is reused across runs (git fetch + reset — fast).
 #   • GitHub Actions: starts clean each run, falls back to git clone --depth 1.
 #
 #   Colleague first-time setup:
-#     GIT_SSH_COMMAND="ssh -i secrets/apple/match/match_ci_key -o StrictHostKeyChecking=no" \
+#     GIT_SSH_COMMAND="ssh -i secrets/live/apple/match/match_ci_key -o StrictHostKeyChecking=no" \
 #       git clone --depth 1 git@github.com:openMF/ios-provisioning-profile.git \
-#       secrets/apple/match/ios-provisioning-profile
+#       secrets/live/apple/match/ios-provisioning-profile
 #   Subsequent runs: the lane updates the clone automatically.
 #
 # Safe: does NOT revoke from Apple Developer Portal (expired certs are already unusable).
@@ -885,7 +885,7 @@ end
 # gradlew at root, not inside cmp-android/ — incompatible with gradle() action's
 # project_dir expectation.
 def buildAndSignApp(taskName:, buildType: "Release", **signing_config)
-  # DRIFT FIX: was hardcoded "secrets/android/keystores/upload_keystore.keystore"
+  # DRIFT FIX: was hardcoded "secrets/live/android/keystores/upload_keystore.keystore"
   # (flat pre-restructure path — broke after secrets/{live,sample} split). CI passes
   # keystore_path from `build-secrets path upload_keystore`; the local-run fallback
   # must resolve through the SAME LAYOUT resolver (live-wins-else-sample), never hardcode.

--- a/deployment/_shared/project_config.rb
+++ b/deployment/_shared/project_config.rb
@@ -171,14 +171,14 @@ module FastlaneConfig
         # ENV overrides: APPSTORE_KEY_ID / APPSTORE_ISSUER_ID / APPSTORE_KEY_PATH
         key_id:       ENV["APPSTORE_KEY_ID"]    || "",
         issuer_id:    ENV["APPSTORE_ISSUER_ID"] || "",
-        key_filepath: ENV["APPSTORE_KEY_PATH"]  || "secrets/apple/appstore/AuthKey.p8",
+        key_filepath: ENV["APPSTORE_KEY_PATH"]  || "secrets/live/apple/appstore/AuthKey.p8",
       },
       code_signing: {
         match_type:            "adhoc",
         # ENV overrides: MATCH_GIT_URL / MATCH_GIT_BRANCH / MATCH_GIT_PRIVATE_KEY
         match_git_url:         _match_git_url,
         match_git_branch:      _match_git_branch,
-        match_git_private_key: ENV["MATCH_GIT_PRIVATE_KEY"] || "./secrets/apple/match/match_ci_key",
+        match_git_private_key: ENV["MATCH_GIT_PRIVATE_KEY"] || "./secrets/live/apple/match/match_ci_key",
         provisioning_profiles: {
           adhoc:    "match AdHoc #{_app_id}",
           appstore: "match AppStore #{_app_id}",

--- a/deployment/_shared/scripts/keystore-manager.sh
+++ b/deployment/_shared/scripts/keystore-manager.sh
@@ -181,7 +181,7 @@ show_help() {
     echo ""
     echo "Commands:"
     echo "  generate - Generate Android keystores; reads DN from gradle/fork.properties,"
-    echo "             reads passwords from secrets/android/keystores/ files (default)"
+    echo "             reads passwords from secrets/live/android/keystores/ files (default)"
     echo "  encode-secrets - [DEPRECATED] Encode files from secrets/ directory and update"
     echo "             secrets/shared/secrets.env. Use scripts/secrets/sync-secrets-to-github.sh"
     echo "             (the modern replacement) to push secrets from secrets/ to GitHub."
@@ -371,7 +371,7 @@ create_secrets_dir() {
 
 # Parse iOS string secrets from the new two-source model:
 #   - Non-secret identity/metadata → gradle/fork.properties
-#   - Secret values → per-value files under secrets/apple/...
+#   - Secret values → per-value files under secrets/live/apple/...
 #
 # DEPRECATED: this function previously read secrets/shared/shared_keys.env.
 # That file is being retired. All callers continue to work through this
@@ -381,7 +381,7 @@ parse_shared_keys_env() {
     local FORK_PROPS="gradle/fork.properties"
 
     # Skip if neither source is present (Android-only setup)
-    if [[ ! -f "$FORK_PROPS" ]] && [[ ! -f "secrets/apple/appstore/key_id" ]]; then
+    if [[ ! -f "$FORK_PROPS" ]] && [[ ! -f "secrets/live/apple/appstore/key_id" ]]; then
         print_info "iOS configuration not found - skipping iOS secrets (Android-only project)"
         return 0
     fi
@@ -390,19 +390,19 @@ parse_shared_keys_env() {
 
     # Read MATCH_PASSWORD from .match_password file if it exists
     local MATCH_PWD=""
-    if [[ -f "secrets/apple/match/.match_password" ]]; then
-        MATCH_PWD=$(head -n1 secrets/apple/match/.match_password 2>/dev/null | tr -d '\n\r')
+    if [[ -f "secrets/live/apple/match/.match_password" ]]; then
+        MATCH_PWD=$(head -n1 secrets/live/apple/match/.match_password 2>/dev/null | tr -d '\n\r')
         print_success "Loaded MATCH_PASSWORD from .match_password file"
     else
-        print_warning "secrets/apple/match/.match_password not found - MATCH_PASSWORD will be empty"
+        print_warning "secrets/live/apple/match/.match_password not found - MATCH_PASSWORD will be empty"
     fi
 
     # Extract non-secret identity from fork.properties
     local NOTARIZATION_TEAM_ID=$(grep -E "^apple\.team\.id=" "$FORK_PROPS" 2>/dev/null | cut -d= -f2- | tr -d '\n\r')
 
     # Extract secret values from per-value files
-    local APPSTORE_KEY_ID=$(cat "secrets/apple/appstore/key_id" 2>/dev/null | tr -d '\n\r')
-    local APPSTORE_ISSUER_ID=$(cat "secrets/apple/appstore/issuer_id" 2>/dev/null | tr -d '\n\r')
+    local APPSTORE_KEY_ID=$(cat "secrets/live/apple/appstore/key_id" 2>/dev/null | tr -d '\n\r')
+    local APPSTORE_ISSUER_ID=$(cat "secrets/live/apple/appstore/issuer_id" 2>/dev/null | tr -d '\n\r')
     local NOTARIZATION_APPLE_ID=""   # not yet migrated to a file; leave empty
     local NOTARIZATION_PASSWORD=""   # not yet migrated to a file; leave empty
 
@@ -443,9 +443,9 @@ parse_macos_password_files() {
     local count=0
 
     # Read KEYCHAIN_PASSWORD from .keychain_password file
-    if [[ -f "secrets/apple/match/.keychain_password" ]]; then
+    if [[ -f "secrets/live/apple/match/.keychain_password" ]]; then
         local val
-        val=$(head -n1 secrets/apple/match/.keychain_password 2>/dev/null | tr -d '\n\r')
+        val=$(head -n1 secrets/live/apple/match/.keychain_password 2>/dev/null | tr -d '\n\r')
         if [[ -n "$val" ]]; then
             MACOS_PASSWORD_SECRETS["KEYCHAIN_PASSWORD"]="$val"
             count=$((count + 1))
@@ -454,13 +454,13 @@ parse_macos_password_files() {
             print_warning ".keychain_password file is empty"
         fi
     else
-        print_info "secrets/apple/match/.keychain_password not found - KEYCHAIN_PASSWORD will remain as-is"
+        print_info "secrets/live/apple/match/.keychain_password not found - KEYCHAIN_PASSWORD will remain as-is"
     fi
 
     # Read CERTIFICATES_PASSWORD from .certificates_password file
-    if [[ -f "secrets/apple/match/.certificates_password" ]]; then
+    if [[ -f "secrets/live/apple/match/.certificates_password" ]]; then
         local val
-        val=$(head -n1 secrets/apple/match/.certificates_password 2>/dev/null | tr -d '\n\r')
+        val=$(head -n1 secrets/live/apple/match/.certificates_password 2>/dev/null | tr -d '\n\r')
         if [[ -n "$val" ]]; then
             MACOS_PASSWORD_SECRETS["CERTIFICATES_PASSWORD"]="$val"
             count=$((count + 1))
@@ -469,7 +469,7 @@ parse_macos_password_files() {
             print_warning ".certificates_password file is empty"
         fi
     else
-        print_info "secrets/apple/match/.certificates_password not found - CERTIFICATES_PASSWORD will remain as-is"
+        print_info "secrets/live/apple/match/.certificates_password not found - CERTIFICATES_PASSWORD will remain as-is"
     fi
 
     print_success "Found $count of 2 macOS password secrets"
@@ -847,14 +847,14 @@ EOF
 # Place .p12 and .provisionprofile files in secrets/ directory, then run sync.
 #
 # Password files (read automatically by sync):
-#   secrets/apple/match/.keychain_password              → KEYCHAIN_PASSWORD
-#   secrets/apple/match/.certificates_password          → CERTIFICATES_PASSWORD
+#   secrets/live/apple/match/.keychain_password              → KEYCHAIN_PASSWORD
+#   secrets/live/apple/match/.certificates_password          → CERTIFICATES_PASSWORD
 #
 # Certificate/profile files (base64 encoded by sync):
-#   secrets/desktop/macos/app_distribution.p12        → MAC_APP_DISTRIBUTION_CERTIFICATE_B64
-#   secrets/desktop/macos/installer_distribution.p12  → MAC_INSTALLER_DISTRIBUTION_CERTIFICATE_B64
-#   secrets/desktop/macos/embedded.provisionprofile   → MAC_EMBEDDED_PROVISION_B64
-#   secrets/desktop/macos/runtime.provisionprofile    → MAC_RUNTIME_PROVISION_B64
+#   secrets/live/desktop/macos/app_distribution.p12        → MAC_APP_DISTRIBUTION_CERTIFICATE_B64
+#   secrets/live/desktop/macos/installer_distribution.p12  → MAC_INSTALLER_DISTRIBUTION_CERTIFICATE_B64
+#   secrets/live/desktop/macos/embedded.provisionprofile   → MAC_EMBEDDED_PROVISION_B64
+#   secrets/live/desktop/macos/runtime.provisionprofile    → MAC_RUNTIME_PROVISION_B64
 EOF
         then
             print_error "Failed to append macOS App Store section"
@@ -895,7 +895,7 @@ validate_sync_result() {
     fi
 
     # Check for iOS Configuration section header (if iOS project)
-    if [[ -f "secrets/apple/appstore/key_id" ]] || grep -qE "^apple\.team\.id=" gradle/fork.properties 2>/dev/null; then
+    if [[ -f "secrets/live/apple/appstore/key_id" ]] || grep -qE "^apple\.team\.id=" gradle/fork.properties 2>/dev/null; then
         if ! grep -q "^# iOS Configuration" "$SECRETS_FILE"; then
             format_errors+=("Missing iOS configuration section header (iOS project detected)")
         fi
@@ -1005,7 +1005,7 @@ validate_sync_result() {
     done
 
     # Check iOS secrets if iOS project detected
-    if [[ -f "secrets/apple/appstore/key_id" ]] || grep -qE "^apple\.team\.id=" gradle/fork.properties 2>/dev/null; then
+    if [[ -f "secrets/live/apple/appstore/key_id" ]] || grep -qE "^apple\.team\.id=" gradle/fork.properties 2>/dev/null; then
         local required_ios=(
             "APPSTORE_KEY_ID"
             "APPSTORE_ISSUER_ID"
@@ -1278,7 +1278,7 @@ module FastlaneConfig
 
     ANDROID = {
       package_name: "cmp.android.app",
-      play_store_json_key: "secrets/android/playStorePublishServiceCredentialsFile.json",
+      play_store_json_key: "secrets/live/android/playStorePublishServiceCredentialsFile.json",
       apk_paths: {
         prod: "cmp-android/build/outputs/apk/prod/release/cmp-android-prod-release.apk",
         demo: "cmp-android/build/outputs/apk/demo/release/cmp-android-demo-release.apk"
@@ -1298,7 +1298,7 @@ module FastlaneConfig
     }
 
     SHARED = {
-      firebase_service_credentials: "secrets/android/firebaseAppDistributionServiceCredentialsFile.json"
+      firebase_service_credentials: "secrets/live/android/firebaseAppDistributionServiceCredentialsFile.json"
     }
   end
 end
@@ -1369,12 +1369,12 @@ _read_fork_prop() {
     grep "^${key}=" "$props_file" 2>/dev/null | cut -d= -f2- | tr -d '\n\r'
 }
 
-# Read a secret from a per-value file under secrets/android/keystores/.
+# Read a secret from a per-value file under secrets/live/android/keystores/.
 # Returns empty string (not an error) when the file is absent so the caller
 # can fall back to a default.
 _read_keystore_secret() {
     local secret_name="$1"   # e.g. keystore_password
-    local secret_file="secrets/android/keystores/${secret_name}"
+    local secret_file="secrets/live/android/keystores/${secret_name}"
     if [[ -f "$secret_file" ]]; then
         cat "$secret_file" | tr -d '\n\r'
     else
@@ -1385,7 +1385,7 @@ _read_keystore_secret() {
 # Function to generate keystore
 # Reads:
 #   - DN components from gradle/fork.properties (keystore.dn.* + legal.company.name)
-#   - Passwords    from secrets/android/keystores/{keystore_password,keystore_alias,
+#   - Passwords    from secrets/live/android/keystores/{keystore_password,keystore_alias,
 #                  keystore_alias_password}
 # Generation constants (VALIDITY=25, KEYALG=RSA, KEYSIZE=2048, OVERWRITE=false)
 # are hard-coded defaults here — they are not per-fork configuration.
@@ -1430,7 +1430,7 @@ generate_keystore() {
 
     # ── Build Distinguished Name from gradle/fork.properties ──────────────────
     # Non-secret cert identity lives in fork.properties (new home); passwords come
-    # from secrets/android/keystores/ per-value files (new home).
+    # from secrets/live/android/keystores/ per-value files (new home).
     # Legacy: previously these values came from secrets.env (retired).
     local FORK_PROPS="gradle/fork.properties"
     DN_PARTS=()
@@ -1525,9 +1525,9 @@ generate_keystore() {
 # Per https://support.google.com/googleplay/android-developer/answer/9842756
 #
 # Password sources (new model — secrets.env is RETIRED):
-#   secrets/android/keystores/keystore_password       → UPLOAD_KEYSTORE_FILE_PASSWORD
-#   secrets/android/keystores/keystore_alias          → UPLOAD_KEYSTORE_ALIAS
-#   secrets/android/keystores/keystore_alias_password → UPLOAD_KEYSTORE_ALIAS_PASSWORD
+#   secrets/live/android/keystores/keystore_password       → UPLOAD_KEYSTORE_FILE_PASSWORD
+#   secrets/live/android/keystores/keystore_alias          → UPLOAD_KEYSTORE_ALIAS
+#   secrets/live/android/keystores/keystore_alias_password → UPLOAD_KEYSTORE_ALIAS_PASSWORD
 # If a file is absent the script falls back to a safe default so first-run works.
 # Run `scripts/secrets/setup-secrets.sh android` to populate those files.
 #
@@ -1559,7 +1559,7 @@ generate_keystores() {
     UPLOAD_KEYSTORE_ALIAS_PASSWORD="${UPLOAD_KEYSTORE_ALIAS_PASSWORD:-Alias_password}"
 
     echo -e "${BLUE}🔑 Play App Signing mode: generating UPLOAD keystore${NC}"
-    print_info "Password source: secrets/android/keystores/ (new model)"
+    print_info "Password source: secrets/live/android/keystores/ (new model)"
     print_info "DN source: gradle/fork.properties (new model)"
     generate_keystore "UPLOAD" "$UPLOAD_KEYSTORE_NAME" "$UPLOAD_KEYSTORE_ALIAS" "$UPLOAD_KEYSTORE_FILE_PASSWORD" "$UPLOAD_KEYSTORE_ALIAS_PASSWORD"
     UPLOAD_RESULT=$?
@@ -1567,10 +1567,10 @@ generate_keystores() {
     if [ $UPLOAD_RESULT -eq 0 ]; then
         # DEPRECATED: update_secrets_env wrote passwords + base64 keystore into
         # secrets/shared/secrets.env (legacy bundle). That file is retired.
-        # Passwords now live permanently in secrets/android/keystores/ per-value files.
+        # Passwords now live permanently in secrets/live/android/keystores/ per-value files.
         # The keystore file itself (keystores/upload_keystore.keystore) is the artifact.
         # To push all secrets to GitHub use: scripts/secrets/sync-secrets-to-github.sh
-        print_info "Skipping legacy secrets.env update (retired). Secrets live in secrets/android/keystores/."
+        print_info "Skipping legacy secrets.env update (retired). Secrets live in secrets/live/android/keystores/."
 
         # Update fastlane-config/project_config.rb with UPLOAD keystore information
         update_fastlane_config "$UPLOAD_KEYSTORE_NAME" "$UPLOAD_KEYSTORE_FILE_PASSWORD" "$UPLOAD_KEYSTORE_ALIAS" "$UPLOAD_KEYSTORE_ALIAS_PASSWORD"

--- a/deployment/_shared/scripts/materialize-android-secrets.sh
+++ b/deployment/_shared/scripts/materialize-android-secrets.sh
@@ -18,7 +18,7 @@
 # the UPLOAD key. One keystore family is materialized.
 set -euo pipefail
 
-mkdir -p secrets/android/keystores cmp-android/src/prod cmp-android/src/demo
+mkdir -p secrets/live/android/keystores cmp-android/src/prod cmp-android/src/demo
 
 # Google Services — required for prod + demo flavors.
 if [[ -n "${GOOGLESERVICES:-}" ]]; then
@@ -27,14 +27,14 @@ if [[ -n "${GOOGLESERVICES:-}" ]]; then
 fi
 
 # Play Store + Firebase distribution credentials.
-[[ -n "${PLAYSTORECREDS:-}"  ]] && printf '%s' "$PLAYSTORECREDS"  > secrets/android/playStorePublishServiceCredentialsFile.json
-[[ -n "${FIREBASECREDS:-}"   ]] && printf '%s' "$FIREBASECREDS"   > secrets/android/firebaseAppDistributionServiceCredentialsFile.json
+[[ -n "${PLAYSTORECREDS:-}"  ]] && printf '%s' "$PLAYSTORECREDS"  > secrets/live/android/playStorePublishServiceCredentialsFile.json
+[[ -n "${FIREBASECREDS:-}"   ]] && printf '%s' "$FIREBASECREDS"   > secrets/live/android/firebaseAppDistributionServiceCredentialsFile.json
 
 # UPLOAD keystore — the ONE keystore the developer holds under Play App Signing.
-# Gradle's signingConfig reads from secrets/android/keystores/upload_keystore.keystore.
+# Gradle's signingConfig reads from secrets/live/android/keystores/upload_keystore.keystore.
 # Google's KMS holds the app signing key; it's never materialized locally.
 if [[ -n "${UPLOAD_KEYSTORE_FILE:-}" ]]; then
-  echo "$UPLOAD_KEYSTORE_FILE" | base64 -d > secrets/android/keystores/upload_keystore.keystore
+  echo "$UPLOAD_KEYSTORE_FILE" | base64 -d > secrets/live/android/keystores/upload_keystore.keystore
 fi
 
 echo "✅ Android secrets materialized (manual-mode)"

--- a/deployment/_shared/scripts/materialize-ios-secrets.sh
+++ b/deployment/_shared/scripts/materialize-ios-secrets.sh
@@ -13,24 +13,24 @@
 #   FIREBASECREDS                Firebase App Distribution SA JSON (optional — firebase lane only)
 set -euo pipefail
 
-mkdir -p secrets/apple/appstore secrets/apple/match secrets
+mkdir -p secrets/live/apple/appstore secrets/live/apple/match secrets
 
 # App Store Connect API key (drives Match + pilot + deliver + notarize).
-[[ -n "${APPSTORE_AUTH_KEY_B64:-}" ]] && echo "$APPSTORE_AUTH_KEY_B64" | base64 -d > secrets/apple/appstore/AuthKey.p8
-[[ -n "${APPSTORE_KEY_ID:-}"       ]] && printf '%s' "$APPSTORE_KEY_ID"     > secrets/apple/appstore/key_id
-[[ -n "${APPSTORE_ISSUER_ID:-}"    ]] && printf '%s' "$APPSTORE_ISSUER_ID"  > secrets/apple/appstore/issuer_id
+[[ -n "${APPSTORE_AUTH_KEY_B64:-}" ]] && echo "$APPSTORE_AUTH_KEY_B64" | base64 -d > secrets/live/apple/appstore/AuthKey.p8
+[[ -n "${APPSTORE_KEY_ID:-}"       ]] && printf '%s' "$APPSTORE_KEY_ID"     > secrets/live/apple/appstore/key_id
+[[ -n "${APPSTORE_ISSUER_ID:-}"    ]] && printf '%s' "$APPSTORE_ISSUER_ID"  > secrets/live/apple/appstore/issuer_id
 
 # Match repo access.
 if [[ -n "${MATCH_SSH_PRIVATE_KEY_B64:-}" ]]; then
-  echo "$MATCH_SSH_PRIVATE_KEY_B64" | base64 -d > secrets/apple/match/match_ci_key
-  chmod 600 secrets/apple/match/match_ci_key
+  echo "$MATCH_SSH_PRIVATE_KEY_B64" | base64 -d > secrets/live/apple/match/match_ci_key
+  chmod 600 secrets/live/apple/match/match_ci_key
 fi
 if [[ -n "${MATCH_PASSWORD:-}" ]]; then
-  printf '%s' "$MATCH_PASSWORD" > secrets/apple/match/.match_password
-  chmod 600 secrets/apple/match/.match_password
+  printf '%s' "$MATCH_PASSWORD" > secrets/live/apple/match/.match_password
+  chmod 600 secrets/live/apple/match/.match_password
 fi
 
 # Firebase distribution (only firebase lane).
-[[ -n "${FIREBASECREDS:-}" ]] && printf '%s' "$FIREBASECREDS" > secrets/android/firebaseAppDistributionServiceCredentialsFile.json
+[[ -n "${FIREBASECREDS:-}" ]] && printf '%s' "$FIREBASECREDS" > secrets/live/android/firebaseAppDistributionServiceCredentialsFile.json
 
 echo "✅ iOS secrets materialized (manual-mode)"

--- a/deployment/_shared/scripts/materialize-mac-secrets.sh
+++ b/deployment/_shared/scripts/materialize-mac-secrets.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 bash "$(dirname "$0")/materialize-ios-secrets.sh"
 
 # Mac-specific cert .p12 (consumed by mac-app-store/lane.rb when Match isn't wired).
-[[ -n "${MAC_APP_STORE_CERT_B64:-}" ]] && echo "$MAC_APP_STORE_CERT_B64" | base64 -d > secrets/desktop/macos/app_store.p12
-[[ -n "${MAC_INSTALLER_CERT_B64:-}" ]] && echo "$MAC_INSTALLER_CERT_B64" | base64 -d > secrets/desktop/macos/installer.p12
+[[ -n "${MAC_APP_STORE_CERT_B64:-}" ]] && echo "$MAC_APP_STORE_CERT_B64" | base64 -d > secrets/live/desktop/macos/app_store.p12
+[[ -n "${MAC_INSTALLER_CERT_B64:-}" ]] && echo "$MAC_INSTALLER_CERT_B64" | base64 -d > secrets/live/desktop/macos/installer.p12
 
 echo "✅ macOS secrets materialized (manual-mode)"

--- a/deployment/android/firebase/secrets-needs.yaml
+++ b/deployment/android/firebase/secrets-needs.yaml
@@ -7,24 +7,24 @@ required_for: [android-signing, android-firebase-distribute]
 
 vault_aliases:
   - alias: kmp_template_release_keystore
-    canonical: "secrets/android/keystores/upload_keystore.keystore"
+    canonical: "secrets/live/android/keystores/upload_keystore.keystore"
     required_for: ["build", "sign"]
     materialize:
       format: "file"
       via: "copy"
   - alias: firebase_service_account_json
-    canonical: "secrets/android/firebase/firebaseAppDistributionServiceCredentialsFile.json"
+    canonical: "secrets/live/android/firebase/firebaseAppDistributionServiceCredentialsFile.json"
     required_for: ["distribute"]
     materialize:
       format: "file"
       via: "copy"
 
 manual_inputs:
-  - canonical: "secrets/android/keystores/upload_keystore.keystore"
+  - canonical: "secrets/live/android/keystores/upload_keystore.keystore"
     source_hint: "Request from release-mgr or generate via deployment/_shared/scripts/keystore-manager.sh"
     placeholder: "<base64-keystore>"
     gha_secret_var: "ANDROID_RELEASE_KEYSTORE_B64"
-  - canonical: "secrets/android/firebase/firebaseAppDistributionServiceCredentialsFile.json"
+  - canonical: "secrets/live/android/firebase/firebaseAppDistributionServiceCredentialsFile.json"
     source_hint: "Firebase Console → Project Settings → Service Accounts → Generate Key"
     placeholder: "<service-account-json>"
     gha_secret_var: "FIREBASE_SERVICE_ACCOUNT_JSON"

--- a/deployment/android/firebase/workflow-snippet.yml
+++ b/deployment/android/firebase/workflow-snippet.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Materialize secrets (manual-mode)
         if: ${{ secrets.SOPS_AGE_KEY == '' }}
         run: |
-          mkdir -p secrets/android/keystores secrets
+          mkdir -p secrets/live/android/keystores secrets
           echo "${{ secrets.ANDROID_RELEASE_KEYSTORE_B64 }}" | base64 -d > keystores/upload_keystore.keystore
-          echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}' > secrets/android/firebaseAppDistributionServiceCredentialsFile.json
+          echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}' > secrets/live/android/firebaseAppDistributionServiceCredentialsFile.json
 
       - name: Run Fastlane (prod)
         if: ${{ inputs.flavor == 'prod' }}

--- a/deployment/android/play-beta/secrets-needs.yaml
+++ b/deployment/android/play-beta/secrets-needs.yaml
@@ -7,12 +7,12 @@ required_for: [android-play-internal-publish]
 
 vault_aliases:
   - alias: play_publisher_service_account_json
-    canonical: "secrets/android/play/playStorePublishServiceCredentialsFile.json"
+    canonical: "secrets/live/android/play/playStorePublishServiceCredentialsFile.json"
     required_for: ["promote"]
     materialize: { format: "file", via: "copy" }
 
 manual_inputs:
-  - canonical: "secrets/android/play/playStorePublishServiceCredentialsFile.json"
+  - canonical: "secrets/live/android/play/playStorePublishServiceCredentialsFile.json"
     source_hint: "Play Console → API access → Service accounts → Download JSON key"
     placeholder: "<service-account-json>"
     gha_secret_var: "PLAYSTORE_PUBLISHER_JSON"

--- a/deployment/android/play-beta/workflow-snippet.yml
+++ b/deployment/android/play-beta/workflow-snippet.yml
@@ -24,7 +24,7 @@ jobs:
         if: ${{ secrets.SOPS_AGE_KEY == '' }}
         run: |
           mkdir -p secrets
-          echo '${{ secrets.PLAYSTORE_PUBLISHER_JSON }}' > secrets/android/playStorePublishServiceCredentialsFile.json
+          echo '${{ secrets.PLAYSTORE_PUBLISHER_JSON }}' > secrets/live/android/playStorePublishServiceCredentialsFile.json
 
       - name: Promote to beta
         run: bundle exec fastlane android promoteToBeta

--- a/deployment/android/play-closed/secrets-needs.yaml
+++ b/deployment/android/play-closed/secrets-needs.yaml
@@ -7,12 +7,12 @@ required_for: [android-play-internal-publish]
 
 vault_aliases:
   - alias: play_publisher_service_account_json
-    canonical: "secrets/android/play/playStorePublishServiceCredentialsFile.json"
+    canonical: "secrets/live/android/play/playStorePublishServiceCredentialsFile.json"
     required_for: ["promote"]
     materialize: { format: "file", via: "copy" }
 
 manual_inputs:
-  - canonical: "secrets/android/play/playStorePublishServiceCredentialsFile.json"
+  - canonical: "secrets/live/android/play/playStorePublishServiceCredentialsFile.json"
     source_hint: "Play Console → API access → Service accounts → Download JSON key"
     placeholder: "<service-account-json>"
     gha_secret_var: "PLAYSTORE_PUBLISHER_JSON"

--- a/deployment/android/play-closed/workflow-snippet.yml
+++ b/deployment/android/play-closed/workflow-snippet.yml
@@ -24,7 +24,7 @@ jobs:
         if: ${{ secrets.SOPS_AGE_KEY == '' }}
         run: |
           mkdir -p secrets
-          echo '${{ secrets.PLAYSTORE_PUBLISHER_JSON }}' > secrets/android/playStorePublishServiceCredentialsFile.json
+          echo '${{ secrets.PLAYSTORE_PUBLISHER_JSON }}' > secrets/live/android/playStorePublishServiceCredentialsFile.json
 
       - name: Promote to closed/alpha
         run: bundle exec fastlane android promoteToClosed

--- a/deployment/android/play-internal/secrets-needs.yaml
+++ b/deployment/android/play-internal/secrets-needs.yaml
@@ -7,20 +7,20 @@ required_for: [android-signing, android-play-internal-publish]
 
 vault_aliases:
   - alias: kmp_template_release_keystore
-    canonical: "secrets/android/keystores/upload_keystore.keystore"
+    canonical: "secrets/live/android/keystores/upload_keystore.keystore"
     required_for: ["build", "sign"]
     materialize: { format: "file", via: "copy" }
   - alias: play_publisher_service_account_json
-    canonical: "secrets/android/play/playStorePublishServiceCredentialsFile.json"
+    canonical: "secrets/live/android/play/playStorePublishServiceCredentialsFile.json"
     required_for: ["upload"]
     materialize: { format: "file", via: "copy" }
 
 manual_inputs:
-  - canonical: "secrets/android/keystores/upload_keystore.keystore"
+  - canonical: "secrets/live/android/keystores/upload_keystore.keystore"
     source_hint: "Request from release-mgr"
     placeholder: "<base64-keystore>"
     gha_secret_var: "ANDROID_RELEASE_KEYSTORE_B64"
-  - canonical: "secrets/android/play/playStorePublishServiceCredentialsFile.json"
+  - canonical: "secrets/live/android/play/playStorePublishServiceCredentialsFile.json"
     source_hint: "Play Console → API access → Service accounts → Download JSON key"
     placeholder: "<service-account-json>"
     gha_secret_var: "PLAYSTORE_PUBLISHER_JSON"

--- a/deployment/android/play-internal/workflow-snippet.yml
+++ b/deployment/android/play-internal/workflow-snippet.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           mkdir -p secrets keystores
           echo "${{ secrets.ANDROID_RELEASE_KEYSTORE_B64 }}" | base64 -d > keystores/upload_keystore.keystore
-          echo '${{ secrets.PLAYSTORE_PUBLISHER_JSON }}' > secrets/android/playStorePublishServiceCredentialsFile.json
+          echo '${{ secrets.PLAYSTORE_PUBLISHER_JSON }}' > secrets/live/android/playStorePublishServiceCredentialsFile.json
 
       - name: Deploy to Play internal
         run: bundle exec fastlane android deployInternal

--- a/deployment/android/play-production/secrets-needs.yaml
+++ b/deployment/android/play-production/secrets-needs.yaml
@@ -7,20 +7,20 @@ required_for: [android-signing, android-play-prod-publish]
 
 vault_aliases:
   - alias: kmp_template_release_keystore
-    canonical: "secrets/android/keystores/upload_keystore.keystore"
+    canonical: "secrets/live/android/keystores/upload_keystore.keystore"
     required_for: ["sign-verification"]
     materialize: { format: "file", via: "copy" }
   - alias: play_publisher_service_account_json
-    canonical: "secrets/android/play/playStorePublishServiceCredentialsFile.json"
+    canonical: "secrets/live/android/play/playStorePublishServiceCredentialsFile.json"
     required_for: ["promote-to-prod"]
     materialize: { format: "file", via: "copy" }
 
 manual_inputs:
-  - canonical: "secrets/android/keystores/upload_keystore.keystore"
+  - canonical: "secrets/live/android/keystores/upload_keystore.keystore"
     source_hint: "Request from release-mgr"
     placeholder: "<base64-keystore>"
     gha_secret_var: "ANDROID_RELEASE_KEYSTORE_B64"
-  - canonical: "secrets/android/play/playStorePublishServiceCredentialsFile.json"
+  - canonical: "secrets/live/android/play/playStorePublishServiceCredentialsFile.json"
     source_hint: "Play Console → API access → Service accounts → Download JSON key (PROD)"
     placeholder: "<service-account-json>"
     gha_secret_var: "PLAYSTORE_PUBLISHER_JSON"

--- a/deployment/android/play-production/workflow-snippet.yml
+++ b/deployment/android/play-production/workflow-snippet.yml
@@ -32,7 +32,7 @@ jobs:
         if: ${{ secrets.SOPS_AGE_KEY == '' }}
         run: |
           mkdir -p secrets
-          echo '${{ secrets.PLAYSTORE_PUBLISHER_JSON }}' > secrets/android/playStorePublishServiceCredentialsFile.json
+          echo '${{ secrets.PLAYSTORE_PUBLISHER_JSON }}' > secrets/live/android/playStorePublishServiceCredentialsFile.json
 
       - name: Promote to production
         run: bundle exec fastlane android promote_to_production

--- a/deployment/desktop/dmg-notarized/lane.rb
+++ b/deployment/desktop/dmg-notarized/lane.rb
@@ -33,11 +33,11 @@
 #   run with `match_readonly: false` from a maintainer machine.
 #
 # Secrets (resolved via _shared/config.rb#_secret — ENV first, secrets/ fallback):
-#   secrets/apple/match/match_ci_key             — SSH key for Match git repo access
-#   secrets/apple/match/.match_password          — Match encryption password
-#   secrets/apple/appstore/AuthKey.p8            — ASC API key (Match cert issuance + notarize)
-#   secrets/apple/appstore/key_id                — ASC key ID
-#   secrets/apple/appstore/issuer_id             — ASC issuer ID
+#   secrets/live/apple/match/match_ci_key             — SSH key for Match git repo access
+#   secrets/live/apple/match/.match_password          — Match encryption password
+#   secrets/live/apple/appstore/AuthKey.p8            — ASC API key (Match cert issuance + notarize)
+#   secrets/live/apple/appstore/key_id                — ASC key ID
+#   secrets/live/apple/appstore/issuer_id             — ASC issuer ID
 #
 # Env vars (optional overrides):
 #   MAC_APP_IDENTIFIER  — macOS bundle ID (defaults to ForkIdentity::APP_ID)

--- a/deployment/desktop/dmg-notarized/secrets-needs.yaml
+++ b/deployment/desktop/dmg-notarized/secrets-needs.yaml
@@ -21,46 +21,46 @@ required_for: [macos-signing, desktop-dmg-notarized]
 vault_aliases:
   # ── App Store Connect API key (shared with iOS appstore + mac-app-store) ──
   - alias: appstore_private_key_p8
-    canonical: "secrets/apple/appstore/AuthKey.p8"
+    canonical: "secrets/live/apple/appstore/AuthKey.p8"
     required_for: ["match-cert-issuance", "notarytool"]
     materialize: { format: "file", via: "copy" }
   - alias: appstore_key_id
-    canonical: "secrets/apple/appstore/key_id"
+    canonical: "secrets/live/apple/appstore/key_id"
     required_for: ["match-cert-issuance", "notarytool"]
     materialize: { format: "file", via: "copy" }
   - alias: appstore_key_issuer_id
-    canonical: "secrets/apple/appstore/issuer_id"
+    canonical: "secrets/live/apple/appstore/issuer_id"
     required_for: ["match-cert-issuance", "notarytool"]
     materialize: { format: "file", via: "copy" }
 
   # ── Match repo access (shared with iOS + mac-app-store) ─────────────────────
   - alias: match_git_ssh_private_key
-    canonical: "secrets/apple/match/match_ci_key"
+    canonical: "secrets/live/apple/match/match_ci_key"
     required_for: ["match-clone"]
     materialize: { format: "file", via: "copy" }
   - alias: match_password
-    canonical: "secrets/apple/match/.match_password"
+    canonical: "secrets/live/apple/match/.match_password"
     required_for: ["match-decrypt"]
     materialize: { format: "file", via: "copy" }
 
 manual_inputs:
-  - canonical: "secrets/apple/appstore/AuthKey.p8"
+  - canonical: "secrets/live/apple/appstore/AuthKey.p8"
     source_hint: "App Store Connect → Users and Access → Keys (Admin or App Manager role)"
     placeholder: "<base64-p8>"
     gha_secret_var: "APPSTORE_AUTH_KEY_B64"
-  - canonical: "secrets/apple/appstore/key_id"
+  - canonical: "secrets/live/apple/appstore/key_id"
     source_hint: "App Store Connect key id (10-char alphanumeric)"
     placeholder: "<key-id>"
     gha_secret_var: "APPSTORE_KEY_ID"
-  - canonical: "secrets/apple/appstore/issuer_id"
+  - canonical: "secrets/live/apple/appstore/issuer_id"
     source_hint: "App Store Connect issuer id (UUID)"
     placeholder: "<issuer-id>"
     gha_secret_var: "APPSTORE_ISSUER_ID"
-  - canonical: "secrets/apple/match/match_ci_key"
+  - canonical: "secrets/live/apple/match/match_ci_key"
     source_hint: "Match repo SSH deploy key (private half). Generate with `ssh-keygen -t ed25519 -N ''`."
     placeholder: "<base64-ssh-private-key>"
     gha_secret_var: "MATCH_SSH_PRIVATE_KEY_B64"
-  - canonical: "secrets/apple/match/.match_password"
+  - canonical: "secrets/live/apple/match/.match_password"
     source_hint: "Match encryption password — used to encrypt certs at rest in the Match git repo"
     placeholder: "<password>"
     gha_secret_var: "MATCH_PASSWORD"

--- a/deployment/desktop/dmg-notarized/workflow-snippet.yml
+++ b/deployment/desktop/dmg-notarized/workflow-snippet.yml
@@ -42,14 +42,14 @@ jobs:
       - name: Materialize secrets (manual-mode)
         if: ${{ secrets.SOPS_AGE_KEY == '' }}
         run: |
-          mkdir -p secrets/apple/appstore secrets/apple/match
-          echo "${{ secrets.APPSTORE_AUTH_KEY_B64 }}" | base64 -d > secrets/apple/appstore/AuthKey.p8
-          printf '%s' "${{ secrets.APPSTORE_KEY_ID }}"    > secrets/apple/appstore/key_id
-          printf '%s' "${{ secrets.APPSTORE_ISSUER_ID }}" > secrets/apple/appstore/issuer_id
-          echo "${{ secrets.MATCH_SSH_PRIVATE_KEY_B64 }}" | base64 -d > secrets/apple/match/match_ci_key
-          printf '%s' "${{ secrets.MATCH_PASSWORD }}" > secrets/apple/match/.match_password
-          chmod 600 secrets/apple/match/match_ci_key
-          chmod 600 secrets/apple/match/.match_password
+          mkdir -p secrets/live/apple/appstore secrets/live/apple/match
+          echo "${{ secrets.APPSTORE_AUTH_KEY_B64 }}" | base64 -d > secrets/live/apple/appstore/AuthKey.p8
+          printf '%s' "${{ secrets.APPSTORE_KEY_ID }}"    > secrets/live/apple/appstore/key_id
+          printf '%s' "${{ secrets.APPSTORE_ISSUER_ID }}" > secrets/live/apple/appstore/issuer_id
+          echo "${{ secrets.MATCH_SSH_PRIVATE_KEY_B64 }}" | base64 -d > secrets/live/apple/match/match_ci_key
+          printf '%s' "${{ secrets.MATCH_PASSWORD }}" > secrets/live/apple/match/.match_password
+          chmod 600 secrets/live/apple/match/match_ci_key
+          chmod 600 secrets/live/apple/match/.match_password
 
       - name: Build + sign + notarize + staple + upload via Fastlane
         env:

--- a/deployment/desktop/mac-app-store/lane.rb
+++ b/deployment/desktop/mac-app-store/lane.rb
@@ -27,11 +27,11 @@
 #           from ~/Library/Keychains/build.keychain-db and resolves identities from it.
 #
 # Secrets (all read via config.rb _secret helper — ENV first, secrets/ fallback):
-#   secrets/apple/appstore/AuthKey.p8          — ASC API key
-#   secrets/apple/appstore/key_id              — ASC key ID
-#   secrets/apple/appstore/issuer_id           — ASC issuer ID
-#   secrets/apple/match/match_ci_key           — SSH key for Match git repo (local only)
-#   secrets/apple/match/.match_password        — Match encryption password (local only)
+#   secrets/live/apple/appstore/AuthKey.p8          — ASC API key
+#   secrets/live/apple/appstore/key_id              — ASC key ID
+#   secrets/live/apple/appstore/issuer_id           — ASC issuer ID
+#   secrets/live/apple/match/match_ci_key           — SSH key for Match git repo (local only)
+#   secrets/live/apple/match/.match_password        — Match encryption password (local only)
 #
 # Env vars (optional overrides):
 #   MAC_APP_IDENTIFIER             — macOS bundle ID (defaults to ForkIdentity::APP_ID)

--- a/deployment/desktop/mac-app-store/secrets-needs.yaml
+++ b/deployment/desktop/mac-app-store/secrets-needs.yaml
@@ -6,44 +6,44 @@ required_for: [macos-signing, desktop-mac-app-store]
 
 vault_aliases:
   - alias: mac_app_store_cert_p12
-    canonical: "secrets/desktop/macos/app_store.p12"
+    canonical: "secrets/live/desktop/macos/app_store.p12"
     required_for: ["mas-sign"]
     materialize: { format: "file", via: "copy" }
   - alias: mac_installer_cert_p12
-    canonical: "secrets/desktop/macos/installer.p12"
+    canonical: "secrets/live/desktop/macos/installer.p12"
     required_for: ["pkg-sign"]
     materialize: { format: "file", via: "copy" }
   - alias: appstore_private_key_p8
-    canonical: "secrets/apple/appstore/AuthKey.p8"
+    canonical: "secrets/live/apple/appstore/AuthKey.p8"
     required_for: ["asc-upload"]
     materialize: { format: "file", via: "copy" }
   - alias: appstore_key_id
-    canonical: secrets/apple/appstore/key_id
+    canonical: secrets/live/apple/appstore/key_id
     required_for: ["asc-upload"]
     materialize: { format: "env", via: "export" }
   - alias: appstore_key_issuer_id
-    canonical: secrets/apple/appstore/issuer_id
+    canonical: secrets/live/apple/appstore/issuer_id
     required_for: ["asc-upload"]
     materialize: { format: "env", via: "export" }
 
 manual_inputs:
-  - canonical: "secrets/desktop/macos/app_store.p12"
+  - canonical: "secrets/live/desktop/macos/app_store.p12"
     source_hint: "Apple Developer → Certificates → Mac App Distribution (.p12)"
     placeholder: "<base64-p12>"
     gha_secret_var: "MAC_APP_STORE_CERT_B64"
-  - canonical: "secrets/desktop/macos/installer.p12"
+  - canonical: "secrets/live/desktop/macos/installer.p12"
     source_hint: "Apple Developer → Certificates → 3rd Party Mac Developer Installer (.p12)"
     placeholder: "<base64-p12>"
     gha_secret_var: "MAC_INSTALLER_CERT_B64"
-  - canonical: "secrets/apple/appstore/AuthKey.p8"
+  - canonical: "secrets/live/apple/appstore/AuthKey.p8"
     source_hint: "App Store Connect → Users and Access → Keys"
     placeholder: "<base64-p8>"
     gha_secret_var: "APPSTORE_AUTH_KEY_B64"
-  - canonical: secrets/apple/appstore/key_id
+  - canonical: secrets/live/apple/appstore/key_id
     source_hint: "App Store Connect key id (10-char alphanumeric)"
     placeholder: "<key-id>"
     gha_secret_var: "APPSTORE_CONNECT_KEY_ID"
-  - canonical: secrets/apple/appstore/issuer_id
+  - canonical: secrets/live/apple/appstore/issuer_id
     source_hint: "App Store Connect issuer id (UUID)"
     placeholder: "<issuer-id>"
     gha_secret_var: "APPSTORE_CONNECT_ISSUER_ID"

--- a/deployment/desktop/mac-app-store/workflow-snippet.yml
+++ b/deployment/desktop/mac-app-store/workflow-snippet.yml
@@ -34,9 +34,9 @@ jobs:
         if: ${{ secrets.SOPS_AGE_KEY == '' }}
         run: |
           mkdir -p secrets
-          echo "${{ secrets.APPSTORE_AUTH_KEY_B64 }}" | base64 -d > secrets/apple/appstore/AuthKey.p8
-          echo "${{ secrets.MAC_APP_STORE_CERT_B64 }}" | base64 -d > secrets/desktop/macos/app_store.p12
-          echo "${{ secrets.MAC_INSTALLER_CERT_B64 }}" | base64 -d > secrets/desktop/macos/installer.p12
+          echo "${{ secrets.APPSTORE_AUTH_KEY_B64 }}" | base64 -d > secrets/live/apple/appstore/AuthKey.p8
+          echo "${{ secrets.MAC_APP_STORE_CERT_B64 }}" | base64 -d > secrets/live/desktop/macos/app_store.p12
+          echo "${{ secrets.MAC_INSTALLER_CERT_B64 }}" | base64 -d > secrets/live/desktop/macos/installer.p12
 
       - name: Build macOS distributable
         run: ./gradlew :cmp-desktop:packageReleaseDmg

--- a/deployment/ios/appstore/secrets-needs.yaml
+++ b/deployment/ios/appstore/secrets-needs.yaml
@@ -6,11 +6,11 @@ required_for: [ios-signing, ios-app-store]
 
 vault_aliases:
   - alias: appstore_private_key_p8
-    canonical: "secrets/apple/appstore/AuthKey.p8"
+    canonical: "secrets/live/apple/appstore/AuthKey.p8"
     required_for: ["asc-auth", "build-sign", "appstore-upload"]
     materialize: { format: "file", via: "copy" }
   - alias: match_git_ssh_private_key
-    canonical: "secrets/apple/match/match_ci_key"
+    canonical: "secrets/live/apple/match/match_ci_key"
     required_for: ["match-clone"]
     materialize: { format: "file", via: "copy", mode: "0600" }
   - alias: match_password
@@ -19,11 +19,11 @@ vault_aliases:
     materialize: { format: "env", via: "export" }
 
 manual_inputs:
-  - canonical: "secrets/apple/appstore/AuthKey.p8"
+  - canonical: "secrets/live/apple/appstore/AuthKey.p8"
     source_hint: "App Store Connect → Users and Access → Keys → Download .p8"
     placeholder: "<base64-p8>"
     gha_secret_var: "APPSTORE_AUTH_KEY_B64"
-  - canonical: "secrets/apple/match/match_ci_key"
+  - canonical: "secrets/live/apple/match/match_ci_key"
     source_hint: "SSH key with read access to the Match git repo"
     placeholder: "<ssh-private-key>"
     gha_secret_var: "MATCH_CI_KEY"

--- a/deployment/ios/appstore/workflow-snippet.yml
+++ b/deployment/ios/appstore/workflow-snippet.yml
@@ -31,9 +31,9 @@ jobs:
         if: ${{ secrets.SOPS_AGE_KEY == '' }}
         run: |
           mkdir -p secrets
-          echo "${{ secrets.APPSTORE_AUTH_KEY_B64 }}" | base64 -d > secrets/apple/appstore/AuthKey.p8
-          echo "${{ secrets.MATCH_CI_KEY }}" > secrets/apple/match/match_ci_key
-          chmod 600 secrets/apple/match/match_ci_key
+          echo "${{ secrets.APPSTORE_AUTH_KEY_B64 }}" | base64 -d > secrets/live/apple/appstore/AuthKey.p8
+          echo "${{ secrets.MATCH_CI_KEY }}" > secrets/live/apple/match/match_ci_key
+          chmod 600 secrets/live/apple/match/match_ci_key
 
       - name: Install CocoaPods
         run: gem install cocoapods

--- a/deployment/ios/firebase/secrets-needs.yaml
+++ b/deployment/ios/firebase/secrets-needs.yaml
@@ -7,11 +7,11 @@ required_for: [ios-signing, ios-firebase-distribute]
 
 vault_aliases:
   - alias: appstore_private_key_p8
-    canonical: "secrets/apple/appstore/AuthKey.p8"
+    canonical: "secrets/live/apple/appstore/AuthKey.p8"
     required_for: ["match-auth", "build-sign"]
     materialize: { format: "file", via: "copy" }
   - alias: match_git_ssh_private_key
-    canonical: "secrets/apple/match/match_ci_key"
+    canonical: "secrets/live/apple/match/match_ci_key"
     required_for: ["match-clone"]
     materialize: { format: "file", via: "copy", mode: "0600" }
   - alias: match_password
@@ -19,16 +19,16 @@ vault_aliases:
     required_for: ["match-decrypt"]
     materialize: { format: "env", via: "export" }
   - alias: firebase_service_account_json
-    canonical: "secrets/android/firebase/firebaseAppDistributionServiceCredentialsFile.json"
+    canonical: "secrets/live/android/firebase/firebaseAppDistributionServiceCredentialsFile.json"
     required_for: ["distribute"]
     materialize: { format: "file", via: "copy" }
 
 manual_inputs:
-  - canonical: "secrets/apple/appstore/AuthKey.p8"
+  - canonical: "secrets/live/apple/appstore/AuthKey.p8"
     source_hint: "App Store Connect → Users and Access → Keys → Download .p8"
     placeholder: "<base64-p8>"
     gha_secret_var: "APPSTORE_AUTH_KEY_B64"
-  - canonical: "secrets/apple/match/match_ci_key"
+  - canonical: "secrets/live/apple/match/match_ci_key"
     source_hint: "SSH key with read access to the Match git repo"
     placeholder: "<ssh-private-key>"
     gha_secret_var: "MATCH_CI_KEY"
@@ -36,7 +36,7 @@ manual_inputs:
     source_hint: "The encryption password set when running `fastlane match init`"
     placeholder: "<match-password>"
     gha_secret_var: "MATCH_PASSWORD"
-  - canonical: "secrets/android/firebase/firebaseAppDistributionServiceCredentialsFile.json"
+  - canonical: "secrets/live/android/firebase/firebaseAppDistributionServiceCredentialsFile.json"
     source_hint: "Firebase Console → Project Settings → Service Accounts"
     placeholder: "<service-account-json>"
     gha_secret_var: "FIREBASE_SERVICE_ACCOUNT_JSON"

--- a/deployment/ios/firebase/workflow-snippet.yml
+++ b/deployment/ios/firebase/workflow-snippet.yml
@@ -24,10 +24,10 @@ jobs:
         if: ${{ secrets.SOPS_AGE_KEY == '' }}
         run: |
           mkdir -p secrets
-          echo "${{ secrets.APPSTORE_AUTH_KEY_B64 }}" | base64 -d > secrets/apple/appstore/AuthKey.p8
-          echo "${{ secrets.MATCH_CI_KEY }}" > secrets/apple/match/match_ci_key
-          chmod 600 secrets/apple/match/match_ci_key
-          echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}' > secrets/android/firebaseAppDistributionServiceCredentialsFile.json
+          echo "${{ secrets.APPSTORE_AUTH_KEY_B64 }}" | base64 -d > secrets/live/apple/appstore/AuthKey.p8
+          echo "${{ secrets.MATCH_CI_KEY }}" > secrets/live/apple/match/match_ci_key
+          chmod 600 secrets/live/apple/match/match_ci_key
+          echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}' > secrets/live/android/firebaseAppDistributionServiceCredentialsFile.json
 
       - name: Install CocoaPods
         run: gem install cocoapods

--- a/deployment/ios/testflight/secrets-needs.yaml
+++ b/deployment/ios/testflight/secrets-needs.yaml
@@ -6,11 +6,11 @@ required_for: [ios-signing, ios-testflight]
 
 vault_aliases:
   - alias: appstore_private_key_p8
-    canonical: "secrets/apple/appstore/AuthKey.p8"
+    canonical: "secrets/live/apple/appstore/AuthKey.p8"
     required_for: ["asc-auth", "build-sign", "testflight-upload"]
     materialize: { format: "file", via: "copy" }
   - alias: match_git_ssh_private_key
-    canonical: "secrets/apple/match/match_ci_key"
+    canonical: "secrets/live/apple/match/match_ci_key"
     required_for: ["match-clone"]
     materialize: { format: "file", via: "copy", mode: "0600" }
   - alias: match_password
@@ -19,11 +19,11 @@ vault_aliases:
     materialize: { format: "env", via: "export" }
 
 manual_inputs:
-  - canonical: "secrets/apple/appstore/AuthKey.p8"
+  - canonical: "secrets/live/apple/appstore/AuthKey.p8"
     source_hint: "App Store Connect → Users and Access → Keys → Download .p8"
     placeholder: "<base64-p8>"
     gha_secret_var: "APPSTORE_AUTH_KEY_B64"
-  - canonical: "secrets/apple/match/match_ci_key"
+  - canonical: "secrets/live/apple/match/match_ci_key"
     source_hint: "SSH key with read access to the Match git repo"
     placeholder: "<ssh-private-key>"
     gha_secret_var: "MATCH_CI_KEY"

--- a/deployment/ios/testflight/workflow-snippet.yml
+++ b/deployment/ios/testflight/workflow-snippet.yml
@@ -23,9 +23,9 @@ jobs:
         if: ${{ secrets.SOPS_AGE_KEY == '' }}
         run: |
           mkdir -p secrets
-          echo "${{ secrets.APPSTORE_AUTH_KEY_B64 }}" | base64 -d > secrets/apple/appstore/AuthKey.p8
-          echo "${{ secrets.MATCH_CI_KEY }}" > secrets/apple/match/match_ci_key
-          chmod 600 secrets/apple/match/match_ci_key
+          echo "${{ secrets.APPSTORE_AUTH_KEY_B64 }}" | base64 -d > secrets/live/apple/appstore/AuthKey.p8
+          echo "${{ secrets.MATCH_CI_KEY }}" > secrets/live/apple/match/match_ci_key
+          chmod 600 secrets/live/apple/match/match_ci_key
 
       - name: Install CocoaPods
         run: gem install cocoapods

--- a/scripts/ci/check-secrets-resolver.sh
+++ b/scripts/ci/check-secrets-resolver.sh
@@ -58,15 +58,19 @@ if grep -nE 'secrets/(android|apple|desktop|web|shared)/[A-Za-z0-9_.-]' "$WF" 2>
   echo "❌ SR-11: workflow hardcodes a secrets/<platform>/ path — use \"\$BS\" path <key> instead"; fail=1
 fi
 
-# ── SR-12: no hardcoded service-account path/name — ANY consumer must resolve via
-#     build-secrets. Catches the class the firebase/play rename exposed (`secrets/android/
-#     {play,firebase}/…` literals + the bare old `service-account.json` filename). Scans the
-#     WIDER surface SR-7/SR-11 missed: deployment + .github/workflows + scripts. Exempt: the
-#     resolver itself, the path-declaration SoT (LAYOUT.yaml + secrets-needs.yaml +
-#     secrets-manifest.yaml — these DECLARE paths, they don't consume), comment lines, and the
-#     sample/live trees. Deferred desktop/ms/azure use `$SECRETS_DIR/<plat>/` — NOT this
-#     class — so they don't trip here; broaden further when those platforms get LAYOUT rows. ──
-SR12=$(grep -rnE 'secrets/android/(play|firebase)/[A-Za-z0-9_.-]|service-account\.json' \
+# ── SR-12: no hardcoded on-disk secret path (any stale flat `secrets/<platform>/…`) or
+#     service-account name — ANY consumer must resolve via build-secrets. Broadened from the
+#     firebase/play-only literal to catch the WHOLE class the live/+sample/ split exposed:
+#     any `secrets/(android|apple|desktop)/…` that is NOT rooted at secrets/live/ or
+#     secrets/sample/ (the resolver composes roots.live/roots.sample + LAYOUT rel: paths, so a
+#     flat literal silently breaks the moment the tree restructures) + the bare old
+#     `service-account.json` filename. Scans the WIDER surface SR-7/SR-11 missed: deployment +
+#     .github/workflows + scripts. Exempt: the resolver itself, the path-declaration SoT
+#     (LAYOUT.yaml + secrets-needs.yaml + secrets-manifest.yaml — these DECLARE paths, they
+#     don't consume), comment lines, and the sample/live trees. Out-of-scope roots
+#     (`secrets/shared/secrets.env`, `secrets/web/…`) + deferred `$SECRETS_DIR/<plat>/` are NOT
+#     this class — so they don't trip here; add their platforms once they get LAYOUT rows. ──
+SR12=$(grep -rnE 'secrets/(android|apple|desktop)/[A-Za-z0-9_.-]|service-account\.json' \
        deployment .github/workflows scripts \
        --include='*.rb' --include='*.sh' --include='*.yml' --include='*.yaml' 2>/dev/null \
      | grep -vE 'build_secrets\.rb|secrets/LAYOUT\.yaml|secrets-needs\.yaml|secrets-manifest\.yaml|/sample/|/live/' \

--- a/scripts/deploy/deploy_appstore.sh
+++ b/scripts/deploy/deploy_appstore.sh
@@ -90,11 +90,11 @@ print_success "Bundler installed"
 print_section "📋 Validating Configuration"
 
 REQUIRED_FILES=(
-    "secrets/apple/appstore/key_id"
-    "secrets/apple/appstore/issuer_id"
-    "secrets/apple/appstore/AuthKey.p8"
-    "secrets/apple/match/.match_password"
-    "secrets/apple/match/match_ci_key"
+    "secrets/live/apple/appstore/key_id"
+    "secrets/live/apple/appstore/issuer_id"
+    "secrets/live/apple/appstore/AuthKey.p8"
+    "secrets/live/apple/match/.match_password"
+    "secrets/live/apple/match/match_ci_key"
 )
 
 MISSING_FILES=()
@@ -126,25 +126,25 @@ MATCH_GIT_URL=$(grep -E "^apple\.match\.git\.url=" gradle/fork.properties 2>/dev
 MATCH_GIT_BRANCH=$(grep -E "^apple\.match\.git\.branch=" gradle/fork.properties 2>/dev/null | cut -d= -f2- | tr -d '\n\r')
 
 # Secret values from per-file secrets
-APPSTORE_KEY_ID=$(cat secrets/apple/appstore/key_id 2>/dev/null | tr -d '\n\r')
-APPSTORE_ISSUER_ID=$(cat secrets/apple/appstore/issuer_id 2>/dev/null | tr -d '\n\r')
+APPSTORE_KEY_ID=$(cat secrets/live/apple/appstore/key_id 2>/dev/null | tr -d '\n\r')
+APPSTORE_ISSUER_ID=$(cat secrets/live/apple/appstore/issuer_id 2>/dev/null | tr -d '\n\r')
 
 # Validate App Store Connect API key configuration
 if [ -z "$APPSTORE_KEY_ID" ] || [ -z "$APPSTORE_ISSUER_ID" ]; then
     print_error "App Store Connect API credentials not configured"
-    print_info "Ensure secrets/apple/appstore/key_id and secrets/apple/appstore/issuer_id exist"
+    print_info "Ensure secrets/live/apple/appstore/key_id and secrets/live/apple/appstore/issuer_id exist"
     exit 1
 fi
 
 # Load Match password
-export MATCH_PASSWORD=$(cat secrets/apple/match/.match_password)
+export MATCH_PASSWORD=$(cat secrets/live/apple/match/.match_password)
 
 # Setup SSH for Match
-export GIT_SSH_COMMAND="ssh -i secrets/apple/match/match_ci_key -o IdentitiesOnly=yes"
+export GIT_SSH_COMMAND="ssh -i secrets/live/apple/match/match_ci_key -o IdentitiesOnly=yes"
 
 # Export for fastlane
 export APPSTORE_KEY_ID APPSTORE_ISSUER_ID TEAM_ID MATCH_GIT_URL MATCH_GIT_BRANCH
-export APPSTORE_KEY_PATH="./secrets/apple/appstore/AuthKey.p8"
+export APPSTORE_KEY_PATH="./secrets/live/apple/appstore/AuthKey.p8"
 
 print_success "Configuration loaded"
 

--- a/scripts/deploy/deploy_firebase.sh
+++ b/scripts/deploy/deploy_firebase.sh
@@ -85,9 +85,9 @@ print_success "Bundler installed"
 print_section "📋 Validating Configuration"
 
 REQUIRED_FILES=(
-    "secrets/apple/match/.match_password"
-    "secrets/apple/match/match_ci_key"
-    "secrets/android/firebaseAppDistributionServiceCredentialsFile.json"
+    "secrets/live/apple/match/.match_password"
+    "secrets/live/apple/match/match_ci_key"
+    "secrets/live/android/firebaseAppDistributionServiceCredentialsFile.json"
 )
 
 MISSING_FILES=()
@@ -120,10 +120,10 @@ MATCH_GIT_BRANCH=$(grep -E "^apple\.match\.git\.branch=" gradle/fork.properties 
 export TEAM_ID MATCH_GIT_URL MATCH_GIT_BRANCH
 
 # Load Match password
-export MATCH_PASSWORD=$(cat secrets/apple/match/.match_password)
+export MATCH_PASSWORD=$(cat secrets/live/apple/match/.match_password)
 
 # Setup SSH for Match
-export GIT_SSH_COMMAND="ssh -i secrets/apple/match/match_ci_key -o IdentitiesOnly=yes"
+export GIT_SSH_COMMAND="ssh -i secrets/live/apple/match/match_ci_key -o IdentitiesOnly=yes"
 
 print_success "Configuration loaded"
 

--- a/scripts/deploy/deploy_testflight.sh
+++ b/scripts/deploy/deploy_testflight.sh
@@ -85,11 +85,11 @@ print_success "Bundler installed"
 print_section "📋 Validating Configuration"
 
 REQUIRED_FILES=(
-    "secrets/apple/appstore/key_id"
-    "secrets/apple/appstore/issuer_id"
-    "secrets/apple/appstore/AuthKey.p8"
-    "secrets/apple/match/.match_password"
-    "secrets/apple/match/match_ci_key"
+    "secrets/live/apple/appstore/key_id"
+    "secrets/live/apple/appstore/issuer_id"
+    "secrets/live/apple/appstore/AuthKey.p8"
+    "secrets/live/apple/match/.match_password"
+    "secrets/live/apple/match/match_ci_key"
 )
 
 MISSING_FILES=()
@@ -120,25 +120,25 @@ MATCH_GIT_URL=$(grep -E "^apple\.match\.git\.url=" gradle/fork.properties 2>/dev
 MATCH_GIT_BRANCH=$(grep -E "^apple\.match\.git\.branch=" gradle/fork.properties 2>/dev/null | cut -d= -f2- | tr -d '\n\r')
 TESTFLIGHT_GROUPS=$(grep -E "^apple\.tf\.groups=" gradle/fork.properties 2>/dev/null | cut -d= -f2- | tr -d '\n\r')
 
-APPSTORE_KEY_ID=$(cat secrets/apple/appstore/key_id 2>/dev/null | tr -d '\n\r')
-APPSTORE_ISSUER_ID=$(cat secrets/apple/appstore/issuer_id 2>/dev/null | tr -d '\n\r')
+APPSTORE_KEY_ID=$(cat secrets/live/apple/appstore/key_id 2>/dev/null | tr -d '\n\r')
+APPSTORE_ISSUER_ID=$(cat secrets/live/apple/appstore/issuer_id 2>/dev/null | tr -d '\n\r')
 
 # Validate App Store Connect API key configuration
 if [ -z "$APPSTORE_KEY_ID" ] || [ -z "$APPSTORE_ISSUER_ID" ]; then
     print_error "App Store Connect API credentials not configured"
-    print_info "Ensure secrets/apple/appstore/key_id and secrets/apple/appstore/issuer_id exist"
+    print_info "Ensure secrets/live/apple/appstore/key_id and secrets/live/apple/appstore/issuer_id exist"
     exit 1
 fi
 
 # Load Match password
-export MATCH_PASSWORD=$(cat secrets/apple/match/.match_password)
+export MATCH_PASSWORD=$(cat secrets/live/apple/match/.match_password)
 
 # Setup SSH for Match
-export GIT_SSH_COMMAND="ssh -i secrets/apple/match/match_ci_key -o IdentitiesOnly=yes"
+export GIT_SSH_COMMAND="ssh -i secrets/live/apple/match/match_ci_key -o IdentitiesOnly=yes"
 
 # Export for fastlane
 export APPSTORE_KEY_ID APPSTORE_ISSUER_ID TEAM_ID MATCH_GIT_URL MATCH_GIT_BRANCH TESTFLIGHT_GROUPS
-export APPSTORE_KEY_PATH="./secrets/apple/appstore/AuthKey.p8"
+export APPSTORE_KEY_PATH="./secrets/live/apple/appstore/AuthKey.p8"
 
 print_success "Configuration loaded"
 

--- a/scripts/ios/setup_apn_key.sh
+++ b/scripts/ios/setup_apn_key.sh
@@ -50,7 +50,7 @@ print_section() {
 print_section "🔔 APN (Apple Push Notification) Key Setup"
 
 # Ensure APN secrets directory exists
-mkdir -p "secrets/apple/apn"
+mkdir -p "secrets/live/apple/apn"
 
 # Read TEAM_ID from fork.properties (non-secret identity)
 TEAM_ID=$(grep -E "^apple\.team\.id=" gradle/fork.properties 2>/dev/null | cut -d= -f2- | tr -d '\n\r')
@@ -108,7 +108,7 @@ echo
 print_info "Looking for APN .p8 key file..."
 
 # Find .p8 files
-P8_FILES=($(find . -maxdepth 2 -name "AuthKey_*.p8" 2>/dev/null | grep -v "secrets/apple/appstore/AuthKey.p8"))
+P8_FILES=($(find . -maxdepth 2 -name "AuthKey_*.p8" 2>/dev/null | grep -v "secrets/live/apple/appstore/AuthKey.p8"))
 
 if [ ${#P8_FILES[@]} -eq 0 ]; then
     print_warning "No APN .p8 key files found in current directory"
@@ -140,26 +140,26 @@ if ! grep -q "BEGIN PRIVATE KEY" "$APN_P8_PATH"; then
 fi
 
 # Copy to secrets directory
-cp "$APN_P8_PATH" "secrets/apple/apn/APNAuthKey.p8"
-chmod 600 "secrets/apple/apn/APNAuthKey.p8"
-print_success "Copied APN key to secrets/apple/apn/APNAuthKey.p8"
+cp "$APN_P8_PATH" "secrets/live/apple/apn/APNAuthKey.p8"
+chmod 600 "secrets/live/apple/apn/APNAuthKey.p8"
+print_success "Copied APN key to secrets/live/apple/apn/APNAuthKey.p8"
 echo
 
 # Write APN secrets to individual files
 print_section "💾 Writing APN Configuration Files"
 
 # Write key_id
-printf '%s' "$APN_KEY_ID" > "secrets/apple/apn/key_id"
-chmod 600 "secrets/apple/apn/key_id"
-print_success "Written: secrets/apple/apn/key_id"
+printf '%s' "$APN_KEY_ID" > "secrets/live/apple/apn/key_id"
+chmod 600 "secrets/live/apple/apn/key_id"
+print_success "Written: secrets/live/apple/apn/key_id"
 
 # Write team_id
-printf '%s' "$TEAM_ID" > "secrets/apple/apn/team_id"
-chmod 600 "secrets/apple/apn/team_id"
-print_success "Written: secrets/apple/apn/team_id"
+printf '%s' "$TEAM_ID" > "secrets/live/apple/apn/team_id"
+chmod 600 "secrets/live/apple/apn/team_id"
+print_success "Written: secrets/live/apple/apn/team_id"
 
 # APNAuthKey.p8 was already copied above
-print_success "APN configuration files written to secrets/apple/apn/"
+print_success "APN configuration files written to secrets/live/apple/apn/"
 echo
 
 # Firebase Console Instructions
@@ -174,7 +174,7 @@ echo "  3. Click the gear icon → Project settings"
 echo "  4. Go to the 'Cloud Messaging' tab"
 echo "  5. Scroll to 'Apple app configuration'"
 echo "  6. Under 'APNs authentication key', click 'Upload'"
-echo "  7. Upload: secrets/apple/apn/APNAuthKey.p8"
+echo "  7. Upload: secrets/live/apple/apn/APNAuthKey.p8"
 echo "  8. Enter Key ID: $APN_KEY_ID"
 echo "  9. Enter Team ID: $TEAM_ID"
 echo "  10. Click 'Upload'"
@@ -193,16 +193,16 @@ echo
 print_info "Configuration Summary:"
 echo "  ✓ APN Key ID: $APN_KEY_ID"
 echo "  ✓ APN Team ID: $TEAM_ID"
-echo "  ✓ APN Key File: secrets/apple/apn/APNAuthKey.p8"
+echo "  ✓ APN Key File: secrets/live/apple/apn/APNAuthKey.p8"
 echo
 
 print_info "Files created/updated:"
-echo "  ✓ secrets/apple/apn/APNAuthKey.p8"
-echo "  ✓ secrets/apple/apn/key_id"
-echo "  ✓ secrets/apple/apn/team_id"
+echo "  ✓ secrets/live/apple/apn/APNAuthKey.p8"
+echo "  ✓ secrets/live/apple/apn/key_id"
+echo "  ✓ secrets/live/apple/apn/team_id"
 echo
 
-print_warning "IMPORTANT: Keep secrets/apple/apn/APNAuthKey.p8 secure and NEVER commit to git!"
+print_warning "IMPORTANT: Keep secrets/live/apple/apn/APNAuthKey.p8 secure and NEVER commit to git!"
 echo
 
 print_info "Next Steps:"

--- a/scripts/ios/setup_ios_complete.sh
+++ b/scripts/ios/setup_ios_complete.sh
@@ -231,9 +231,9 @@ while [ ! -f "$P8_PATH" ]; do
 done
 
 # Copy to secrets directory
-cp "$P8_PATH" "secrets/apple/appstore/AuthKey.p8"
-chmod 600 "secrets/apple/appstore/AuthKey.p8"
-print_success "Copied .p8 key to secrets/apple/appstore/AuthKey.p8"
+cp "$P8_PATH" "secrets/live/apple/appstore/AuthKey.p8"
+chmod 600 "secrets/live/apple/appstore/AuthKey.p8"
+print_success "Copied .p8 key to secrets/live/apple/appstore/AuthKey.p8"
 echo
 
 # Fastlane Match Configuration
@@ -265,8 +265,8 @@ print_success "Match Branch: $MATCH_GIT_BRANCH"
 # SSH Key for Match
 print_step "5.3" "SSH Key for Match Repository"
 
-if [ -f "secrets/apple/match/match_ci_key" ]; then
-    print_warning "SSH key already exists: secrets/apple/match/match_ci_key"
+if [ -f "secrets/live/apple/match/match_ci_key" ]; then
+    print_warning "SSH key already exists: secrets/live/apple/match/match_ci_key"
     read -p "Do you want to generate a new one? [y/N]: " -n 1 -r
     echo
     GENERATE_NEW=$REPLY
@@ -276,15 +276,15 @@ fi
 
 if [[ $GENERATE_NEW =~ ^[Yy]$ ]]; then
     print_info "Generating new SSH key pair for Match..."
-    ssh-keygen -t ed25519 -C "fastlane-match-$TEAM_ID" -f "secrets/apple/match/match_ci_key" -N ""
-    chmod 600 "secrets/apple/match/match_ci_key"
-    chmod 644 "secrets/apple/match/match_ci_key.pub"
-    print_success "Generated SSH key: secrets/apple/match/match_ci_key"
+    ssh-keygen -t ed25519 -C "fastlane-match-$TEAM_ID" -f "secrets/live/apple/match/match_ci_key" -N ""
+    chmod 600 "secrets/live/apple/match/match_ci_key"
+    chmod 644 "secrets/live/apple/match/match_ci_key.pub"
+    print_success "Generated SSH key: secrets/live/apple/match/match_ci_key"
 fi
 
 print_info "Public key (add this as deploy key to Match repository):"
 echo
-cat "secrets/apple/match/match_ci_key.pub"
+cat "secrets/live/apple/match/match_ci_key.pub"
 echo
 print_warning "IMPORTANT: Add the above public key as a deploy key to your Match repository"
 print_info "Steps:"
@@ -301,7 +301,7 @@ read -p "Press Enter after adding the deploy key..."
 
 # Test SSH connection
 print_info "Testing SSH connection to Match repository..."
-ssh -i secrets/apple/match/match_ci_key -o StrictHostKeyChecking=no -T git@github.com 2>&1 | grep -q "successfully authenticated" && print_success "SSH connection successful" || print_warning "Could not verify SSH connection"
+ssh -i secrets/live/apple/match/match_ci_key -o StrictHostKeyChecking=no -T git@github.com 2>&1 | grep -q "successfully authenticated" && print_success "SSH connection successful" || print_warning "Could not verify SSH connection"
 echo
 
 # Match password
@@ -310,7 +310,7 @@ print_info "Match encrypts your certificates with a password"
 print_warning "IMPORTANT: Store this password securely! You'll need it on all machines and CI/CD"
 echo
 
-if [ -f "secrets/apple/match/.match_password" ]; then
+if [ -f "secrets/live/apple/match/.match_password" ]; then
     print_warning "Match password file already exists"
     read -p "Do you want to generate a new password? [y/N]: " -n 1 -r
     echo
@@ -322,14 +322,14 @@ fi
 if [[ $GENERATE_NEW_PWD =~ ^[Yy]$ ]]; then
     # Generate secure random password
     MATCH_PASSWORD=$(openssl rand -base64 32)
-    echo "$MATCH_PASSWORD" > "secrets/apple/match/.match_password"
-    chmod 600 "secrets/apple/match/.match_password"
-    print_success "Generated Match password (stored in secrets/apple/match/.match_password)"
+    echo "$MATCH_PASSWORD" > "secrets/live/apple/match/.match_password"
+    chmod 600 "secrets/live/apple/match/.match_password"
+    print_success "Generated Match password (stored in secrets/live/apple/match/.match_password)"
     echo
     print_warning "Match Password: $MATCH_PASSWORD"
     print_warning "Save this password in your password manager!"
 else
-    MATCH_PASSWORD=$(cat "secrets/apple/match/.match_password")
+    MATCH_PASSWORD=$(cat "secrets/live/apple/match/.match_password")
     print_success "Using existing Match password"
 fi
 echo
@@ -395,7 +395,7 @@ _upsert_property() {
 }
 
 # Ensure directories exist
-mkdir -p "secrets/apple/appstore" "secrets/apple/match"
+mkdir -p "secrets/live/apple/appstore" "secrets/live/apple/match"
 
 # Non-secret identity / metadata → gradle/fork.properties
 print_info "Writing non-secret metadata to gradle/fork.properties..."
@@ -416,22 +416,22 @@ print_success "Non-secret metadata written to gradle/fork.properties"
 print_info "Writing secret values to secrets/ files..."
 
 # App Store Connect secrets
-printf '%s' "$APPSTORE_KEY_ID"    > "secrets/apple/appstore/key_id"
-printf '%s' "$APPSTORE_ISSUER_ID" > "secrets/apple/appstore/issuer_id"
-chmod 600 "secrets/apple/appstore/key_id" "secrets/apple/appstore/issuer_id"
-print_success "Written: secrets/apple/appstore/key_id, issuer_id"
+printf '%s' "$APPSTORE_KEY_ID"    > "secrets/live/apple/appstore/key_id"
+printf '%s' "$APPSTORE_ISSUER_ID" > "secrets/live/apple/appstore/issuer_id"
+chmod 600 "secrets/live/apple/appstore/key_id" "secrets/live/apple/appstore/issuer_id"
+print_success "Written: secrets/live/apple/appstore/key_id, issuer_id"
 
 # Match secrets (MATCH_PASSWORD already written to .match_password above)
-print_success "Match password already in: secrets/apple/match/.match_password"
-print_success "Match SSH key already in:  secrets/apple/match/match_ci_key"
+print_success "Match password already in: secrets/live/apple/match/.match_password"
+print_success "Match SSH key already in:  secrets/live/apple/match/match_ci_key"
 # Write certificates_password and keychain_password as stubs (populated by match run)
-if [ ! -f "secrets/apple/match/certificates_password" ]; then
-    printf '' > "secrets/apple/match/certificates_password"
-    chmod 600 "secrets/apple/match/certificates_password"
+if [ ! -f "secrets/live/apple/match/certificates_password" ]; then
+    printf '' > "secrets/live/apple/match/certificates_password"
+    chmod 600 "secrets/live/apple/match/certificates_password"
 fi
-if [ ! -f "secrets/apple/match/keychain_password" ]; then
-    printf '%s' "$(openssl rand -base64 16)" > "secrets/apple/match/keychain_password"
-    chmod 600 "secrets/apple/match/keychain_password"
+if [ ! -f "secrets/live/apple/match/keychain_password" ]; then
+    printf '%s' "$(openssl rand -base64 16)" > "secrets/live/apple/match/keychain_password"
+    chmod 600 "secrets/live/apple/match/keychain_password"
 fi
 
 print_success "Configuration written to fork.properties + secrets/ files"
@@ -487,12 +487,12 @@ echo
 
 print_info "Configuration files created:"
 echo "  ✓ gradle/fork.properties (non-secret metadata)"
-echo "  ✓ secrets/apple/appstore/AuthKey.p8"
-echo "  ✓ secrets/apple/appstore/key_id"
-echo "  ✓ secrets/apple/appstore/issuer_id"
-echo "  ✓ secrets/apple/match/match_ci_key"
-echo "  ✓ secrets/apple/match/.match_password"
-echo "  ✓ secrets/apple/match/keychain_password"
+echo "  ✓ secrets/live/apple/appstore/AuthKey.p8"
+echo "  ✓ secrets/live/apple/appstore/key_id"
+echo "  ✓ secrets/live/apple/appstore/issuer_id"
+echo "  ✓ secrets/live/apple/match/match_ci_key"
+echo "  ✓ secrets/live/apple/match/.match_password"
+echo "  ✓ secrets/live/apple/match/keychain_password"
 echo
 
 print_warning "IMPORTANT: Keep these files secure and NEVER commit them to git!"

--- a/scripts/ios/verify_apn_setup.sh
+++ b/scripts/ios/verify_apn_setup.sh
@@ -55,9 +55,9 @@ WARNINGS=0
 # Check if APN secret files exist
 print_info "Checking APN configuration files..."
 
-APN_KEY_ID_FILE="secrets/apple/apn/key_id"
-APN_TEAM_ID_FILE="secrets/apple/apn/team_id"
-APN_KEY_FILE_PATH="secrets/apple/apn/APNAuthKey.p8"
+APN_KEY_ID_FILE="secrets/live/apple/apn/key_id"
+APN_TEAM_ID_FILE="secrets/live/apple/apn/team_id"
+APN_KEY_FILE_PATH="secrets/live/apple/apn/APNAuthKey.p8"
 
 if [ ! -f "$APN_KEY_ID_FILE" ]; then
     print_error "APN key_id file not found: $APN_KEY_ID_FILE"
@@ -123,7 +123,7 @@ fi
 # Check APN key file
 print_section "🔑 Checking APN Key File"
 
-APN_KEY_FILE="secrets/apple/apn/APNAuthKey.p8"
+APN_KEY_FILE="secrets/live/apple/apn/APNAuthKey.p8"
 
 if [ ! -f "$APN_KEY_FILE" ]; then
     print_error "APN key file not found: $APN_KEY_FILE"

--- a/scripts/ios/verify_ios_deployment.sh
+++ b/scripts/ios/verify_ios_deployment.sh
@@ -213,23 +213,23 @@ check "secrets directory exists" \
 warn "fork.properties has apple.team.id" \
     "grep -qE '^apple\\.team\\.id=' gradle/fork.properties"
 
-warn "secrets/apple/appstore/key_id exists" \
-    "[ -f 'secrets/apple/appstore/key_id' ]"
+warn "secrets/live/apple/appstore/key_id exists" \
+    "[ -f 'secrets/live/apple/appstore/key_id' ]"
 
-warn "secrets/apple/appstore/issuer_id exists" \
-    "[ -f 'secrets/apple/appstore/issuer_id' ]"
+warn "secrets/live/apple/appstore/issuer_id exists" \
+    "[ -f 'secrets/live/apple/appstore/issuer_id' ]"
 
 warn ".match_password exists" \
-    "[ -f 'secrets/apple/match/.match_password' ]"
+    "[ -f 'secrets/live/apple/match/.match_password' ]"
 
 warn "match_ci_key (SSH key) exists" \
-    "[ -f 'secrets/apple/match/match_ci_key' ]"
+    "[ -f 'secrets/live/apple/match/match_ci_key' ]"
 
 warn "AuthKey.p8 (App Store Connect API) exists" \
-    "[ -f 'secrets/apple/appstore/AuthKey.p8' ]"
+    "[ -f 'secrets/live/apple/appstore/AuthKey.p8' ]"
 
 warn "Firebase credentials exist" \
-    "[ -f 'secrets/android/firebaseAppDistributionServiceCredentialsFile.json' ]"
+    "[ -f 'secrets/live/android/firebaseAppDistributionServiceCredentialsFile.json' ]"
 
 # ============================================================================
 # 6. Deployment Scripts

--- a/setup-project.sh
+++ b/setup-project.sh
@@ -234,7 +234,7 @@ collect_inputs() {
 }
 
 # Write keystore DN identity to gradle/fork.properties (non-secret values).
-# Keystore passwords are written to secrets/android/keystores/ per-value files.
+# Keystore passwords are written to secrets/live/android/keystores/ per-value files.
 # This replaces the retired create_secrets_env() function that wrote secrets.env.
 setup_keystore_config() {
     print_info "Writing keystore DN to gradle/fork.properties"
@@ -271,7 +271,7 @@ setup_keystore_config() {
     fi
 
     # Write keystore passwords to per-value secret files
-    local KEYSTORE_SECRETS_DIR="secrets/android/keystores"
+    local KEYSTORE_SECRETS_DIR="secrets/live/android/keystores"
     mkdir -p "$KEYSTORE_SECRETS_DIR"
     printf '%s' "$KEYSTORE_PASSWORD" > "$KEYSTORE_SECRETS_DIR/keystore_password"
     printf '%s' "$KEY_ALIAS"         > "$KEYSTORE_SECRETS_DIR/keystore_alias"
@@ -420,14 +420,14 @@ print_final_summary() {
     echo -e "  - Upload keystore generated"
     echo -e "  - Configuration files updated with keystore info"
     echo -e "  - Keystore DN written to gradle/fork.properties (non-secret)"
-    echo -e "  - Keystore passwords written to secrets/android/keystores/ (gitignored)"
+    echo -e "  - Keystore passwords written to secrets/live/android/keystores/ (gitignored)"
     echo
 
     print_section "Important Files Created"
     echo -e "  ${BOLD}keystores/${NC}"
     echo -e "    └── upload_keystore.keystore  ${YELLOW}(Keep this secure!)${NC}"
     echo
-    echo -e "  ${BOLD}secrets/android/keystores/${NC}  ${CYAN}(Keystore passwords — gitignored)${NC}"
+    echo -e "  ${BOLD}secrets/live/android/keystores/${NC}  ${CYAN}(Keystore passwords — gitignored)${NC}"
     echo -e "    ├── keystore_password"
     echo -e "    ├── keystore_alias"
     echo -e "    └── keystore_alias_password"
@@ -473,7 +473,7 @@ print_final_summary() {
     echo -e "${CYAN}6. ${BOLD}Version Control${NC}"
     echo -e "   ⚠️  ${YELLOW}NEVER commit these files:${NC}"
     echo -e "     - keystores/*.keystore"
-    echo -e "     - secrets/android/keystores/*"
+    echo -e "     - secrets/live/android/keystores/*"
     echo -e "     - secrets/*"
     echo
     echo -e "   ${GREEN}Safe to commit:${NC}"
@@ -534,7 +534,7 @@ Country: $COUNTRY
 
 ## Important Notes
 - Keep keystore files and passwords secure
-- Never commit keystores or secrets/android/keystores/* to version control
+- Never commit keystores or secrets/live/android/keystores/* to version control
 - Add required secret files to secrets/ directory
 - Run 'bash scripts/secrets/sync-secrets-to-github.sh' to push secrets to GitHub
 EOF
@@ -552,7 +552,7 @@ main() {
     # Collect user inputs
     collect_inputs
     
-    # Write keystore DN to fork.properties + passwords to secrets/android/keystores/
+    # Write keystore DN to fork.properties + passwords to secrets/live/android/keystores/
     setup_keystore_config
 
     # Step 1: Customization

--- a/sync-dirs.sh
+++ b/sync-dirs.sh
@@ -106,7 +106,7 @@ declare -A EXCLUSIONS=(
     # fork-local (each fork's filled-in identity), so it is NEVER synced. Only the
     # committed schema gradle/fork.properties.template syncs (see SYNC_FILES above).
     # Keystore passwords live in
-    # secrets/android/keystores/ per-value files (gitignored, not synced).
+    # secrets/live/android/keystores/ per-value files (gitignored, not synced).
     # DO NOT REMOVE — preserves consumer-specific flavor extensions across syncs.
     # Each downstream consumer app (mifos-mobile, mifos-pay, mifos-x-field-officer-app,
     # mifos-x-group-banking, mifos-x-open-banking, reels-downloader-new, ...) may


### PR DESCRIPTION
## Problem
The Phase-7 secrets layout — real secrets in `secrets/live/` (gitignored), committed fakes in `secrets/sample/`, `secrets/LAYOUT.yaml` with `precedence: [live, sample]` — updated the resolver (`scripts/secrets/_lib.sh`, which already uses `secrets/live/…`) but **not the consumers**. Many still hardcode the pre-`live` flat path `secrets/{android,apple,desktop}/…`, which exists in neither `live/` nor `sample/`. Result: e.g. `cmp-android/build.gradle.kts` `storeFile` looks for the upload keystore at `secrets/android/keystores/…` — a directory that does not exist in Phase-7.

## Change
Resolve every **functional** flat `secrets/<platform>/…` consumer to `secrets/live/<platform>/…`, keeping **materializer ↔ reader in lockstep** (a workflow that decodes a secret to a path and the reader that consumes it point at the same `secrets/live/…` path).

- **Signing** — `cmp-android/build.gradle.kts` `storeFile` now resolves `secrets/live/…` with a `secrets/sample/…` fallback (so local/debug builds work without real secrets); `KEYSTORE_PATH` still overrides.
- **Materializers** — `.github/workflows/release-multi-platform{,-local}.yml`, `deployment/_shared/scripts/materialize-{android,ios,mac}-secrets.sh` now decode to `secrets/live/…`.
- **Readers** — `scripts/deploy/deploy_{appstore,firebase,testflight}.sh`, `deployment/_shared/{config,project_config}.rb`, desktop lanes, iOS setup/verify scripts.
- **Declarations/docs** — `deployment/**/secrets-needs.yaml` canonical paths, `workflow-snippet.yml`, `setup-project.sh`, `gradle/fork.properties`, `sync-dirs.sh`.
- **Regression lock** — `scripts/ci/check-secrets-resolver.sh` SR-12 broadened from `secrets/android/(play|firebase)/…` to catch **any** flat `secrets/(android|apple|desktop)/…` literal (keystores/match/appstore/desktop-certs included), excluding `live/`, `sample/`, LAYOUT/secrets-needs/secrets-manifest declarations, and comments.

Untouched: `scripts/secrets/_lib.sh` (already correct), `secrets/LAYOUT.yaml`, `secrets/{live,sample}/**`, `core-base/**`.

## Verification
- 0 functional flat `secrets/<platform>/` paths remain (only the gate's own bad-literal example + layout-doc lines).
- Android keystore lockstep: materializer + `KEYSTORE_PATH` + `build.gradle.kts` all → `secrets/live/android/keystores/upload_keystore.keystore`. Apple match key likewise → `secrets/live/apple/match/…`.
- `scripts/ci/check-secrets-resolver.sh` → **exit 0** (SR-7/8/9/10/11/12 pass).

Draft — for maintainer review. Automated via the framework's template-fix-upstream flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized Android, iOS, macOS, and deployment credentials under the new `secrets/live` directory structure.
  * Updated release workflows, signing configuration, deployment scripts, and validation tools to use the new locations.
  * Preserved compatibility with legacy credential paths where required.
* **Documentation**
  * Updated setup guidance, workflow descriptions, and security instructions to reflect the new credential layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->