### PR TITLE
fix(keystore + build-logic): PKCS12 key==store pw, RSA-4096, 1000y validity + config-cache opt-out for worker-app codegen

### DIFF
--- a/build-logic/convention/src/main/kotlin/WorkerComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/WorkerComposeConventionPlugin.kt
@@ -36,6 +36,19 @@ class WorkerComposeConventionPlugin : Plugin<Project> {
             // (see build-logic/convention/build.gradle.kts).
             pluginManager.apply("io.github.mobilebytelabs.worker-app")
 
+            // worker-app's per-platform codegen tasks (workerKmpAppCodegen*) capture the
+            // Project at execution time, which Gradle 9.5's configuration cache rejects —
+            // failing e.g. :core:database:desktopTest under the Kover coverage run
+            // ("cannot serialize object of type 'DefaultProject'"). Opt these tasks out of
+            // the configuration cache gracefully: codegen still runs, it just isn't cached.
+            // Proper fix is upstream in MobileByteLabs/worker-kmp; this is the template-side
+            // workaround so config-cache builds (Kover) stay green.
+            tasks.matching { it.name.startsWith("workerKmpAppCodegen") }.configureEach {
+                notCompatibleWithConfigurationCache(
+                    "worker-app codegen captures Project (upstream: MobileByteLabs/worker-kmp)"
+                )
+            }
+
             // 2 + 3. Add umbrella + koin-compose to commonMain.
             dependencies {
                 add("commonMainImplementation", libs.findLibrary("worker-compose-all").get())

--- a/deployment/_shared/scripts/keystore-manager.sh
+++ b/deployment/_shared/scripts/keystore-manager.sh
@@ -1397,9 +1397,9 @@ generate_keystore() {
     local key_password=$5
 
     # Hard-coded generation constants (not per-fork config)
-    local validity=25
+    local validity=1000  # ~1000 years — upload key must outlive the app
     local keyalg="RSA"
-    local keysize=2048
+    local keysize=4096
     local overwrite=false
 
     # Path to save the keystore
@@ -1485,24 +1485,28 @@ generate_keystore() {
         DN=$(IFS=,; echo "${DN_PARTS[*]}")
         keytool -genkey -v \
             -keystore "$keystore_path" \
-            -alias "$key_alias" \
+            -storetype PKCS12 \
+              -alias "$key_alias" \
             -keyalg "$keyalg" \
             -keysize "$keysize" \
-            -validity $((validity*365)) \
+            -sigalg SHA256withRSA \
+              -validity $((validity*365)) \
             -storepass "$keystore_password" \
-            -keypass "$key_password" \
+            -keypass "$keystore_password" \  # PKCS12: key pw == store pw
             -dname "$DN"
     else
         # gradle/fork.properties not present — fall back to interactive DN entry
         echo -e "${BLUE}gradle/fork.properties not found. Using interactive mode for certificate DN.${NC}"
         keytool -genkey -v \
             -keystore "$keystore_path" \
-            -alias "$key_alias" \
+            -storetype PKCS12 \
+              -alias "$key_alias" \
             -keyalg "$keyalg" \
             -keysize "$keysize" \
-            -validity $((validity*365)) \
+            -sigalg SHA256withRSA \
+              -validity $((validity*365)) \
             -storepass "$keystore_password" \
-            -keypass "$key_password"
+            -keypass "$keystore_password"  # PKCS12: key pw == store pw
     fi
 
     # Check if keystore was successfully created


### PR DESCRIPTION
Two independent template fixes, both surfaced by a downstream fork's first prod-release deploy.

## 1. keystore-manager (`deployment/_shared/scripts/keystore-manager.sh`)
keytool defaults to **PKCS12** (JDK 9+), which requires **key password == store password**. The script generated with a *separate* `-keypass`, so Android's apksig fails `:cmp-android:packageRelease`:

    UnrecoverableKeyException: Get Key failed: Given final block not properly padded

Fix: `-keypass` = `-storepass` + explicit `-storetype PKCS12`. Strengthened while here: RSA `2048→4096`, `-sigalg SHA256withRSA`, validity `25y→1000y`.

## 2. config-cache opt-out for worker-app codegen (`WorkerComposeConventionPlugin.kt`)
Included because the PR's own **Kover Coverage** check (and every PR's) fails on a pre-existing base-branch issue: the external `io.github.mobilebytelabs.worker-app` plugin's `workerKmpAppCodegen*` tasks capture `Project`, which Gradle 9.5's configuration cache rejects:

    Task ':cmp-shared:workerKmpAppCodegenAutoShim' … cannot serialize object of type 'DefaultProject'
    … not supported with the configuration cache
    Execution failed for task ':core:database:desktopTest'

Fix: mark those tasks `notCompatibleWithConfigurationCache(…)` — a graceful opt-out (codegen still runs, just uncached). Proper fix is upstream in MobileByteLabs/worker-kmp; this unblocks config-cache builds template-wide. Applied in the convention plugin, which both `cmp-shared` and `sync` use.

Draft for maintainer review — happy to split into two PRs if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)