### PR TITLE
feat(sync-dirs): --only targeted sync + preserve fork-extended shared files on full sync

### DIFF
--- a/customization-surface.yaml
+++ b/customization-surface.yaml
@@ -64,6 +64,33 @@ rules:
   - glob: "cmp-navigation/**/RootNav*.kt"
     owner: merge
     strategy: kotlin-3way
+  # Nav DI + tab registry: template ships the base graph; forks add their feature
+  # modules + bottom-nav tabs. Blind copy drops them (the awaazly 2026-07-19 loss class).
+  - glob: "cmp-navigation/**/di/*.kt"
+    owner: merge
+    strategy: kotlin-3way
+  - glob: "cmp-navigation/**/*TabItem*.kt"
+    owner: merge
+    strategy: kotlin-3way
+  # Room database registry: template ships the base @Database; forks add their own
+  # entities/DAOs to the SAME AppDatabase.kt. Must merge, never overwrite.
+  - glob: "**/AppDatabase.kt"
+    owner: merge
+    strategy: kotlin-3way
+  # Android FileProvider paths: template ships base <paths>; forks add feature paths
+  # (exports/recordings/imports). Blind copy drops them → runtime FileProvider crash.
+  - glob: "**/res/xml/provider_paths.xml"
+    owner: merge
+    strategy: kotlin-3way
+  # App entry point: template ships the base Activity; forks wire app-init/SDK hooks.
+  - glob: "**/MainActivity.kt"
+    owner: merge
+    strategy: kotlin-3way
+  # Android app build script: template updates plugins/config; forks add deps + flavors.
+  # Merge (conflicts surface) beats a blind overwrite that silently drops every fork dep.
+  - glob: "cmp-android/build.gradle.kts"
+    owner: merge
+    strategy: kotlin-3way
 
   # ── fork-owned (carve-outs INSIDE otherwise-template dirs; declared before template) ──
   - glob: "branding/**"

--- a/sync-dirs.sh
+++ b/sync-dirs.sh
@@ -19,6 +19,7 @@ DEFAULT_UPSTREAM_URL="https://github.com/openMF/kmp-project-template.git"
 # Script options
 DRY_RUN=false
 FORCE=false
+ONLY_ITEMS=""   # --only <a,b,c>: restrict the sync to this subset of SYNC_DIRS/SYNC_FILES
 LOG_FILE="sync-$(date +%d%m%Y-%H%M%S).log"
 
 # Directories and files to sync
@@ -128,11 +129,15 @@ show_help() {
     echo "  -h, --help      Display this help message and exit"
     echo "  --dry-run       Show what would be done without making changes"
     echo "  -f, --force     Skip confirmation prompts and proceed automatically"
+    echo "  --only <list>   Restrict the sync to a comma/space-separated subset of the declared"
+    echo "                  SYNC_DIRS/SYNC_FILES (e.g. --only build-logic,gradle/wrapper,spotless)."
+    echo "                  Use it when a diverged fork only wants specific infra refreshed."
     echo
     echo -e "${BOLD}Examples:${NC}"
     echo "  ./sync-dirs.sh              # Run with interactive prompts"
     echo "  ./sync-dirs.sh --dry-run    # Test run without changes"
     echo "  ./sync-dirs.sh --force      # Run with no prompts"
+    echo "  ./sync-dirs.sh --only build-logic,gradle/wrapper --dry-run   # only that infra subset"
 }
 
 # Logging function
@@ -537,11 +542,33 @@ while [[ $# -gt 0 ]]; do
             FORCE=true
             shift
             ;;
+        --only)
+            ONLY_ITEMS="${2:-}"
+            [ -z "$ONLY_ITEMS" ] && handle_error "--only requires a comma/space-separated list of dirs/files (e.g. --only build-logic,gradle/wrapper)"
+            shift 2
+            ;;
         *)
             handle_error "Unknown option: $1. Use --help for usage information."
             ;;
     esac
 done
+
+# --only: restrict SYNC_DIRS/SYNC_FILES to the named subset (targeted sync for diverged forks
+# that only want specific infra refreshed). Each named item MUST already be a declared SYNC_DIR
+# or SYNC_FILE — this narrows the canonical set, it never adds un-vetted paths.
+if [ -n "$ONLY_ITEMS" ]; then
+    ONLY_ITEMS="${ONLY_ITEMS//,/ }"
+    declare -a _KEEP_DIRS=() _KEEP_FILES=()
+    for _want in $ONLY_ITEMS; do
+        _found=false
+        for _d in "${SYNC_DIRS[@]}";  do [ "$_d" = "$_want" ] && { _KEEP_DIRS+=("$_want");  _found=true; break; }; done
+        for _f in "${SYNC_FILES[@]}"; do [ "$_f" = "$_want" ] && { _KEEP_FILES+=("$_want"); _found=true; break; }; done
+        [ "$_found" = false ] && handle_error "--only: '$_want' is not a declared SYNC_DIR or SYNC_FILE. Choose from: ${SYNC_DIRS[*]} ${SYNC_FILES[*]}"
+    done
+    SYNC_DIRS=("${_KEEP_DIRS[@]}")
+    SYNC_FILES=("${_KEEP_FILES[@]}")
+    echo -e "${YELLOW}${BOLD}Targeted sync (--only):${NC} ${SYNC_DIRS[*]} ${SYNC_FILES[*]}"
+fi
 
 # Check git configuration
 if ! git config user.name > /dev/null || ! git config user.email > /dev/null; then


### PR DESCRIPTION
## Why
A heavily-diverged fork that runs the full `sync-dirs.sh` can lose project-specific code it added to *shared* files (permissions, Room entities, nav routes/tabs, build deps). The customization-surface merge contract already protects `AndroidManifest.xml`, `settings.gradle.kts`, `libs.versions.toml`, and `cmp-navigation` Navigation/RootNav — but not the rest. And there was no way to sync just a safe subset.

## Changes
**1. `--only <a,b,c>` in `sync-dirs.sh`** — restrict the sync to a comma/space-separated subset of the declared `SYNC_DIRS`/`SYNC_FILES`. Each item is validated against the canonical set (unknown → error). A diverged fork can pull just infra (`--only build-logic,gradle/wrapper,spotless`) without touching `core/`/`cmp-navigation/` where its product lives.

**2. Broaden `owner: merge` in `customization-surface.yaml`** to the other fork-EXTENDED shared files:
- `**/AppDatabase.kt` — forks add entities/DAOs to the shared @Database
- `cmp-navigation/**/di/*.kt`, `cmp-navigation/**/*TabItem*.kt` — feature DI modules + bottom-nav tabs
- `**/res/xml/provider_paths.xml` — FileProvider paths (exports/recordings/imports)
- `**/MainActivity.kt` — app-init / SDK hooks
- `cmp-android/build.gradle.kts` — fork deps/flavors (merge → conflicts surface, beats a blind overwrite that silently drops every fork dep)

These become 3-way merges (fork edits preserved, real conflicts surfaced). `core-base/**` stays `owner: template` — forks are told never to edit it, so that boundary is respected (a fork editing core-base is correctly overwritten).

## Verified
- `--only` restricts the plan to the named subset; unknown item errors with the valid list.
- `cs_match_g` now classifies AppDatabase/nav-DI/provider_paths → merge, core-base → template.
- `tests/customization-surface/merge-3way-test.sh` passes (conflicts surface, none silently shipped).

Draft — for maintainer review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a targeted synchronization option, allowing selected directories or files to be synced instead of the entire configured set.
  * Added command-line guidance and validation to help ensure only valid sync targets are selected.

* **Bug Fixes**
  * Improved template synchronization so custom fork additions are preserved and merged across supported Android project areas rather than being overwritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->