### PR TITLE
feat(designsystem): add optional testTag to TopAppBarAction

### DIFF
--- a/core-base/designsystem/src/commonMain/kotlin/kpt/core/base/designsystem/component/KptTopAppBar.kt
+++ b/core-base/designsystem/src/commonMain/kotlin/kpt/core/base/designsystem/component/KptTopAppBar.kt
@@ -93,6 +93,7 @@ fun KptTopAppBar(configuration: KptTopAppBarConfiguration) {
             IconButton(
                 onClick = action.onClick,
                 enabled = action.enabled,
+                modifier = action.testTag?.let { Modifier.testTag(it) } ?: Modifier,
             ) {
                 Icon(
                     imageVector = action.icon,

--- a/core-base/designsystem/src/commonMain/kotlin/kpt/core/base/designsystem/core/KptTopAppBarConfiguration.kt
+++ b/core-base/designsystem/src/commonMain/kotlin/kpt/core/base/designsystem/core/KptTopAppBarConfiguration.kt
@@ -133,6 +133,9 @@ data class KptTopAppBarConfiguration(
  * @param contentDescription Accessibility description for screen readers
  * @param onClick Callback invoked when the action is clicked
  * @param enabled Whether the action button is enabled and clickable
+ * @param testTag Optional stable test tag applied to the action's IconButton so UI/E2E
+ *   tests (Maestro, runComposeUiTest) can select it deterministically; null keeps the
+ *   prior behaviour (the action carries only its contentDescription)
  *
  * @see KptTopAppBarConfiguration
  */
@@ -141,6 +144,7 @@ data class TopAppBarAction(
     val contentDescription: String,
     val onClick: () -> Unit,
     val enabled: Boolean = true,
+    val testTag: String? = null,
 )
 
 @DslMarker


### PR DESCRIPTION
## Summary

`TopAppBarAction` (the shared top-app-bar action config in `core-base/designsystem`) exposed **no test-tag slot**, so every top-bar action across every consumer (search / overflow / notification / custom icons) was **un-selectable by UI/E2E tests** — forcing brittle `contentDescription` / point-tap fallbacks in Maestro flows and `runComposeUiTest`.

This adds an optional `testTag` to the action and applies it to the rendered `IconButton`.

## Change

- `TopAppBarAction` — new optional field `val testTag: String? = null` (documented via `@param`).
- `KptTopAppBar` — the actions `IconButton` now applies `Modifier.testTag(action.testTag)` when non-null.

**Fully backward-compatible / additive:** when `testTag` is null (the default), behaviour is unchanged — the action carries only its `contentDescription`, exactly as before. No existing call site changes.

## Why it matters

A consumer that wants to E2E-test a top-bar action can now pass a stable tag:

```kotlin
TopAppBarAction(
    icon = Icons.Filled.GroupAdd,
    contentDescription = inviteCd,
    onClick = { … },
    testTag = "member_list_invite_action", // ← now selectable by Maestro / runComposeUiTest
)
```

**Device-truth motivation:** in a downstream fork, a top-bar invite action could not be tapped by its declared test tag until this slot existed — the tag was defined but had nowhere to be applied. This benefits every template consumer that E2E-tests a top-bar action.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional stable test tags for top app bar action buttons, enabling more reliable UI test targeting.
  * Existing actions without a test tag continue to work unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->