### PR TITLE
fix(ci): guard the empty successful_tasks expansion in ci-prepush.sh

### DIFF
--- a/ci-prepush.sh
+++ b/ci-prepush.sh
@@ -231,7 +231,7 @@ else
 fi
 echo "──────────────────────────────────────────────"
 echo "Successful tasks: ${#successful_tasks[@]}"
-for t in "${successful_tasks[@]}"; do echo "  ✅ $t"; done
+for t in ${successful_tasks[@]+"${successful_tasks[@]}"}; do echo "  ✅ $t"; done
 
 if [ "${#healed_tasks[@]}" -gt 0 ]; then
     echo ""


### PR DESCRIPTION
### What is wrong

`ci-prepush.sh` runs under `set -uo pipefail` (line 43). On bash 3.2, which is still `/bin/bash` on macOS, expanding an empty array as `"${arr[@]}"` raises `unbound variable`.

`successful_tasks` is empty whenever every task fails, and the loop at line 234 is not behind a count check the way the `healed` and `failed` loops are:

```bash
echo "Successful tasks: ${#successful_tasks[@]}"
for t in "${successful_tasks[@]}"; do echo "  ✅ $t"; done   # line 234, unguarded

if [ "${#healed_tasks[@]}" -gt 0 ]; then                      # guarded
if [ "${#failed_tasks[@]}" -gt 0 ]; then                      # guarded
```

So the summary aborts at line 234 and the `Failed tasks` section below it never prints. The script dies exactly when it has something useful to report, and the contributor is left without the reason.

### Reproduction

```
$ bash --version   # GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)

before:
  Successful tasks: 0
  /bin/bash: successful_tasks[@]: unbound variable

after:
  Successful tasks: 0
  Failed tasks: 1
    ❌ detekt
```

### Changes

- `ci-prepush.sh:234` guard the expansion with `${successful_tasks[@]+"${successful_tasks[@]}"}`

That is the same idiom already used in this repo at `sync-dirs.sh:934`, so it matches surrounding style rather than introducing a new pattern. `bash -n` passes on the modified file. The `healed` and `failed` loops are left alone since their `-gt 0` guards already make them safe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed pre-push checks failing with an “unbound variable” error when no tasks complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->