### PR TITLE
fix(network): consumer ProGuard rules for Ktor java.lang.management refs

### DIFF
--- a/cmp-android/proguard-rules.pro
+++ b/cmp-android/proguard-rules.pro
@@ -3,12 +3,6 @@
 -dontwarn org.conscrypt.**
 -dontwarn org.bouncycastle.**
 -dontwarn org.openjsse.**
-
-# Ktor's IntellijIdeaDebugDetector references JVM-only java.lang.management.* (absent
-# on Android). Safe to ignore — used only for debugger detection. Without these,
-# `:cmp-android:minifyProdReleaseWithR8` fails on every fork's prod release build.
--dontwarn java.lang.management.ManagementFactory
--dontwarn java.lang.management.RuntimeMXBean
 -keep class * extends androidx.room.RoomDatabase { <init>(); }
 
 # Security module — keep expect/actual classes that use reflection or JNI

--- a/cmp-android/proguard-rules.pro
+++ b/cmp-android/proguard-rules.pro
@@ -3,6 +3,12 @@
 -dontwarn org.conscrypt.**
 -dontwarn org.bouncycastle.**
 -dontwarn org.openjsse.**
+
+# Ktor's IntellijIdeaDebugDetector references JVM-only java.lang.management.* (absent
+# on Android). Safe to ignore — used only for debugger detection. Without these,
+# `:cmp-android:minifyProdReleaseWithR8` fails on every fork's prod release build.
+-dontwarn java.lang.management.ManagementFactory
+-dontwarn java.lang.management.RuntimeMXBean
 -keep class * extends androidx.room.RoomDatabase { <init>(); }
 
 # Security module — keep expect/actual classes that use reflection or JNI

--- a/core-base/network/consumer-rules.pro
+++ b/core-base/network/consumer-rules.pro
@@ -1,0 +1,8 @@
+# Network module consumer ProGuard rules — automatically applied to consuming modules
+
+# Ktor's IntellijIdeaDebugDetector references JVM-only java.lang.management.* (absent on
+# Android). Safe to ignore — used only for debugger detection (returns false on Android).
+# Without these, :cmp-android:minifyReleaseWithR8 fails on every consuming app's
+# release build (R8 "Missing class java.lang.management.ManagementFactory").
+-dontwarn java.lang.management.ManagementFactory
+-dontwarn java.lang.management.RuntimeMXBean


### PR DESCRIPTION
## Summary
Adds the missing `consumer-rules.pro` for `core-base/network`, so consuming apps automatically get R8 keep rules for Ktor's JVM-only references.

Ktor's `IntellijIdeaDebugDetector` (in `ktor-utils`, pulled by `core-base/network`) references `java.lang.management.ManagementFactory` / `RuntimeMXBean`, which don't exist on Android. Without `-dontwarn` rules, R8 minification fails on **every consuming app's** release build:

    ERROR: R8: Missing class java.lang.management.ManagementFactory
      (referenced from: io.ktor.util.debug.IntellijIdeaDebugDetector...)
    Task :cmp-android:minifyReleaseWithR8 FAILED

## Why here (not cmp-android)
Every other `core-base/*` module ships its own `consumer-rules.pro` (analytics, common, platform, security, ui) — the convention plugin applies them to consumers automatically. `core-base/network` was the only one missing it, despite owning the Ktor client. Putting the rule here fixes it once for **all** forks/consumers, instead of each app repeating it in `cmp-android/proguard-rules.pro`.

Surfaced on a downstream fork's first prod-release deploy. Draft for maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Android build warnings caused by JVM-only management classes during code shrinking.
  * Improved compatibility with R8 and ProGuard processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->