### PR TITLE
[WIP] feat(template): .template-version marker linking a tree to its last template sync

### DIFF
--- a/.template-version
+++ b/.template-version
@@ -1,0 +1,15 @@
+# .template-version — the openMF/kmp-project-template state this working tree corresponds to.
+#
+# In the TEMPLATE repo (openMF/kmp-project-template) this is the release baseline the tree
+# corresponds to. In a FORK it is the template commit the fork last synced FROM — updated
+# automatically by scripts/white-label/sync-dirs.sh on every /kmp-project-template-sync.
+#
+# DO NOT hand-edit. It lets a fork tell whether it is behind the template (compare template_sha
+# against the template's latest release) and anchors the next sync's 3-way merge base.
+#
+# Format: bash-parseable `key=value` (same convention as gradle/fork.properties).
+template_repo=openMF/kmp-project-template
+template_ref=dev
+template_sha=81d0cc6f952346a76be52cd5f74c1fd4999cb221
+template_tag=
+synced_at=2026-08-15T00:00:00Z

--- a/customization-surface.yaml
+++ b/customization-surface.yaml
@@ -61,6 +61,11 @@ rules:
   # settings.gradle.kts applies it via `apply(from = ...)` and stays full-copy / include-union.
   - glob: "settings.local.gradle.kts"
     owner: fork
+  # Template-sync version marker: records the template commit this fork last synced from. Written by
+  # scripts/white-label/sync-dirs.sh on every sync, so it is FORK-OWNED — a template dir-copy must
+  # never overwrite a fork's own last-synced pointer with the template's.
+  - glob: ".template-version"
+    owner: fork
   # Root navigation host: template owns the scaffold; forks wire feature routes in.
   - glob: "cmp-navigation/**/*Navigation*.kt"
     owner: merge

--- a/scripts/white-label/sync-dirs.sh
+++ b/scripts/white-label/sync-dirs.sh
@@ -1084,6 +1084,28 @@ if [ "$DRY_RUN" = false ]; then
     git branch -D "$TEMP_BRANCH" || handle_error "Failed to delete temporary branch"
     show_progress
 
+    # Record which template commit this sync pulled from. This is the whole point of the
+    # `.template-version` marker: a fork can tell whether it is behind the template (compare
+    # template_sha against the template's latest release) and the NEXT sync can anchor its 3-way
+    # merge base on this exact point instead of git's guessed common ancestor. Written here (before
+    # the commit gate) so a version-only bump still commits; the file is fork-owned
+    # (customization-surface.yaml owner: fork) so a template dir-copy never clobbers it.
+    print_step "Recording template sync version (.template-version)..."
+    _tv_sha="$(git rev-parse "$TEMPLATE_REMOTE/$BASE_BRANCH" 2>/dev/null || echo "")"
+    _tv_tag="$(git describe --tags --exact-match "$_tv_sha" 2>/dev/null || echo "")"
+    {
+        echo "# .template-version — the openMF/kmp-project-template commit this tree last synced from."
+        echo "# Managed by scripts/white-label/sync-dirs.sh — DO NOT hand-edit."
+        echo "# Format: bash-parseable key=value (same convention as gradle/fork.properties)."
+        echo "template_repo=openMF/kmp-project-template"
+        echo "template_ref=$BASE_BRANCH"
+        echo "template_sha=$_tv_sha"
+        echo "template_tag=$_tv_tag"
+        echo "synced_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    } > .template-version
+    git add .template-version 2>/dev/null || true
+    show_progress
+
     # Check for changes
     if ! git diff --quiet --exit-code --cached; then
         print_step "Committing changes..."


### PR DESCRIPTION
Introduces a committed `.template-version` marker (key=value, fork.properties-style) at the template root so every consumer inherits it. It records the openMF/kmp-project-template commit a tree corresponds to — in a fork, the commit last synced FROM. scripts/white-label/sync-dirs.sh now writes it (synced SHA/ref/tag + timestamp) on every /kmp-project-template-sync, and customization-surface.yaml marks it owner: fork so a template dir-copy never clobbers a fork's pointer. Foundation for behind/ahead checks + anchoring the next sync's 3-way merge base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metadata tracking for the template source, branch, commit, tag, and synchronization time.
  * Added documentation describing the metadata format and automatic update behavior.

* **Chores**
  * Updated synchronization handling to preserve the project-owned metadata during template updates.
  * Automatically records and stages synchronization details after updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->