### PR TITLE
fix(white-label): correct CS_READER path depth in sync-dirs.sh advisory sourcing

### DIFF
--- a/scripts/white-label/sync-dirs.sh
+++ b/scripts/white-label/sync-dirs.sh
@@ -986,8 +986,8 @@ fi
 # preserves fork edits (e.g. AndroidManifest permissions). The mechanical sync
 # below is UNCHANGED — the contract is the declared source of truth the merge
 # engine adopts next. Fully guarded so it can never abort a sync.
-CS_READER="$(dirname "$0")/scripts/customization-surface.sh"
-if [ -f "$CS_READER" ] && [ -f "$(dirname "$0")/customization-surface.yaml" ]; then
+CS_READER="$SCRIPT_DIR/../customization-surface.sh"
+if [ -f "$CS_READER" ] && [ -f "$SCRIPT_DIR/../../customization-surface.yaml" ]; then
     # shellcheck source=/dev/null
     source "$CS_READER" 2>/dev/null || true
     if declare -F cs_match_g >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

The customization-surface advisory block in `scripts/white-label/sync-dirs.sh` sources the
fork-ownership reader from `$(dirname "$0")/scripts/customization-surface.sh` and checks for
`$(dirname "$0")/customization-surface.yaml`. Since `$0` resolves to
`scripts/white-label/sync-dirs.sh`, `dirname("$0")` is `scripts/white-label/` — one level too
deep for the reader script (lives at `scripts/customization-surface.sh`) and two levels too
deep for the yaml contract (lives at the repo root).

This block is what sources `cs_match_g`/`cs_merge` into the running shell for the rest of the
sync. With the broken paths, both existence checks fail, so those functions are **never
declared** — every `owner: merge` file in `customization-surface.yaml` (AndroidManifest.xml,
build.gradle.kts files, KoinModules.kt, RootNavScreen.kt, etc.) then falls through
`sync_directory()`'s inline merge check to a blind template overwrite instead of a real 3-way
merge.

## Repro

Reproducible on any fork whose base branch predates the merge-protection contract files
(`customization-surface.yaml` + `scripts/customization-surface.sh`) — e.g. a fork mid a
white-label-adoption PR that hasn't merged to its default branch yet, or any fork running the
STEP-0-BOOTSTRAP self-materialization path. Observed concretely on a downstream fork: a full
sync silently dropped CAMERA/storage permissions from AndroidManifest.xml and the fork's entire
DI surface (RepositoryModule, DomainModule, passcode wiring) from KoinModules.kt, with no
warning — the sync reported success.

## Fix

Use `$SCRIPT_DIR`-relative paths at the correct depth for each file's real location, matching
the pattern already used correctly elsewhere in this same file (e.g. `is_excluded()`'s own
contract-driven check already does `$SCRIPT_DIR/../customization-surface.sh` correctly).

```diff
-CS_READER="$(dirname "$0")/scripts/customization-surface.sh"
-if [ -f "$CS_READER" ] && [ -f "$(dirname "$0")/customization-surface.yaml" ]; then
+CS_READER="$SCRIPT_DIR/../customization-surface.sh"
+if [ -f "$CS_READER" ] && [ -f "$SCRIPT_DIR/../../customization-surface.yaml" ]; then
```

## Test plan

- [x] Verified the reader's functions (cs_match_g, cs_merge) are declared after sourcing with
      the corrected paths, invoked exactly as sync-dirs.sh invokes them
- [x] Re-ran a full --force sync on a fork with disjoint git history from the template; the
      "Fork-ownership contract" advisory now correctly lists all owner: merge paths and the
      per-directory merge routing produces real Merged (kotlin-3way|manifest-union|strings-union)
      output for them instead of silent blind overwrites
- [x] `./gradlew spotlessCheck detekt` clean on this branch

Related but independent: #292 already fixes a different bug in the same merge subsystem
(phantom `include(...)` lines surviving the `include-union` strategy) — that PR does not touch
this file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of white-label synchronization checks when the script is run from different directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->