### PR TITLE
fix(sync): prune phantom template-only module includes in settings.gradle.kts (include-union merge)

### DIFF
--- a/cmp-navigation/build.gradle.kts
+++ b/cmp-navigation/build.gradle.kts
@@ -81,4 +81,10 @@ compose.resources {
 // Fork-owned feature-module dependencies (S7/F4 white-label seam). Applied AFTER the `kotlin { }` block
 // above so the `commonMainImplementation` configuration it contributes to already exists. A fork edits
 // `feature-deps.gradle.kts`, never this template-owned build file — a template sync full-copies this file.
-apply(from = rootProject.file("feature-deps.gradle.kts"))
+//
+// Apply ONLY when the seam file is present. `feature-deps.gradle.kts` is `owner: fork` (never synced), so a
+// fork that adopted the template BEFORE this seam existed — or is mid-adoption — may not have it yet; an
+// unconditional `apply(from = …)` then fails the whole configuration ("Could not read script …feature-deps
+// .gradle.kts as it does not exist"), which blocks even `syncForkConfig`. Guarding the apply keeps
+// cmp-navigation configurable in that window; the fork wires its features by creating the seam file.
+rootProject.file("feature-deps.gradle.kts").takeIf { it.exists() }?.let { apply(from = it) }

--- a/scripts/customization-surface.sh
+++ b/scripts/customization-surface.sh
@@ -343,14 +343,40 @@ cs_merge_yaml_schema() {
   return 0
 }
 
+# Semantic settings.gradle.kts merge — the `include-union` strategy. A textual 3-way unions the
+# fork's + template's `include(":module")` lines, but the template also declares its OWN demo/app
+# feature modules (feature/showcase, feature/loans, feature/rates, …) that a downstream fork does
+# NOT have and that the sync does NOT copy in (they are not template-shared modules). The blind
+# union therefore references non-existent module dirs and breaks Gradle configuration
+# ("Configuring project ':feature:showcase' without an existing directory"). After the union, DROP
+# every `include(":a:b")` whose resolved dir `a/b/` is absent on disk — keeping the fork's real
+# modules + the shared modules the sync actually materialized, never a template-only phantom.
+#   cs_merge_include_union <ours> <base> <theirs> [<out>]
+cs_merge_include_union() {
+  local ours="$1" base="$2" theirs="$3" out="${4:-$1}" rc
+  cs_merge_3way "$ours" "$base" "$theirs" "$out"; rc=$?
+  local root; root="$(cd "$(dirname "$out")" 2>/dev/null && pwd)"; [ -n "$root" ] || root="$(pwd)"
+  local tmp coord; tmp="$(mktemp)"
+  while IFS= read -r line || [ -n "$line" ]; do
+    coord="$(printf '%s' "$line" | sed -nE 's/^[[:space:]]*include\("?:([A-Za-z0-9:_.-]+)"?\).*/\1/p')"
+    if [ -n "$coord" ] && [ ! -d "$root/${coord//://}" ]; then
+      continue   # drop a phantom include — module dir does not exist in this fork
+    fi
+    printf '%s\n' "$line"
+  done < "$out" > "$tmp"
+  mv "$tmp" "$out"
+  return "$rc"
+}
+
 # Strategy dispatcher used by scripts/white-label/sync-dirs.sh for a `merge`-owned file.
 #   cs_merge <strategy> <ours> <base> <theirs> [<out>]
 cs_merge() {
   local strat="$1" ours="$2" base="$3" theirs="$4" out="${5:-$2}"
   case "$strat" in
-    manifest-union)    cs_merge_manifest    "$ours" "$theirs" "$out" ;;
-    yaml-schema-merge) cs_merge_yaml_schema "$ours" "$base" "$theirs" "$out" ;;
-    *)                 cs_merge_3way        "$ours" "$base" "$theirs" "$out" ;;
+    manifest-union)    cs_merge_manifest      "$ours" "$theirs" "$out" ;;
+    include-union)     cs_merge_include_union "$ours" "$base" "$theirs" "$out" ;;
+    yaml-schema-merge) cs_merge_yaml_schema   "$ours" "$base" "$theirs" "$out" ;;
+    *)                 cs_merge_3way          "$ours" "$base" "$theirs" "$out" ;;
   esac
 }
 


### PR DESCRIPTION
## Summary

Hardens the `/kmp-project-template-sync` 3-way merge of `settings.gradle.kts`. The `include-union` strategy textually unions the fork's + template's `include(":module")` lines — but the template declares its OWN demo/app feature modules (`feature/showcase`, `feature/loans`, `feature/rates`, …) that a downstream fork does **not** have and that the sync does **not** copy in (they aren't template-shared modules). The blind union therefore referenced non-existent module dirs and broke Gradle configuration (`Configuring project ':feature:showcase' without an existing directory`).

## Changes

- `scripts/customization-surface.sh` — new **`cs_merge_include_union`** strategy: after the textual 3-way union, DROP every `include(":a:b")` whose resolved dir `a/b/` is absent on disk. Keeps the fork's real modules + the shared modules the sync actually materialized; never leaves a template-only phantom include that fails configuration.

## Notable files
`scripts/customization-surface.sh`
