### PR TITLE
docs(deployment): fix invalid --fastlane-dir Fastlane invocation

### DIFF
--- a/deployment/Appfile
+++ b/deployment/Appfile
@@ -3,7 +3,7 @@
 # Identity values read from FastlaneConfig, which parses gradle/libs.versions.toml.
 # config.rb is imported by Fastfile before this file is evaluated.
 #
-# Entry point: bundle exec fastlane --fastlane-dir deployment <platform> <lane>
+# Entry point: cd deployment && bundle exec fastlane <platform> <lane>
 
 # Android
 json_key_file(FastlaneConfig::ProjectConfig::ANDROID[:play_store_json_key])

--- a/deployment/BOOTSTRAP.md
+++ b/deployment/BOOTSTRAP.md
@@ -9,7 +9,7 @@ one that matches your team's secret-management posture.
 
 > ⚠️  **Seeing `/release: command not found`?** You're on the OSS-fork path
 > (you don't have the `claude-product-cycle` framework cloned). That's
-> expected — use `bundle exec fastlane --fastlane-dir deployment <lane>`
+> expected — use `cd deployment && bundle exec fastlane <lane>`
 > instead. See **Path A** below for the canonical OSS-fork commands.
 >
 > Optional convenience: `source deployment/_shared/scripts/release-fallback.sh`
@@ -46,8 +46,8 @@ point for Path A. Use these primary invocations instead:
 
 ```bash
 # Local deploy (developer's machine — runs Fastlane directly)
-bundle exec fastlane --fastlane-dir deployment android deployInternal
-bundle exec fastlane --fastlane-dir deployment ios release
+cd deployment && bundle exec fastlane android deployInternal
+cd deployment && bundle exec fastlane ios release
 bash deployment/web/cloudflare-pages/script.sh   # non-Fastlane targets ship script.sh
 
 # CI deploy (GitHub Actions on push or workflow_dispatch)
@@ -110,7 +110,7 @@ vault preflight + PROMOTION_LOG audit but is **NOT** required for Path A.
 
 ```bash
 # Local
-bundle exec fastlane --fastlane-dir deployment android deployReleaseApkOnFirebase
+cd deployment && bundle exec fastlane android deployReleaseApkOnFirebase
 
 # CI
 gh workflow run release-android.yml -f target=firebase-app-distribution
@@ -125,7 +125,7 @@ Required secrets (from `deployment/android/firebase-app-distribution/secrets-nee
 
 ```bash
 # Local (requires Xcode + CocoaPods)
-bundle exec fastlane --fastlane-dir deployment ios beta
+cd deployment && bundle exec fastlane ios beta
 
 # CI
 gh workflow run release-ios.yml -f target=testflight
@@ -291,7 +291,7 @@ What `/release` does:
   computes the capability id (e.g. `android-firebase-app-distribution`).
 - Runs `/secrets verify --required-for android-firebase-app-distribution`.
   PASS → proceeds; FAIL → halts with the missing alias list.
-- Dispatches `bundle exec fastlane --fastlane-dir deployment android
+- Dispatches `cd deployment && bundle exec fastlane android
   deployReleaseApkOnFirebase`.
 - On success, appends a row to `PROMOTION_LOG.yaml` with timestamp, target,
   mode (`vault`), git-sha, fastlane exit code, lane.rb sha, secrets-needs
@@ -351,7 +351,7 @@ admin to push. Once the upstream tags land, a follow-up PR (the
    6 PR Check jobs to confirm green on the post-deletion tree.
 
 Until then, the per-target deployment dirs are **functionally complete** —
-direct `bundle exec fastlane --fastlane-dir deployment <lane>` invocations
+direct `cd deployment && bundle exec fastlane <lane>` invocations
 work against the new tree right now. The legacy `fastlane/` block exists
 only as a fallback for unmigrated callers.
 


### PR DESCRIPTION
## Summary

Fix the deployment docs to use a valid Fastlane invocation. `deployment/BOOTSTRAP.md` and `deployment/Appfile` document the entry point as `bundle exec fastlane --fastlane-dir deployment <lane>`, but **`--fastlane-dir` is not a valid Fastlane option** — Fastlane 2.235 rejects it with `invalid option: --fastlane-dir`. (The `deployment/Fastfile` header already notes this: *"--fastlane-dir flag does NOT exist in Fastlane 2.235.0 (doc bug)"*.)

Replace with the working, already-documented form (`deployment/BOOTSTRAP.md` line 154 uses it):

```diff
-bundle exec fastlane --fastlane-dir deployment <platform> <lane>
+cd deployment && bundle exec fastlane <platform> <lane>
```

Running from `deployment/` lets Fastlane discover `deployment/fastlane/Fastfile` (which imports the per-target lanes) and uses `deployment/Gemfile`.

## Why it matters

Anyone following BOOTSTRAP.md verbatim hits `invalid option: --fastlane-dir` on the first deploy. This was hit live promoting a fork's Play Store release (internal → beta); the promote lane only ran once switched to `cd deployment && bundle exec fastlane android promoteToBeta`.

## Change

- `deployment/BOOTSTRAP.md` — 7 invocations corrected
- `deployment/Appfile` — entry-point comment corrected

Docs-only; no lane/config behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment instructions and examples to run Fastlane from the `deployment` directory.
  * Standardized documented deployment commands for local use, Path B, and migration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->