### PR TITLE
chore(white-label-template): source session branch

### DIFF
--- a/deployment/_shared/config.rb
+++ b/deployment/_shared/config.rb
@@ -416,9 +416,14 @@ def setup_ios_keychain(options = {})
   keychain_pass = options[:keychain_password] ||
                   ENV["KEYCHAIN_PASSWORD"] ||
                   cfg[:keychain_password]
-  return unless keychain_pass
 
   if ENV["CI"].to_s != ""
+    # CI: create an isolated, throwaway build keychain for Match to import into.
+    # The password is EPHEMERAL — a per-run random value when none is supplied — so
+    # NO persisted keychain secret is required (the fastlane setup_ci pattern). All
+    # Apple signing material comes from the fastlane-match provisioning repo.
+    require "securerandom"
+    keychain_pass ||= SecureRandom.hex(24)
     create_keychain(
       name:             "build.keychain-db",
       password:         keychain_pass,
@@ -428,6 +433,10 @@ def setup_ios_keychain(options = {})
       lock_when_sleeps: false,
     )
   else
+    # Local: the developer's login keychain is already unlocked in their session, so
+    # Match imports into it with NO secret at all. Only unlock explicitly when a
+    # password was deliberately provided (e.g. a locked-session CI-like local run).
+    return unless keychain_pass
     unlock_keychain(
       path:        File.expand_path("~/Library/Keychains/login.keychain-db"),
       password:    keychain_pass,

--- a/deployment/_shared/config.rb
+++ b/deployment/_shared/config.rb
@@ -315,8 +315,15 @@ module FastlaneConfig
   # Reads UPLOAD keystore credentials (Play App Signing model — Play Console
   # verifies upload signature, then re-signs with the Google-held app signing key).
   def self.get_android_signing_config(options = {})
-    _s = SECRETS_DIR
-    props_path = "#{_s}/android/keystores/upload_keystore.properties"
+    # Resolve the keystore + its .properties through the LAYOUT resolver
+    # (live-wins-else-sample) — NOT the raw SECRETS_DIR base, which misses the
+    # `live/` segment after the secrets/{live,sample} split and yields a
+    # non-existent `secrets/android/keystores/…` path (breaks local signed
+    # builds). Matches the same resolver buildAndSignApp uses for its fallback
+    # (BuildSecrets.for.path). (fix 2026-07-31)
+    ks_rel     = BuildSecrets.for.path(:upload_keystore)
+    ks_dir     = File.dirname(ks_rel)
+    props_path = "#{ks_dir}/upload_keystore.properties"
     props = {}
     if File.exist?(File.join(DEPLOYMENT_REPO_ROOT, props_path))
       File.readlines(File.join(DEPLOYMENT_REPO_ROOT, props_path)).each do |line|
@@ -327,7 +334,7 @@ module FastlaneConfig
 
     # Read storeFile dynamically so forks can rename the keystore without
     # touching config.rb (storeFile key in upload_keystore.properties is canonical).
-    default_jks = "#{_s}/android/keystores/#{props.fetch("storeFile", "upload_keystore.keystore")}"
+    default_jks = "#{ks_dir}/#{props.fetch("storeFile", "upload_keystore.keystore")}"
 
     {
       keystore_path:     options[:keystore_path]     ||

--- a/deployment/_shared/config.rb
+++ b/deployment/_shared/config.rb
@@ -234,6 +234,12 @@ module FastlaneConfig
   # --------------------------------------------------------------------------
   module AndroidConfig
     METADATA_PATH = "deployment/android/metadata".freeze
+    # Primary Play Store listing locale (the metadata subdir under METADATA_PATH).
+    # Android-owned — platform-wise config, do NOT borrow IosConfig for an Android lane.
+    # Fork-configurable via gradle/fork.properties `store.primary.locale` (falls back to en-US).
+    # Replaces the broken `FastlaneConfig::SHARED[:primary_locale]` reference (SHARED was undefined)
+    # the android sync-listing lane used — which raised NameError on any local Play listing sync. (2026-07-31)
+    PRIMARY_LOCALE = (_fork_prop("store.primary.locale") || "en-US").freeze
 
     # Per-flavor Play track destination — the mechanism that makes demo's Play
     # publication config, not a Ruby conditional (AC-12). Each flavor maps to

--- a/deployment/android/sync-listing/lane.rb
+++ b/deployment/android/sync-listing/lane.rb
@@ -8,7 +8,7 @@ platform :android do
   lane :syncListing do |options|
     options = sanitize_options(options)
 
-    locale = FastlaneConfig::SHARED[:primary_locale] || "en-US"
+    locale = FastlaneConfig::AndroidConfig::PRIMARY_LOCALE   # fork.properties store.primary.locale (was broken SHARED[:primary_locale])
     metadata_root = File.join(DEPLOYMENT_REPO_ROOT, "deployment/android/metadata")
 
     UI.message("📋 Syncing Play Store listing for locale: #{locale}")

--- a/gradle/fork.properties.template
+++ b/gradle/fork.properties.template
@@ -235,6 +235,14 @@ store.ios.keywords=keyword1,keyword2,keyword3,keyword4
 # Full list: https://developer.apple.com/app-store/categories/
 store.ios.category=Finance
 
+# ── Store locale (primary listing language) ──────────────────────────────────
+
+# Primary store-listing locale (BCP-47, e.g. en-US, fr-FR). The metadata subdir
+# name under deployment/<platform>/metadata/, and the locale the sync-listing lane
+# targets. Read by FastlaneConfig::AndroidConfig::PRIMARY_LOCALE (falls back to en-US).
+# ENV: STORE_PRIMARY_LOCALE
+store.primary.locale=en-US
+
 # ── Store Metadata — macOS App Store ─────────────────────────────────────────
 
 # Keywords for Mac App Store search (comma-separated, same rules as iOS).


### PR DESCRIPTION
## Summary

chore(white-label-template): source session branch

## Commits (1)

- `9ba0bc74` chore: initialize session branch — white label template

## Session metadata

- **Branch:** `claude-session-kmp-project-template-20260725183456`
- **Base:** `dev`
- **Repo:** `kmp-project-template`
- **Last refreshed:** `2026-07-25T13:17:24Z`

_Body auto-managed by `/git-session-start` + `/git-session-commit` (refreshes after every push)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable primary locale support for Android store listings, defaulting to English (United States).
  - Store metadata and screenshots now use the configured locale consistently.

- **Bug Fixes**
  - Improved Android signing configuration across forked builds.
  - Enhanced iOS CI keychain handling with safer temporary credentials and more predictable local behavior.

- **Documentation**
  - Added configuration guidance for setting the primary store-listing locale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->