### PR TITLE
fix(template): template-settings-include-union-real-fn-prune

### DIFF
--- a/scripts/white-label/sync-dirs.sh
+++ b/scripts/white-label/sync-dirs.sh
@@ -409,6 +409,22 @@ merge_settings_include_union() {
         fi
         print_step "include-union: preserved $(printf '%s\n' "$fork_only" | grep -c . ) fork-local module include(s) in ${BOLD}$(basename "$out")${NC}"
     fi
+    # Prune PHANTOM includes: the union starts from the TEMPLATE file, which declares the template's OWN
+    # demo/app feature modules (feature/showcase, feature/loans, feature/rates, …) that a downstream fork
+    # does NOT have and the sync does NOT copy in. Left in, they reference non-existent module dirs and
+    # Gradle configuration hard-fails ("Configuring project ':feature:showcase' without an existing
+    # directory"), blocking even syncForkConfig. Drop every include(":a:b") whose resolved dir a/b/ is
+    # absent on disk (relative to the settings.gradle.kts dir) — keep the fork's real + synced modules.
+    local _iu_root _iu_out _iu_dropped=0 _iu_coord
+    _iu_root="$(cd "$(dirname "$out")" 2>/dev/null && pwd)"; [ -n "$_iu_root" ] || _iu_root="$(pwd)"
+    _iu_out="$(mktemp)"
+    while IFS= read -r _iu_line || [ -n "$_iu_line" ]; do
+        _iu_coord="$(printf '%s' "$_iu_line" | sed -nE 's/^[[:space:]]*include\("?:([A-Za-z0-9:_.-]+)"?\).*/\1/p')"
+        if [ -n "$_iu_coord" ] && [ ! -d "$_iu_root/${_iu_coord//://}" ]; then _iu_dropped=$((_iu_dropped + 1)); continue; fi
+        printf '%s\n' "$_iu_line"
+    done < "$tmp" > "$_iu_out"
+    mv "$_iu_out" "$tmp"
+    [ "$_iu_dropped" -gt 0 ] && print_step "include-union: pruned ${BOLD}$_iu_dropped${NC} phantom include(s) (module dir absent in this fork) from ${BOLD}$(basename "$out")${NC}"
     mv "$tmp" "$out"
     return 0
 }


### PR DESCRIPTION
TEMPLATE-DERIVED upstream fix (RULE-TEMPLATE-MODULE-FIX-UPSTREAM-001). DRAFT — human review + merge at openMF/kmp-project-template. Do not auto-merge.