### PR TITLE
fix(core-base/store): gate CACHE_FIRST_SWR background revalidation on connectivity

### DIFF
--- a/core-base/store/src/commonMain/kotlin/kpt/core/base/store/screen/ScreenDataStream.kt
+++ b/core-base/store/src/commonMain/kotlin/kpt/core/base/store/screen/ScreenDataStream.kt
@@ -376,7 +376,13 @@ fun <Key : Any, Output : Any> Store<Key, Output>.asScreenStream(
                 )
                 val isStale = band == FreshnessBand.Stale || band == FreshnessBand.VeryStale
                 val wasStale = lastBand == FreshnessBand.Stale || lastBand == FreshnessBand.VeryStale
-                if (isStale && !wasStale) {
+                // Gate the SWR revalidation on ONLINE: never fire a doomed background fetch
+                // while offline (or on a falsely-'Available' no-plan / captive-portal link). This
+                // side-fetch is already decoupled from rendering, so offline it only wastes a
+                // guaranteed-to-fail network attempt (and can leave a spurious error stamp). The
+                // reconnect trigger re-emits storeFlow, so the gate re-fires once the network is back.
+                val isOnline = networkStatusFlow.value is NetworkStatus.Available
+                if (isOnline && isStale && !wasStale) {
                     scope.launch {
                         try {
                             this@asScreenStream
@@ -576,7 +582,13 @@ fun <Key : Any, Output : Any> Store<Key, Output>.asScreenStream(
                 )
                 val isStale = band == FreshnessBand.Stale || band == FreshnessBand.VeryStale
                 val wasStale = lastBand == FreshnessBand.Stale || lastBand == FreshnessBand.VeryStale
-                if (isStale && !wasStale) {
+                // Gate the SWR revalidation on ONLINE: never fire a doomed background fetch
+                // while offline (or on a falsely-'Available' no-plan / captive-portal link). This
+                // side-fetch is already decoupled from rendering, so offline it only wastes a
+                // guaranteed-to-fail network attempt (and can leave a spurious error stamp). The
+                // reconnect trigger re-emits storeFlow, so the gate re-fires once the network is back.
+                val isOnline = networkStatusFlow.value is NetworkStatus.Available
+                if (isOnline && isStale && !wasStale) {
                     val revalidateKey = lastObservedKey
                     val revalidateCacheKey = currentCacheKey
                     if (revalidateKey != null && revalidateCacheKey != null) {


### PR DESCRIPTION
## Summary

Gate the `CACHE_FIRST_SWR` background revalidation in `asScreenStream` on connectivity, so the stale-while-revalidate side-fetch is only launched when the device is actually online.

Both `asScreenStream` overloads (single-key and dynamic-key) previously fired the stale-edge revalidation purely on the freshness transition:

```kotlin
if (isStale && !wasStale) { /* launch stream(StoreReadRequest.fresh(...)) */ }
```

This runs regardless of network state. While offline — or on a link that *reports* `Available` but has no real reachability (a no-plan SIM, a captive portal) — it launches a guaranteed-to-fail background fetch. That wastes a network attempt and can leave a spurious error stamp on the store, which in turn pushes the freshness band further stale.

The fix reads the current `NetworkStatus` snapshot and gates the side-fetch on it:

```kotlin
val isOnline = networkStatusFlow.value is NetworkStatus.Available
if (isOnline && isStale && !wasStale) { ... }
```

## Why this is safe

- **Rendering is unaffected.** The screen state comes from the separate `combine(storeFlow, networkStatusFlow) → DecisionEngine.decide` flow (with `onStart { emit NoNetwork }` when offline). This gate touches only the background *fetch* decision, never what the UI shows — the cache is still served exactly as before.
- **No change when online.** When online, `isOnline == true`, so the condition collapses to the original `isStale && !wasStale`. Stale data still revalidates in the background identically.
- **Nothing is lost offline.** The reconnect trigger re-emits `storeFlow` on `Unavailable → Available`, so the gate re-evaluates and fires the deferred revalidation the moment connectivity returns.

This is a defensive-efficiency improvement (skip a doomed offline revalidation), not a bug fix for a user-visible symptom — the decoupled render path already prevents a stuck-loading state.

## Changes

- `core-base/store/.../screen/ScreenDataStream.kt` — add an `isOnline` guard to the `CACHE_FIRST_SWR` band-gate side-fetch in both `asScreenStream` overloads (`+14 −2`).

## Notes

- Framework-shared `core-base/**` change — benefits every template consumer using `CACHE_FIRST_SWR`.
- The one red check (**Kover Coverage**) is the pre-existing `worker-kmp` configuration-cache flake (`workerKmpAppCodegen*` tasks capturing `Project`), unrelated to this one-file `commonMain` change.
