### PR TITLE
fix(sync, store): repair the white-label merge engine (owner: merge never ran) + fix offline-first NoNetwork on iOS

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -60,6 +60,20 @@ jobs:
         with:
           bundler-cache: false
 
+      # xcodeproj — the ONLY gem this job needs, and it is needed for one reason: without it the
+      # pbxproj-merge canary cannot exercise scripts/white-label/merge-pbxproj.rb and downgrades
+      # itself to a WARN. That check is what stops a regression in the Xcode-project 3-way from
+      # reaching a fork, where the symptom is a silently deleted target rather than a build error,
+      # so leaving it unexercised upstream would make it decorative exactly where it matters.
+      #
+      # `gem install` rather than `bundler-cache: true`: bundler would install the whole fastlane
+      # tree (~1-2 min) for a job that is otherwise ~10s. xcodeproj pulls only CFPropertyList /
+      # nanaimo / claide / colored2 / atomos and adds a few seconds. `|| true` keeps a transient
+      # rubygems outage from failing the quality gate on something this job can degrade around —
+      # the check WARNs on its own when the gem is missing.
+      - name: Install xcodeproj (pbxproj-merge canary only)
+        run: gem install xcodeproj --no-document || true
+
       - name: Derive fork.properties from app-profile (SoT → build bridge)
         run: ruby scripts/white-label/derive.rb
 

--- a/core-base/store/src/commonMain/kotlin/kpt/core/base/store/error/ErrorCategory.kt
+++ b/core-base/store/src/commonMain/kotlin/kpt/core/base/store/error/ErrorCategory.kt
@@ -120,13 +120,40 @@ private fun Throwable.messageChain(): Sequence<String> = sequence {
     }
 }
 
+/**
+ * Transport-failure class names, matched on the class-name chain.
+ *
+ * The list is NAME-based because this is commonMain — there is no shared supertype to test against
+ * (`java.io.IOException` does not exist on iOS or Web). That makes coverage a question of evidence,
+ * not intuition: an engine whose exception happens not to contain one of these substrings silently
+ * categorizes Generic, and `DecisionEngine.isExpectedWhenOffline()` then refuses the offline-first
+ * rule and shows a blocking NoNetwork on a screen that should have shown its own Empty.
+ *
+ * Two such holes were measured rather than guessed:
+ *
+ *  - `HttpRequestException` — Ktor's Darwin engine (iOS/macOS) raises `DarwinHttpRequestException`
+ *    (and the deprecated `IosHttpRequestException`) for a transport failure, wrapping the NSError.
+ *    Confirmed against the cached `ktor-client-darwin` 3.2.1 klib. The NSError is a PROPERTY, not a
+ *    `cause`, so the chain never reaches its "offline" text. Matching the `HttpRequestException`
+ *    suffix is deliberately narrow: Ktor reports HTTP STATUS failures as `ClientRequestException` /
+ *    `ServerResponseException`, neither of which contains it, so a 500 stays real signal.
+ *  - `Socket` — `java.net.SocketException` IS an IOException subclass, but a name match cannot see
+ *    that, and "SocketException" contains none of the original six patterns. A dropped connection
+ *    on JVM/Android categorized Generic while its sibling `SocketTimeoutException` matched via
+ *    "Timeout" — an inconsistency nothing in the API surface hinted at.
+ *
+ * Each entry above is pinned by a case in ErrorCategoryTest, including a negative one asserting
+ * `ServerResponseException` does NOT become Network.
+ */
 private fun String.matchesNetworkClassName(): Boolean =
     contains("IOException", ignoreCase = true) ||
         contains("Connect", ignoreCase = true) ||
         contains("Timeout", ignoreCase = true) ||
         contains("UnknownHost", ignoreCase = true) ||
         contains("SSLException", ignoreCase = true) ||
-        contains("Offline", ignoreCase = true)
+        contains("Offline", ignoreCase = true) ||
+        contains("HttpRequestException", ignoreCase = true) ||
+        contains("Socket", ignoreCase = true)
 
 /**
  * Matches any 3-digit HTTP status code in a message, optionally preceded by `HTTP `.

--- a/core-base/store/src/commonTest/kotlin/kpt/core/base/store/error/ErrorCategoryTest.kt
+++ b/core-base/store/src/commonTest/kotlin/kpt/core/base/store/error/ErrorCategoryTest.kt
@@ -11,6 +11,7 @@ package kpt.core.base.store.error
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 
@@ -32,6 +33,66 @@ class ErrorCategoryTest {
         assertEquals(
             ErrorCategory.Network,
             categorize(IOException("disconnect")),
+        )
+    }
+
+    // ─── REAL engine exception names ────────────────────────────────────────
+    // The cases above use invented names that obviously contain the matched substrings. These use
+    // the names the transport layers ACTUALLY throw, which is the only thing that decides whether a
+    // real offline device gets the offline-first Empty or a blocking NoNetwork.
+
+    @Test
+    fun categorize_ktorDarwinTransportFailure_returnsNetwork() {
+        // Ktor's Darwin engine (iOS/macOS — `ktor-client-darwin`, wired in libs.versions.toml) raises
+        // `DarwinHttpRequestException` for a TRANSPORT failure, wrapping the NSError. Verified
+        // against the cached klib for ktor-client-darwin 3.2.1, which declares exactly
+        // `DarwinHttpRequestException` and the deprecated `IosHttpRequestException`.
+        //
+        // The NSError is a PROPERTY of that exception, not its `cause`, so classNameChain() stops at
+        // the Darwin name and never sees "offline". None of IOException / Connect / Timeout /
+        // UnknownHost / SSLException / Offline appears in it — so before this case it categorized
+        // Generic, `isExpectedWhenOffline()` rejected it, and DecisionEngine fell through to a
+        // blocking NoNetwork. That is the exact user-facing bug the offline-first rule exists to
+        // prevent, reachable on every iOS cold start with an empty cache.
+        class DarwinHttpRequestException : RuntimeException()
+        assertEquals(
+            ErrorCategory.Network,
+            categorize(DarwinHttpRequestException()),
+        )
+    }
+
+    @Test
+    fun categorize_ktorDarwinLegacyName_returnsNetwork() {
+        class IosHttpRequestException : RuntimeException()
+        assertEquals(
+            ErrorCategory.Network,
+            categorize(IosHttpRequestException()),
+        )
+    }
+
+    @Test
+    fun categorize_socketException_returnsNetwork() {
+        // java.net.SocketException IS an IOException subclass, but categorize() matches on the NAME,
+        // not the type — and "SocketException" contains none of the six patterns. A dropped
+        // connection on JVM/Android therefore categorized Generic while its sibling
+        // SocketTimeoutException matched (via "Timeout"), which is an inconsistency no caller could
+        // have predicted.
+        class SocketException : RuntimeException()
+        assertEquals(
+            ErrorCategory.Network,
+            categorize(SocketException()),
+        )
+    }
+
+    @Test
+    fun categorize_serverResponseException_staysNonNetwork() {
+        // Guard on the widening: Ktor reports HTTP STATUS failures as ResponseException subclasses,
+        // which must NOT become Network — a 500 is real signal from a reachable server, and calling
+        // it Network would let `isExpectedWhenOffline()` swallow it on an offline screen.
+        class ServerResponseException : RuntimeException()
+        assertNotEquals(
+            ErrorCategory.Network,
+            categorize(ServerResponseException()),
         )
     }
 

--- a/core-base/store/src/commonTest/kotlin/kpt/core/base/store/screen/ScreenDataStreamIntegrationTest.kt
+++ b/core-base/store/src/commonTest/kotlin/kpt/core/base/store/screen/ScreenDataStreamIntegrationTest.kt
@@ -110,12 +110,23 @@ class ScreenDataStreamIntegrationTest {
     @Test
     fun offline_with_empty_store_emits_Empty_offlineFirst() = runTest(timeout = runTestTimeout) {
         // asScreenStream's default policy is CACHE_FIRST_SWR (offline-first): offline with no cached
-        // data and no error surfaces the screen's own Empty state, NOT a blocking full-screen NoNetwork
-        // (DecisionEngine offline-first-empty rule; asserted in DecisionEngineTest "…CACHE_FIRST_SWR =
-        // Empty"). Offline CACHE_FIRST_SWR skips the network leg, so the throwing fetcher is never
-        // invoked and error stays null. Every other policy still shows NoNetwork offline.
+        // data surfaces the screen's own Empty state, NOT a blocking full-screen NoNetwork
+        // (DecisionEngine offline-first-empty rule; asserted deterministically in DecisionEngineTest
+        // "…NETWORK error + CACHE_FIRST_SWR = Empty — doomed fetch ignored").
+        //
+        // The fetcher throws an IOException-NAMED error because that is what an offline fetch really
+        // produces, and `categorize()` keys Network off the class-name chain, not the message. The
+        // old fixture threw a bare RuntimeException("no network"), which categorizes as Generic, so
+        // `isExpectedWhenOffline()` rejected it and DecisionEngine fell through to NoNetwork — the
+        // test then depended on whether the empty emission or the doomed fetch won the race: Empty
+        // on a fast machine, NoNetwork under Kover's instrumentation. The comment here used to claim
+        // "offline CACHE_FIRST_SWR skips the network leg, so the fetcher is never invoked and error
+        // stays null", which is precisely the assumption DecisionEngine documents as FALSE —
+        // Store5's `cached(key, refresh = false)` DOES invoke the fetcher when nothing is cached.
         val store = StoreBuilder
-            .from<String, String>(fetcher = Fetcher.of { _ -> throw RuntimeException("no network") })
+            .from<String, String>(
+                fetcher = Fetcher.of { _ -> throw FakeIOException("connection refused") },
+            )
             .build()
         val network = FakeNetworkMonitor(NetworkStatus.Unavailable)
         val stream = store.asScreenStream(
@@ -183,8 +194,21 @@ class ScreenDataStreamIntegrationTest {
 
     @Test
     fun reconnect_triggers_refresh_after_offline() = runTest(timeout = runTestTimeout) {
+        // The fetcher is connectivity-aware because a real one is: while the device is offline it
+        // MUST fail. The old fixture returned "refreshed" unconditionally, so the doomed offline
+        // fetch that Store5 issues on a cold cache (`cached(refresh = false)` invokes the fetcher
+        // when nothing is cached) SUCCEEDED — and the offline half of this test then asserted Empty
+        // against a stream that had legitimately reached Content. Fast machines emitted Empty first
+        // and passed; under Kover the fetch landed first and the assertion saw Content. Modelling
+        // the fetcher honestly makes both halves deterministic without touching either assertion.
+        var reachable = false
         val store = StoreBuilder
-            .from<String, String>(fetcher = Fetcher.of { _ -> "refreshed" })
+            .from<String, String>(
+                fetcher = Fetcher.of { _ ->
+                    if (!reachable) throw FakeIOException("connection refused")
+                    "refreshed"
+                },
+            )
             .build()
         val network = FakeNetworkMonitor(NetworkStatus.Unavailable)
 
@@ -204,7 +228,9 @@ class ScreenDataStreamIntegrationTest {
             while (state is ScreenState.Loading) { state = awaitItem() }
             assertIs<ScreenState.Empty>(state)
 
-            // Simulate reconnect
+            // Simulate reconnect — the fetcher becomes reachable at the same instant the monitor
+            // reports Available, so the refresh that the reconnect triggers can actually succeed.
+            reachable = true
             network.setStatus(NetworkStatus.Available(onlineInfo))
             advanceUntilIdle()
 
@@ -231,3 +257,11 @@ class ScreenDataStreamIntegrationTest {
         }
     }
 }
+
+/**
+ * An offline transport failure. The NAME is what matters: `categorize()` resolves
+ * [ErrorCategory.Network] from the class-name chain (it looks for "IOException"), never from the
+ * message — so a bare `RuntimeException("no network")` is Generic and does NOT get the offline-first
+ * treatment. Declared file-private, matching DecisionEngineTest and PagingScreenStreamDecisionParityTest.
+ */
+private class FakeIOException(message: String) : Exception(message)

--- a/customization-surface.yaml
+++ b/customization-surface.yaml
@@ -37,6 +37,30 @@
 version: 1
 
 rules:
+  # ── DEMO feature modules — declared before the merge-required globs below ──
+  # Same first-match accident as core-base. The repo-wide `**/composeResources/**/strings.xml → merge`
+  # rule below claims 280 strings.xml across the 14 DEMO feature modules (loans, bills, rates, …),
+  # while everything else in those same modules — their Kotlin, their build.gradle.kts — resolves
+  # `fork`. One module, two answers, and the strings half was never reachable anyway: demo modules are
+  # NOT in SYNC_DIRS (only the home/profile/settings BACKBONE is) and `remove-demo.sh --clean` deletes
+  # them outright. So the contract promised to sync 280 files the engine cannot fetch and the
+  # customizer will delete.
+  #
+  # The BACKBONE keeps `merge`: those three ARE synced, and a fork legitimately adds its own strings to
+  # home/profile/settings. Declared first so it wins over the demo rule that follows.
+  - glob: "feature/home/**/composeResources/**/strings.xml"
+    owner: merge
+    strategy: strings-union
+  - glob: "feature/profile/**/composeResources/**/strings.xml"
+    owner: merge
+    strategy: strings-union
+  - glob: "feature/settings/**/composeResources/**/strings.xml"
+    owner: merge
+    strategy: strings-union
+  # Every other feature module is the fork's / a demo's — its strings follow the module.
+  - glob: "feature/**/composeResources/**/strings.xml"
+    owner: fork
+
   # ── core-base is FRAMEWORK-SHARED — declared before the merge-required globs below ──
   # `core-base/**` resolves `template` further down, but the two merge-required rules that follow
   # are repo-WIDE (`**/AndroidManifest.xml`, `**/composeResources/**/strings.xml`) and first-match
@@ -846,6 +870,12 @@ rules:
   - { glob: "build.gradle.kts",              owner: template }
   - { glob: "kotlin-js-store/**",            owner: template }
   - { glob: "legal/**",                      owner: template }
+  # .swiftpm-locks — per-fork SwiftPM resolution state (Package.resolved + generated module maps,
+  # most of it already gitignored). It is BUILD OUTPUT keyed to the fork's own dependency graph,
+  # not template code, so syncing it would push one fork's resolution onto another. It had no rule
+  # and, once the catch-all flipped template-first, began resolving `template` — the one place that
+  # flip needed an explicit answer rather than the default.
+  - { glob: ".swiftpm-locks/**",             owner: fork }
   - { glob: "tests/**",                      owner: template }   # test harness — E0/T1 (closes the classification gap)
   # tools/*-ksp — the template's OWN codegen engine (store / database / network / data processors
   # that generate AppStoreRegistry, AppDatabase and the Generated*Bindings from the @StoreProvider /

--- a/customization-surface.yaml
+++ b/customization-surface.yaml
@@ -423,6 +423,35 @@ rules:
     owner: fork
   - glob: "cmp-ios/Configuration/Config.xcconfig"  # syncForkConfig-generated identity
     owner: fork
+  # project.pbxproj — a serialized OBJECT GRAPH, not a document. It inherits `merge` from the
+  # cmp-ios blanket below, but must NOT take the default line-based `git merge-file`: adding a
+  # target rewrites UUID arrays far from the object it adds, so adjacent insertions read as
+  # conflicts, and a conflict marker inside a pbxproj makes the project UNOPENABLE — Xcode itself
+  # cannot be used to resolve it. Measured template ⋈ mbs/cappy: 6 markers from git merge-file,
+  # 0 from the structural merge. UUIDs are stable across the fork boundary (33 of 36 shared), so a
+  # keyed 3-way with array union is exact. Engine: scripts/white-label/merge-pbxproj.rb.
+  - glob: "**/*.xcodeproj/project.pbxproj"
+    owner: merge
+    strategy: pbxproj-3way
+  # Info.plist / *.entitlements — a flat <dict> both sides add their OWN keys to, so additions can
+  # collide in the TEXT while not overlapping in MEANING. Union is the only correct resolution: the
+  # template's keychain-access-groups (core-base/datastore needs it, or errSecMissingEntitlement
+  # -34018 at launch) and the fork's app-group + CFBundleURLTypes (widget shared container, OAuth
+  # redirect) are ALL required — neither side may win. Comment-preserving, so the rationale travels
+  # with the key it explains.
+  # Measured on mbs/cappy: `iosApp.entitlements` is add/add (absent at the fork's base b97eb73d),
+  # where a line merge conflicts and the output does not even parse — that file is why this exists.
+  # `Info.plist` has a real ancestor and line-merges cleanly TODAY; it is routed here because it is
+  # the same shape and one template key added near the fork's block turns it into the same case.
+  - glob: "cmp-ios/**/Info.plist"
+    owner: merge
+    strategy: plist-union
+  - glob: "cmp-ios/**/*.entitlements"
+    owner: merge
+    strategy: plist-union
+  - glob: "cmp-desktop/**/*.entitlements"
+    owner: merge
+    strategy: plist-union
   - glob: "cmp-web/src/jsMain/resources/**"
     owner: fork
   - glob: "cmp-web/src/wasmJsMain/resources/**"
@@ -519,16 +548,52 @@ rules:
     owner: fork
 
   # ── template-owned (the broad sync surface — lowest precedence, declared LAST) ──
+  #
+  # THE PLATFORM SHELLS ARE `merge`, NOT `template` (2026-09-10)
+  # `build-logic` + the four platform application shells are MOSTLY template content, and the
+  # temptation is to call them `template` and full-copy. That is wrong, and cmp-ios is the proof:
+  # a fork's platform shell is the one place where fork-specific PLATFORM WIRING has nowhere else
+  # to live. There is no `module-deps.gradle.kts`-style seam for an Xcode target or a plist key.
+  #
+  # Measured on mbs/cappy 2026-09-10, all under the old `template` blanket, all silently destroyed
+  # by a full-copy:
+  #   iosApp/Info.plist          CFBundleURLTypes for the Google Sign-In OAuth redirect — deleting
+  #                              it does not fail the build; OAuth simply never returns to the app
+  #   iosApp/iosApp.entitlements com.apple.security.application-groups for the WidgetKit shared
+  #                              container — and the template half (keychain-access-groups, required
+  #                              by core-base/datastore) is ALSO needed, so neither side may win
+  #   iosApp.xcodeproj/project.pbxproj  a whole `CappyWidgets` app-extension target (40 refs) the
+  #                              template has no concept of
+  #   iosApp/iOSApp.swift        scene-phase AppBackground/AppForeground hooks (+20 lines)
+  #
+  # A 3-way takes the template's evolution (here: the SwiftPM migration — 5
+  # XCLocalSwiftPackageReference entries and the KotlinMultiplatformLinkedPackage tree) while the
+  # fork's additions survive, and genuine overlaps surface as conflict markers a human resolves
+  # instead of losing silently.
+  #
+  # No `strategy:` — these blankets span .kts/.swift/.plist/.xml/.pbxproj/.xcconfig/.js/.html and
+  # cs_merge's default `cs_merge_3way` (git merge-file) is the only strategy that handles all of
+  # them. The structure-aware strategies stay on the specific rows above that name one filetype.
+  # Binary paths under these dirs are carved out `fork` above (res/**, Assets.xcassets/**,
+  # cmp-desktop/icons/**, cmp-web resources/**); the engine also refuses to line-merge a binary.
+  #
+  # REQUIRES a merge base. `git merge-base` is empty for a COPIED (non-forked) tree, so the engine
+  # resolves it via .template-version#template_sha — see resolve_merge_base() in sync-dirs.sh.
+  # Without that fix these rows would have degraded straight back into the full-copy they replace.
   - glob: "build-logic/**"
-    owner: template
+    owner: merge
   - glob: "cmp-android/**"
-    owner: template
+    owner: merge
   - glob: "cmp-desktop/**"
-    owner: template
+    owner: merge
   - glob: "cmp-ios/**"
-    owner: template
+    owner: merge
   - glob: "cmp-web/**"
-    owner: template
+    owner: merge
+  # cmp-shared + cmp-navigation stay `template`: unlike the four application shells above they carry
+  # no platform project files, and their fork surface is already served by NAMED seams declared
+  # earlier — ForkWorkerDeclarations.kt, registry/**, di/*.kt, RootNav*.kt. Revisit only if a fork
+  # is found editing them outside those seams.
   - glob: "cmp-shared/**"
     owner: template
   - glob: "cmp-navigation/**"

--- a/customization-surface.yaml
+++ b/customization-surface.yaml
@@ -37,6 +37,22 @@
 version: 1
 
 rules:
+  # ── core-base is FRAMEWORK-SHARED — declared before the merge-required globs below ──
+  # `core-base/**` resolves `template` further down, but the two merge-required rules that follow
+  # are repo-WIDE (`**/AndroidManifest.xml`, `**/composeResources/**/strings.xml`) and first-match
+  # wins, so without this they capture 22 core-base paths: core-base/ui's own 21-locale i18n and the
+  # core-base/{common,observability} module manifests.
+  #
+  # Those globs exist so a FORK can union its own permissions and strings into files it legitimately
+  # extends — its app module, its features, its core/* packages. core-base is not one of those: it is
+  # framework-shared, a fork does not touch it, and 3-way merging the framework's own translations
+  # invites a fork to accumulate edits in a tree that upgrades wholesale. Declaring it template here
+  # keeps `core-base/**` exactly copy-and-replace, which is what it has always meant.
+  - glob: "core-base/**/composeResources/**/strings.xml"
+    owner: template
+  - glob: "core-base/**/AndroidManifest.xml"
+    owner: template
+
   # ── merge-required (declared FIRST — must win over the template module globs) ──
   # AndroidManifest: template ships the base manifest; forks add permissions
   # (RECORD_AUDIO, FOREGROUND_SERVICE_*, etc). A blind copy DROPS the fork's — the
@@ -831,15 +847,42 @@ rules:
   - { glob: "kotlin-js-store/**",            owner: template }
   - { glob: "legal/**",                      owner: template }
   - { glob: "tests/**",                      owner: template }   # test harness — E0/T1 (closes the classification gap)
+  # tools/*-ksp — the template's OWN codegen engine (store / database / network / data processors
+  # that generate AppStoreRegistry, AppDatabase and the Generated*Bindings from the @StoreProvider /
+  # @DbEntity / @ApiBinding / @RepositoryBinding annotations). A fork does not author these.
+  # They had NO rule at all and fell to the `fork` DEFAULT, so they never synced — leaving every
+  # fork frozen on the processor version it forked with while the annotations kept evolving. A
+  # fork cannot be told "your registrations are generated for you" and then never receive the
+  # generators. Added to SYNC_DIRS at the same time: ownership alone would not deliver them.
+  - { glob: "tools/**",                      owner: template }
+  # .bundle/config — BUNDLE_PATH for the vendored Ruby toolchain, template build infra. Same
+  # story: no rule, so it defaulted to fork and never reached a consumer.
+  - { glob: ".bundle/**",                    owner: template }
   - { glob: "META-INF/**",                   owner: template }
   - { glob: "CODE_OF_CONDUCT.md",            owner: template }
   - { glob: "CONTRIBUTING.md",               owner: template }
   - { glob: "LICENSE",                       owner: template }
 
-  # ── default: any path not matched above ──
-  # Runtime treats an unmatched path as fork-owned (SAFE — never clobber an unknown
-  # fork file). `--verify` flags anything that reaches this rule so a human classifies
-  # it explicitly (a new template file must not rely on the default).
+  # ── default: any path not matched above — TEMPLATE-FIRST ──
+  # This repo IS the template, so the default answer to "who owns this?" is the template. FORK
+  # territory is declared EXPLICITLY above (`core/**`, `feature/**`, `app-profile/**`, the per-platform
+  # branding carve-outs), never inferred from silence.
+  #
+  # This was `fork` — "never clobber an unknown fork file". That is the right default for a CONSUMER
+  # and the wrong one for a template: a directory the template ADDS that nobody writes a rule for
+  # silently becomes fork-owned and never syncs to anyone. `tools/**` (the KSP processors every
+  # @StoreProvider / @DbEntity / @ApiBinding depends on) and `.bundle/**` both sat in exactly that
+  # state — unowned AND unreachable, so no fork ever received a processor update.
+  #
+  # Flipping is safe BECAUSE fork territory is explicitly claimed: a fork's new
+  # `core/store/.../quests/QuestStore.kt` or `feature/quests/**` resolves `fork` through its module
+  # catch-all, not through this rule. Verified at the time of the change — all 2712 tracked files
+  # matched an explicit rule, so ZERO existing paths changed owner.
+  #
+  # `--verify` still flags anything reaching this rule: relying on the default is a missing
+  # classification either way, and the point is that the FAILURE MODE is now "a fork receives
+  # template code it did not ask for" (visible, fixable) rather than "a fork silently never receives
+  # template code at all" (invisible, permanent).
   - glob: "**"
-    owner: fork
+    owner: template
     default: true

--- a/deployment/_shared/before_all.rb
+++ b/deployment/_shared/before_all.rb
@@ -44,6 +44,42 @@ def restore_deploy_mutated_sources
 end
 
 before_all do
+  # ── INTERPRETER GUARD — the misleading-failure catcher ──────────────────────────────────────────
+  # rbenv works by PATH interception. A shell without `eval "$(rbenv init -)"` never reaches the
+  # pinned ruby, so `bundle exec fastlane …` runs under macOS's system 2.6.10 while every gem was
+  # installed for .ruby-version. The result is a crash inside rubygems' `activate_bin_path` that
+  # reads as a GEM problem — the gems are fine, the interpreter is wrong.
+  #
+  # Shell scripts avoid this by going through scripts/ruby-exec.sh (RT-9 enforces it). But the READMEs
+  # and each target's config.yaml `local:` command DOCUMENT a bare `bundle exec fastlane …` for a
+  # human to copy — correct guidance for a correctly-configured shell, and nothing a lint can fix.
+  # This is the one place every lane passes through, so it is where that human gets told the truth
+  # instead of a gem error.
+  #
+  # WARN, never fail: a mismatched interpreter that still has working gems can deploy fine, and
+  # blocking a release on a shell-config nit would be its own defect.
+  begin
+    _root = Dir.pwd
+    20.times do
+      break if File.exist?(File.join(_root, ".ruby-version"))
+      _parent = File.dirname(_root)
+      break if _parent == _root
+      _root = _parent
+    end
+    _vf = File.join(_root, ".ruby-version")
+    if File.exist?(_vf)
+      _want = File.read(_vf).strip
+      if !_want.empty? && _want != RUBY_VERSION
+        UI.important("⚠️  ruby #{RUBY_VERSION} is running, but .ruby-version pins #{_want}.")
+        UI.important("    If this run dies inside rubygems' activate_bin_path, THAT is the cause —")
+        UI.important("    the gems are fine, the interpreter is wrong. Fix the shell:")
+        UI.important("      eval \"$(rbenv init -)\"     (or: rbenv install #{_want})")
+      end
+    end
+  rescue StandardError
+    nil # a guard that breaks a deploy is worse than the mismatch it reports
+  end
+
   # START-CLEAN: remove any fastlane_tmp keychain left DEFAULT by a prior run that died before
   # delete_keychain (build error / hard kill), and restore the developer's login keychain as default —
   # otherwise unrelated apps keep prompting for fastlane_tmp. Idempotent, no-op on CI / Android.

--- a/docs/architecture/CUSTOMIZATION_SURFACE.md
+++ b/docs/architecture/CUSTOMIZATION_SURFACE.md
@@ -80,7 +80,37 @@ cs_resolve_strategy "gradle/libs.versions.toml"   # → catalog-3way
    theirs` instead of taking the blind upstream copy:
    - `ours` = fork's current file (`BASE_BRANCH`)
    - `theirs` = upstream file (`temp_branch`)
-   - `base` = `git merge-base BASE_BRANCH temp_branch`
+   - `base` = `resolve_merge_base BASE_BRANCH temp_branch` — **not** `git merge-base` alone
+
+   **The base is the whole promise.** Two fork topologies exist and only one gives git a common
+   ancestor: a **forked** repo (clone / `gh repo fork`) shares history, while a **copied** one — the
+   template tree dropped into a fresh repo, the common case in practice — has different root commits
+   and **zero** shared commits, so `git merge-base` returns empty. With an empty base the engine used
+   `ours`, and `git merge-file` then reads every template difference as a clean addition onto an
+   untouched base and takes **all of theirs** — reproducing exactly the full-copy that `merge` exists
+   to prevent, while printing *"Merged (…) — fork edits preserved"* over the top of the loss.
+
+   `resolve_merge_base()` therefore falls back to **`.template-version#template_sha`**, the commit the
+   tree last synced FROM — precisely the ancestor git cannot compute across unrelated histories, and
+   what that file's own header always claimed it was for. With neither available (a copied fork's
+   first-ever sync) the engine still falls back to `ours` but **warns per file** instead of reporting
+   a merge it did not perform. Pinned by `MB-1`–`MB-3` in
+   `scripts/product-health/checks/sync-merge-base.sh`.
+
+   `pbxproj-3way` (`**/*.xcodeproj/project.pbxproj`) delegates to
+   `scripts/white-label/merge-pbxproj.rb`, because a line merge on an Xcode project is not merely
+   worse — it is unusable. A pbxproj is a serialized object graph keyed by 24-hex UUIDs, so adding a
+   target rewrites UUID arrays three levels from the object it adds, and `git merge-file` reads
+   adjacent array insertions as a conflict. A conflict marker inside a pbxproj makes the project
+   **unopenable**, so a human cannot even use Xcode to resolve it. It is tractable because the UUIDs
+   are stable across the fork boundary (measured: 33 of 36 objects shared), which turns the text
+   merge into a keyed 3-way: UUID arrays union, `buildSettings` merge per key, and the declared
+   `FORK_IDENTITY_KEYS` (`DEVELOPMENT_TEAM`, `PRODUCT_BUNDLE_IDENTIFIER`, `CODE_SIGN_*`, …) go to the
+   fork when both sides moved. Anything it cannot decide FAILS the merge rather than guessing, and
+   the engine's fallback when ruby is unavailable is **keep-ours**, never take-theirs — losing a
+   sync is recoverable, losing the fork's targets is not. Uses the `xcodeproj` gem, already resolved
+   in `Gemfile.lock` as a fastlane transitive. Pinned by `scripts/product-health/checks/pbxproj-merge.sh`
+   against a real captured fixture in `tests/fixtures/pbxproj-3way-canary/`.
 
    `manifest-union` runs a **semantic** union (union `<uses-permission>` /
    `<uses-feature>` by `android:name`, keeping the template's structural update) so a
@@ -89,6 +119,39 @@ cs_resolve_strategy "gradle/libs.versions.toml"   # → catalog-3way
    merge-file`, which cleanly unions non-overlapping edits and emits conflict markers
    **only on a true overlap** — surfaced with a `CONFLICT` warning for review, never
    silently shipped.
+
+### The platform shells are `merge`, not `template`
+
+`build-logic/**` and the four platform **application shells** — `cmp-android/**`, `cmp-ios/**`,
+`cmp-desktop/**`, `cmp-web/**` — are mostly template content, which makes `template` + full-copy the
+tempting classification. It is the wrong one: a platform shell is the one place where fork-specific
+**platform wiring** has nowhere else to live. `core/<mod>/module-deps.gradle.kts` gives a fork a seam
+for dependencies; there is no equivalent seam for an Xcode target, an entitlement, or a plist key.
+
+Measured on a real consumer (2026-09-10), every one of these sat under the old `template` blanket and
+would have been destroyed silently by a full-copy:
+
+| Path | Fork content a full-copy deletes |
+|---|---|
+| `cmp-ios/iosApp/Info.plist` | `CFBundleURLTypes` for the Google Sign-In OAuth redirect — no build failure; OAuth just never returns |
+| `cmp-ios/iosApp/iosApp.entitlements` | the WidgetKit app-group. The template half (`keychain-access-groups`, required by `core-base/datastore`) is **also** needed — neither side may win, so it must be a union |
+| `cmp-ios/iosApp.xcodeproj/project.pbxproj` | an entire app-extension target the template has no concept of |
+| `cmp-ios/iosApp/iOSApp.swift` | scene-phase `AppBackground` / `AppForeground` hooks |
+
+A 3-way takes the template's evolution — the SwiftPM migration landed 5 `XCLocalSwiftPackageReference`
+entries plus the `KotlinMultiplatformLinkedPackage` tree this way — while the fork's additions survive,
+and a genuine overlap surfaces as a conflict marker rather than a silent loss.
+
+These blankets carry **no `strategy:`**: they span `.kts` / `.swift` / `.plist` / `.xml` / `.pbxproj` /
+`.xcconfig` / `.js` / `.html`, and `cs_merge`'s default `git merge-file` is the only strategy that
+handles all of them. Structure-aware strategies stay on the specific rows that name one filetype
+(`AndroidManifest.xml` still resolves `merge (strategy: manifest-union)`). Binaries under these
+directories are carved out `fork` (`res/**`, `Assets.xcassets/**`, `cmp-desktop/icons/**`, the
+`cmp-web` resources), and the engine additionally refuses to line-merge a binary.
+
+`cmp-shared/**` and `cmp-navigation/**` stay `template` — they carry no platform project files, and
+their fork surface is already served by named seams (`ForkWorkerDeclarations.kt`, `registry/**`,
+`di/*.kt`, `RootNav*.kt`).
 
 The `template`/`fork` mechanical behaviour (`SYNC_DIRS` + `EXCLUSIONS`) is unchanged;
 the contract adds the `merge` path handling that previously didn't exist. Guarded so

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -37,7 +37,7 @@ scripts/
 ├── secrets/        platform-wise secrets toolkit
 ├── store/          store listing + screenshots
 ├── _shared/        shared bash helpers
-└── product-health/ the 27-check health suite (self-documenting)
+└── product-health/ the 30-check health suite (self-documenting)
 ```
 
 ---
@@ -184,7 +184,7 @@ scripts/white-label/doctor.sh
 # who owns a path (sync ownership)
 scripts/customization-surface.sh resolve core/store/src/commonMain/kotlin/kpt/core/store/di/StoreModule.kt
 
-# health suite (27 checks)
+# health suite (30 checks)
 bash scripts/product-health/product-health.sh
 # on the upstream template itself, where fork-identity checks would misfire:
 TEMPLATE_SELF_BUILD=1 bash scripts/product-health/product-health.sh

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -70,6 +70,13 @@ than silently running the wrong ruby.
 tracked `*.sh` invokes `bundle` directly. Echoed instructions for a human are fine — the match is
 anchored to command position.
 
+**`RT-8`** in the same file asks whether *this repo* can reach the pinned interpreter — it runs the
+resolver and checks the answer. It does **not** ask whether the `ruby` on your PATH happens to be the
+pinned one: that is a property of your shell, not the repo, and every script goes through the
+resolver anyway. So `product-health` passes on a shell that never ran `rbenv init`, and prints a note
+(visible when you run the check directly) reminding you that a **hand-typed** lane is the one path
+that still needs the shell fixed.
+
 ---
 
 ## `white-label/` — the fork lifecycle
@@ -200,8 +207,10 @@ scripts/remove-demo.sh --apply
 
 ## Troubleshooting
 
-**`bundle exec` fails inside `activate_bin_path`** — the interpreter, not the gems. Run
-`eval "$(rbenv init -)"`, or check with `. scripts/ruby-exec.sh && ruby_exec_report`.
+**`bundle exec` fails inside `activate_bin_path`** — the interpreter, not the gems. This only happens
+when you invoke a lane **by hand**; anything going through `ruby-exec.sh` is immune. Run
+`eval "$(rbenv init -)"`, or check with `. scripts/ruby-exec.sh && ruby_exec_report`. `product-health`
+will still pass in this state, by design — see `RT-8` above.
 
 **A script cannot find `gradle/fork.properties` values** — it is derived from `app-profile/`. Run
 `./gradlew syncForkConfig`; never hand-edit the bridge.

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -1,1068 +1,217 @@
-# Bash Scripts - Automation & Setup
+# Bash Scripts — Automation & Setup
 
-**Last Updated:** 2026-02-13
-**Total Scripts:** 17
-**Categories:** Setup (4) | iOS Deployment (3) | iOS Setup (2) | Verification (3) | Utilities (5)
+**Last Updated:** 2026-09-10
+**Tracked scripts:** 34 (excluding `scripts/product-health/`, which documents itself)
 
 [← Back to Main](../CLAUDE.md)
 
+> **This file is a map of what EXISTS.** It was rewritten 2026-09-10 after an audit found it
+> describing a layout the tree had left behind: 8 scripts documented as current no longer existed
+> (`deploy_firebase.sh`, `deploy_testflight.sh`, `deploy_appstore.sh`, `check_environment.sh`,
+> `check_file_env_keys.sh`, `check-commit-signing.sh`, `ensure_base64.sh`,
+> `fix-detekt-permissions.sh`), 22 that do exist were never mentioned, and every path was written
+> flat (`customize.sh`) when the scripts had long since moved into subdirectories
+> (`scripts/white-label/customize.sh`). A doc that names a script which is not there costs more than
+> no doc — it sends a reader looking for something that was deliberately removed.
+>
+> The deploy scripts are gone on purpose: deployment runs through **Fastlane lanes**, not shell
+> wrappers. See [`deployment/BOOTSTRAP.md`](../deployment/BOOTSTRAP.md).
+
 ---
 
-## Table of Contents
+## Layout
 
-1. [Overview](#overview)
-2. [Setup Scripts](#setup-scripts)
-3. [iOS Deployment Scripts](#ios-deployment-scripts)
-4. [iOS Setup Scripts](#ios-setup-scripts)
-5. [Verification Scripts](#verification-scripts)
-6. [Utility Scripts](#utility-scripts)
-7. [Common Tasks](#common-tasks)
-8. [Troubleshooting](#troubleshooting)
-
----
-
-## Overview
-
-This directory contains 17 bash scripts for project setup, deployment, and verification.
-
-**Script Categories:**
 ```
-setup-project.sh                  (565 lines) - thin redirect → scripts/white-label/doctor.sh (--legacy for old flow)
-
-scripts/white-label/             - the white-label lifecycle (see scripts/white-label/README.md)
-├── doctor.sh                     - the ONE entry: setup + verify + sync (RULE-WHITE-LABEL-DOCTOR-001)
-├── derive.rb                     - app-profile → gradle/fork.properties (single SoT)
-├── customize.sh                  (566 lines) - Package name customization  (was customizer.sh)
-├── firebase.sh                   (469 lines) - Firebase project setup      (was firebase-setup.sh)
-├── keystore.sh                 (1,356 lines) - Keystore & secrets mgmt      (was keystore-manager.sh)
-└── sync-dirs.sh                  - template sync engine (owner: template, self-propagating)
-
-ios-deployment/
-├── deploy_firebase.sh            - iOS Firebase deployment
-├── deploy_testflight.sh          - iOS TestFlight deployment
-└── deploy_appstore.sh            - iOS App Store deployment
-
-ios-setup/
-├── setup_ios_complete.sh         (518 lines) - Complete iOS setup wizard
-└── setup_apn_key.sh              - APN key configuration
-
-verification/
-├── verify_ios_deployment.sh      (365 lines, 70+ checks)
-├── verify_apn_setup.sh           - APN verification
-└── check_ios_version.sh          - Version sanitization display
-
-utilities/
-├── check_environment.sh          - Environment validation
-├── check_file_env_keys.sh        - Environment file validation
-├── check-commit-signing.sh       - Git commit signing check
-├── ensure_base64.sh              - Base64 encoding helper
-└── fix-detekt-permissions.sh     - Detekt config permissions fix
+scripts/
+├── ruby-exec.sh                    the ONE way this repo reaches Ruby/Bundler
+├── customization-surface.sh        reader + validator for customization-surface.yaml
+├── remove-demo.sh                  strip the demo showcase, leaving a clean fork
+├── deployment-manifest-validate.sh validate the deploy-target ownership split
+├── configure-release-environments.sh  create + protect the GitHub Environments releases bind to
+├── verify-demo-convention.sh       static gate for the demo⇄framework separation convention
+├── verify-2-4-0.sh                 per-target main+test compile matrix for Kotlin 2.4.0
+│
+├── white-label/    the white-label lifecycle (see white-label/README.md)
+├── ios/            iOS setup + verification
+├── ci/             pre-commit / pre-push / CI-parity gates
+├── secrets/        platform-wise secrets toolkit
+├── store/          store listing + screenshots
+├── _shared/        shared bash helpers
+└── product-health/ the 27-check health suite (self-documenting)
 ```
 
 ---
 
-## Setup Scripts
+## `ruby-exec.sh` — read this before writing any script that shells out to Ruby
 
-### 1. `setup-project.sh` (565 lines)
+**Every** bundler call goes through this. It is not a convenience wrapper; it closes a trap that
+produces a misleading error.
 
-**Purpose:** Master orchestration script for complete project setup
+rbenv works by PATH interception. In a shell without `eval "$(rbenv init -)"` — a cron job, a
+GUI-launched terminal, a CI step that reset PATH — nothing intercepts, `ruby` falls through to
+macOS's `/usr/bin/ruby` 2.6.10, and the pinned interpreter is never used. The gems were installed
+for the pinned version, so `bundle exec` then dies inside rubygems' `activate_bin_path` with an
+error about **gem activation**. The gems are fine; the interpreter is wrong.
 
-**Usage:**
 ```bash
-./setup-project.sh
+. "$REPO_ROOT/scripts/ruby-exec.sh"
+ruby_exec   script.rb [args...]              # run a ruby script under the pinned interpreter
+ruby_bundle <app-root> -- exec fastlane …    # run bundler in an app root, pinned
+ruby_exec_report                             # which interpreter was chosen, and why
 ```
 
-**What it does:**
-1. **Validates Prerequisites:**
-   - Checks for: `git`, `gh` (GitHub CLI), `firebase`, `keytool`, `openssl`, `python3`
-   - Verifies: Git repository initialized, clean working directory
+It resolves `$(rbenv root)/versions/<pin>/bin/ruby` **directly**, so it works whether or not shims
+are on PATH. The pin comes from `.ruby-version` — never a literal, so bumping the pin cannot leave a
+caller asking for a stale version. If the pinned version is not installed it provisions it (framework
+helper, or `RUBY_EXEC_AUTO_INSTALL=1`) and otherwise **fails loudly with the exact command** rather
+than silently running the wrong ruby.
 
-2. **Collects User Inputs:**
-   - Package names (Android, iOS)
-   - Organization info (name, department, city, country)
-   - Firebase project info
-   - Keystore passwords
-
-3. **Orchestrates Setup:**
-   - Runs `scripts/white-label/customize.sh` to update package names
-   - Runs `scripts/white-label/firebase.sh` to create Firebase projects
-   - Runs `scripts/white-label/keystore.sh` to generate keystores
-   - Runs iOS setup (if user confirms)
-
-4. **Generates Documentation:**
-   - Creates `PROJECT_SETUP_INFO.txt` with all configuration details
-   - Saves to project root
-
-**Interactive Prompts:**
-- Android package name
-- iOS bundle identifier
-- Organization details
-- Firebase configuration
-- iOS setup confirmation
-
-**Output:**
-- Updated package names across project
-- Firebase projects configured
-- Keystores generated
-- Secrets encoded for GitHub Actions
-- `PROJECT_SETUP_INFO.txt` documentation
-
-**Line Count:** 565 lines
+**Enforced:** `RT-9` in `product-health/checks/ruby-toolchain-coherence.sh` fails the build if any
+tracked `*.sh` invokes `bundle` directly. Echoed instructions for a human are fine — the match is
+anchored to command position.
 
 ---
 
-### 2. `scripts/white-label/customize.sh` (566 lines)
+## `white-label/` — the fork lifecycle
 
-**Purpose:** Update package names and namespaces throughout the project
+| Script | Purpose |
+|---|---|
+| `doctor.sh` | **the ONE entry**: setup + verify + sync (RULE-WHITE-LABEL-DOCTOR-001) |
+| `derive.rb` | `app-profile/` → `gradle/fork.properties` (the single SoT projection) |
+| `customize.sh` | package-name / namespace customization |
+| `firebase.sh` | Firebase project + app registration |
+| `keystore.sh` | keystore generation and secrets management |
+| `sync-dirs.sh` | the template sync engine (`owner: template`, self-propagating) |
 
-**Usage:**
-```bash
-scripts/white-label/customize.sh
-```
+`setup-project.sh` at the repo root is a thin redirect to `doctor.sh` (`--legacy` for the old flow).
 
-**What it does:**
-1. **Collects Package Info:**
-   - Android package name (e.g., `com.example.app`)
-   - iOS bundle identifier (e.g., `com.example.app`)
-
-2. **Updates Android Configuration:**
-   - `build.gradle.kts`: `namespace`, `applicationId`
-   - `fastlane-config/project_config.rb`: ANDROID hash
-
-3. **Updates iOS Configuration:**
-   - Xcode project: `PRODUCT_BUNDLE_IDENTIFIER`
-   - `fastlane-config/project_config.rb`: IOS hash
-   - **Preserves** `IOS_SHARED` section (critical!)
-
-4. **Creates google-services.json:**
-   - Generates template with 4 variants:
-     - `release`, `debug`, `demo`, `demo.debug`
-   - Placeholder app IDs (will be updated by `scripts/white-label/firebase.sh`)
-
-5. **Updates libs.versions.toml:**
-   - `androidPackageNamespace` version
-
-**⚠️ IMPORTANT:** Run `scripts/white-label/firebase.sh` after this to populate real Firebase app IDs
-
-**Interactive:** Yes (prompts for package names)
-
-**Line Count:** 566 lines
+Full detail: [`white-label/README.md`](white-label/README.md).
 
 ---
 
-### 3. `scripts/white-label/firebase.sh` (469 lines)
+## `ios/` — setup and verification
 
-**Purpose:** Create Firebase projects and register Android/iOS apps
+| Script | Purpose |
+|---|---|
+| `setup_ios_complete.sh` | complete iOS deployment setup wizard (Team ID, App Store Connect API, Match SSH key) |
+| `setup_apn_key.sh` | Apple Push Notification key configuration |
+| `verify_ios_deployment.sh` | 70+ checks across prerequisites, Match, signing, Firebase, security |
+| `verify_apn_setup.sh` | APN key presence, permissions, format |
+| `check_ios_version.sh` | explains Gradle → Firebase → App Store version sanitization |
 
-**Usage:**
-```bash
-scripts/white-label/firebase.sh
-```
-
-**What it does:**
-1. **Creates Firebase Project:**
-   - Project ID from Android package name
-   - Adds Firebase Admin SDK
-
-2. **Registers Apps (2 Android + 1 iOS):**
-   - Android Prod: `{package}.prod` (SHA-1 certificate)
-   - Android Demo: `{package}.demo.debug` (SHA-1 certificate)
-   - iOS: `{bundle_id}` (no SHA required)
-
-3. **Downloads Configurations:**
-   - `google-services.json` for each Android app
-   - `GoogleService-Info.plist` for iOS
-
-4. **Merges Configurations:**
-   - Uses Python script to merge 2 Android configs into 4-variant `google-services.json`
-   - **Optimization:** Only 2 apps registered in Firebase (saves quota), but 4 variants in config
-
-5. **Saves to Correct Locations:**
-   - `cmp-android/google-services.json`
-   - `cmp-ios/GoogleService-Info.plist`
-
-**Prerequisites:**
-- `firebase` CLI installed and logged in
-- `python3` installed
-- Android keystore exists (for SHA-1 certificate)
-
-**Variant Mapping:**
-```
-Firebase App               → Config Variant
----------------------------------------------
-{package}.prod            → release, prod
-{package}.demo.debug      → debug, demo, demo.debug
-```
-
-**Interactive:** Yes (project name, confirmation)
-
-**Line Count:** 469 lines
-
-**⚠️ Note:** Only 2 Firebase apps created, but 4 variants in google-services.json
+iOS uses **SwiftPM / XCFramework** (`cmp-ios/Package.swift` + the Xcode Run-Script phase). There is
+no CocoaPods toolchain.
 
 ---
 
-### 4. `scripts/white-label/keystore.sh` (1,356 lines)
+## `ci/` — gates
 
-**Purpose:** Complete keystore and secrets management tool
-
-**Usage:**
-```bash
-scripts/white-label/keystore.sh <command>
-```
-
-**Commands:**
-
-#### `generate`
-Generate ORIGINAL and UPLOAD keystores
-
-```bash
-scripts/white-label/keystore.sh generate
-```
-
-**What it does:**
-1. Validates `keytool` and `openssl` installed
-2. Loads configuration from `secrets.env` (or prompts for input)
-3. Generates **ORIGINAL keystore**:
-   - File: `keystores/{package}_original.keystore`
-   - Used for app signing
-4. Generates **UPLOAD keystore**:
-   - File: `keystores/{package}_upload.keystore`
-   - Used for Play Console (Play App Signing)
-5. Extracts certificates and keys
-6. Saves configuration to `secrets.env`
-
-**Interactive:** Yes (if no secrets.env)
+| Script | Purpose |
+|---|---|
+| `pre-commit.sh` · `pre-push.sh` | branch guard + Spotless / Detekt / Dependency Guard |
+| `ci-equivalent-check.sh` | local CI parity for the consumer |
+| `check-secrets-resolver.sh` | Phase-7 guard: the build-secrets resolver stays the single reader |
+| `verify-dynamic-flavor-propagation.sh` | AC-9 canary — a flavor added via `LocalFlavors` auto-derives everywhere |
+| `verify-workflow-token-scope.sh` | pre-push gate on `.github/workflows/*` token scope (AC-11) |
 
 ---
 
-#### `encode-secrets`
-Encode all secrets in `secrets/` directory to base64
+## `secrets/` — platform-wise toolkit
 
-```bash
-scripts/white-label/keystore.sh encode-secrets
-```
+| Script | Purpose |
+|---|---|
+| `setup-secrets.sh` | interactive, platform-wise secret setup |
+| `secrets-status.sh` | what is set up vs missing, per platform |
+| `generate-manifest.sh` | regenerate the root `secrets-manifest.yaml` |
+| `sync-secrets-to-github.sh` | push secrets to GitHub repository secrets |
+| `_lib.sh` | shared helpers |
 
-**What it does:**
-1. Scans `secrets/` directory for files
-2. Encodes each file to base64
-3. Updates `secrets.env` with encoded file secrets
-
-**File-to-Secret Mapping:**
-```bash
-FILE_TO_SECRET_MAP["firebaseAppDistributionServiceCredentialsFile.json"]="FIREBASECREDS"
-FILE_TO_SECRET_MAP["google-services.json"]="GOOGLESERVICES"
-FILE_TO_SECRET_MAP["playStorePublishServiceCredentialsFile.json"]="PLAYSTORECREDS"
-FILE_TO_SECRET_MAP["AuthKey.p8"]="APPSTORE_AUTH_KEY"
-FILE_TO_SECRET_MAP["match_ci_key"]="MATCH_SSH_PRIVATE_KEY"
-```
+Never hand-write a secret into `secrets/live/` — that path is fork-owned, gitignored, and excluded
+from sync.
 
 ---
 
-#### `sync`
-Synchronize all secrets to secrets.env
+## `store/` — listing and screenshots
 
-```bash
-scripts/white-label/keystore.sh sync
-```
-
-**What it does:**
-1. Read non-secret metadata from `gradle/fork.properties`
-2. Encode `secrets/*` files to base64
-3. Update `secrets.env` with all platform secrets
-4. Add Desktop signing placeholders
-5. Validate result (format, required secrets, base64)
-
-**Output Artifacts:**
-- Updated `secrets.env` (all platform secrets unified)
-- `secrets.env.backup` (safety backup)
-
-**Use cases:**
-- After iOS setup (automatic via `setup_ios_complete.sh`)
-- After adding new files to `secrets/` directory
-- After updating `gradle/fork.properties` or any `secrets/<platform>/` file
-- To refresh/validate secrets.env
-
-**Features:**
-- Creates backup before modification
-- Preserves existing secrets if source files missing
-- Idempotent: safe to run multiple times
-- Validates format and base64 encoding
+| Script | Purpose |
+|---|---|
+| `store-listing-preflight.sh` | CI mirror of `/release` STEP 1.7 — fails fast on missing fields or store character limits, so an upload is never rejected by the Play/App Store API |
+| `sync-play-listing.sh` | upload the Play listing (title, description, screenshots, feature graphic) without shipping an APK/AAB |
+| `sync-play-listing.rb` | its Ruby implementation |
+| `generate-screenshots.sh` | render generated HTML screenshots to PNG at store-submission resolution (Android 1080×1920, iOS 6.9" 1320×2868) |
 
 ---
 
-#### `view`
-View current secrets (files + environment variables)
+## Root-level
 
-```bash
-scripts/white-label/keystore.sh view
-```
-
-**What it does:**
-- Lists all files in `secrets/` directory
-- Displays selected environment variables from `secrets.env`
-- Shows keystore info (aliases, validity)
-
----
-
-#### `add`
-Add secrets to GitHub repository (requires `gh` CLI)
-
-```bash
-scripts/white-label/keystore.sh add [--repo owner/repo] [--env environment]
-```
-
-**What it does:**
-1. Encodes all secrets to base64
-2. Uses GitHub CLI to set repository secrets:
-   ```bash
-   gh secret set SECRET_NAME --body "$base64_value"
-   ```
-3. Optionally targets specific environment
-
-**Prerequisites:** `gh auth login` (GitHub CLI authenticated)
+| Script | Purpose |
+|---|---|
+| `customization-surface.sh` | reader + validator for `customization-surface.yaml` — `resolve <path>` prints a path's owner; `--verify` fails on a rule matching zero real paths |
+| `remove-demo.sh` | strip the demo showcase, leaving a clean fork |
+| `deployment-manifest-validate.sh` | validate the deploy-target ownership split (E1 / D-1) |
+| `configure-release-environments.sh` | create + protect the GitHub Environments the release pipeline binds to, so store stages pause for manual approval. Run once per dispatching repo |
+| `verify-demo-convention.sh` | static gate for the demo⇄framework separation convention |
+| `verify-2-4-0.sh` | per-target main+test compile matrix for the Kotlin 2.4.0 upgrade |
+| `_shared/fork-props.sh` | the ONE bash reader of `gradle/fork.properties` |
 
 ---
 
-#### `list`
-List all secrets in GitHub repository
+## Deployment
+
+Deployment is **Fastlane lanes**, invoked from `deployment/`:
 
 ```bash
-scripts/white-label/keystore.sh list [--repo owner/repo]
+(cd deployment && bundle exec fastlane android deployInternal)
+(cd deployment && bundle exec fastlane ios beta)
+(cd deployment && bundle exec fastlane mac desktop_testflight)
 ```
 
-**Uses:** `gh secret list`
+Those need rbenv initialized in your shell. If a lane dies inside `activate_bin_path`, the
+`before_all` hook in `deployment/_shared/before_all.rb` will already have warned you that the running
+interpreter does not match `.ruby-version` — that, not the gems, is the cause.
+
+Canonical guide: [`deployment/BOOTSTRAP.md`](../deployment/BOOTSTRAP.md) — Path A (OSS fork, manual
+secrets) and Path B (vault mode).
 
 ---
 
-#### `delete`
-Delete a specific secret from GitHub
+## Common tasks
 
 ```bash
-scripts/white-label/keystore.sh delete [--repo owner/repo] [--name SECRET_NAME]
-```
+# fork setup — the one entry
+scripts/white-label/doctor.sh
 
-**Interactive:** Prompts for secret name if not provided
+# who owns a path (sync ownership)
+scripts/customization-surface.sh resolve core/store/src/commonMain/kotlin/kpt/core/store/di/StoreModule.kt
 
----
+# health suite (27 checks)
+bash scripts/product-health/product-health.sh
+# on the upstream template itself, where fork-identity checks would misfire:
+TEMPLATE_SELF_BUILD=1 bash scripts/product-health/product-health.sh
 
-#### `delete-all`
-Delete ALL secrets from GitHub repository
+# iOS readiness
+scripts/ios/verify_ios_deployment.sh
 
-```bash
-scripts/white-label/keystore.sh delete-all [--repo owner/repo]
-```
-
-**⚠️ WARNING:** Irreversible! Requires confirmation.
-
----
-
-**Configuration File: `secrets.env`**
-
-Example:
-```bash
-# Company & Organization
-COMPANY_NAME="Your Company"
-DEPARTMENT="Mobile Development"
-ORGANIZATION="Your Org"
-CITY="San Francisco"
-STATE="CA"
-COUNTRY="US"
-
-# Keystore Configuration
-VALIDITY=10000
-KEYALG=RSA
-KEYSIZE=2048
-
-# Keystore Credentials (Play App Signing — single UPLOAD keystore)
-UPLOAD_KEYSTORE_PASSWORD="xxx"
-UPLOAD_KEYSTORE_ALIAS="xxx"
-UPLOAD_KEYSTORE_ALIAS_PASSWORD="xxx"
-```
-
-**Line Count:** 1,356 lines (largest script)
-
----
-
-## iOS Deployment Scripts
-
-### 5. `deploy_firebase.sh`
-
-**Purpose:** Deploy iOS app to Firebase App Distribution
-
-**Usage:**
-```bash
-./scripts/deploy/deploy_firebase.sh
-```
-
-**What it does:**
-1. Reads config from `gradle/fork.properties` + `secrets/apple/` files
-2. Calls Fastlane lane: `bundle exec fastlane ios deploy_on_firebase`
-3. Displays success message
-
-**Prerequisites:**
-- `gradle/fork.properties` filled in and `secrets/apple/` files present
-- Fastlane installed
-- Xcode (iOS is SwiftPM/XCFramework since E6)
-
-**Output:** IPA uploaded to Firebase App Distribution
-
----
-
-### 6. `deploy_testflight.sh`
-
-**Purpose:** Deploy iOS app to TestFlight
-
-**Usage:**
-```bash
-./scripts/deploy/deploy_testflight.sh
-```
-
-**What it does:**
-1. Reads config from `gradle/fork.properties` + `secrets/apple/` files
-2. Calls Fastlane lane: `bundle exec fastlane ios beta`
-3. Displays success message
-
-**Prerequisites:** Same as `deploy_firebase.sh`
-
-**Output:** IPA uploaded to TestFlight
-
----
-
-### 7. `deploy_appstore.sh`
-
-**Purpose:** Deploy iOS app to App Store
-
-**Usage:**
-```bash
-./scripts/deploy/deploy_appstore.sh
-```
-
-**What it does:**
-1. **Double Confirmation:**
-   - First confirmation: "Deploy to App Store? (y/n)"
-   - Second confirmation: "This is PRODUCTION. Are you ABSOLUTELY sure? (yes/no)"
-   - Requires typing "yes" (not just "y")
-2. Reads config from `gradle/fork.properties` + `secrets/apple/` files
-3. Calls Fastlane lane: `bundle exec fastlane ios release`
-4. Displays success message
-
-**⚠️ CRITICAL:**
-- Production deployment
-- Double confirmation required
-- Never bypass this script
-
-**Prerequisites:** Same as `deploy_firebase.sh`
-
-**Output:** IPA submitted to App Store for review
-
----
-
-## iOS Setup Scripts
-
-### 8. `setup_ios_complete.sh` (518 lines)
-
-**Purpose:** Complete iOS deployment setup wizard
-
-**Usage:**
-```bash
-./scripts/ios/setup_ios_complete.sh
-```
-
-**What it does:**
-
-1. **Validates Prerequisites:**
-   - Checks: `openssl`, `ssh-keygen`, `gh` CLI, Xcode Command Line Tools
-
-2. **Collects Configuration:**
-   - **Team Information:**
-     - Apple Developer Team ID
-     - Bundle Identifier
-   - **App Store Connect API:**
-     - Key ID
-     - Issuer ID
-     - Private Key (.p8 file path)
-   - **Fastlane Match:**
-     - Git repository URL
-     - Git branch
-     - Passphrase
-
-3. **Generates SSH Key for Match:**
-   - Creates `secrets/apple/match/match_ci_key` (private key)
-   - Creates `secrets/apple/match/match_ci_key.pub` (public key)
-   - Instructions to add public key to Match repository deploy keys
-
-4. **Writes configuration:**
-   - Populates `gradle/fork.properties` with non-secret identity/metadata:
-     ```properties
-     apple.team.id=xxx
-     apple.match.git.url=git@github.com:org/repo.git
-     apple.match.git.branch=master
-     org.email=team@example.com
-     ```
-   - Writes secret values as per-value files under `secrets/<platform>/`:
-     - `secrets/apple/appstore/key_id`, `issuer_id`
-     - `secrets/apple/match/.match_password`
-
-5. **Copies App Store Connect Key:**
-   - Copies `.p8` file to `secrets/apple/appstore/AuthKey.p8`
-
-6. **Verifies Configuration:**
-   - Runs `verify_ios_deployment.sh` (70+ checks)
-
-7. **Displays Next Steps:**
-   - Add SSH public key to Match repository
-   - Run `fastlane match` to generate certificates
-   - Test deployment with `deploy_firebase.sh`
-
-**Interactive:** Extensive (prompts for all configuration)
-
-**Line Count:** 518 lines
-
-**Output:**
-- `gradle/fork.properties` (non-secret identity/metadata)
-- `secrets/apple/appstore/key_id` and `secrets/apple/appstore/issuer_id`
-- `secrets/apple/match/match_ci_key` (SSH private key)
-- `secrets/apple/match/match_ci_key.pub` (SSH public key)
-- `secrets/apple/appstore/AuthKey.p8` (App Store Connect API key)
-
----
-
-### 9. `setup_apn_key.sh`
-
-**Purpose:** Configure Apple Push Notification (APN) key
-
-**Usage:**
-```bash
-./scripts/ios/setup_apn_key.sh
-```
-
-**What it does:**
-1. Prompts for APN Key ID
-2. Prompts for APN .p8 file path
-3. Copies APN key to `secrets/apple/apn/APNAuthKey.p8`
-4. Writes APN Key ID to `secrets/apple/apn/key_id` and Team ID to `secrets/apple/apn/team_id`
-5. Verifies setup with `verify_apn_setup.sh`
-
-**When needed:**
-- If app uses push notifications
-- Optional for apps without notifications
-
----
-
-## Verification Scripts
-
-### 10. `verify_ios_deployment.sh` (365 lines, 70+ checks)
-
-**Purpose:** Comprehensive validation of iOS deployment configuration
-
-**Usage:**
-```bash
-./scripts/ios/verify_ios_deployment.sh
-```
-
-**What it does:**
-
-**70+ Checks across 10 categories:**
-
-1. **Prerequisites (7 checks):**
-   - Ruby installed
-   - Bundler installed
-   - Fastlane installed
-   - Xcode Command Line Tools
-   - Git installed
-   - OpenSSL installed
-
-2. **Fastlane Configuration (8 checks):**
-   - `Gemfile` exists
-   - `Fastfile` exists
-   - iOS platform defined in Fastfile
-   - Required lanes exist (`beta`, `release`, `deploy_on_firebase`)
-   - Plugins installed (`firebase_app_distribution`, `increment_build_number`)
-
-3. **Project Structure (6 checks):**
-   - Xcode project exists
-   - Shared module exists
-   - `cmp-ios/Package.swift` exists (SwiftPM binary target)
-   - Info.plist exists
-
-4. **App Store Connect API (4 checks):**
-   - `APPSTORE_KEY_ID` set
-   - `APPSTORE_ISSUER_ID` set
-   - `APPSTORE_KEY_PATH` set
-   - `.p8` file exists at path
-
-5. **Fastlane Match (6 checks):**
-   - `MATCH_GIT_URL` set
-   - `MATCH_GIT_BRANCH` set
-   - `MATCH_SSH_KEY_PATH` set
-   - SSH private key exists
-   - `MATCH_PASSWORD` set
-   - SSH key has correct permissions (600)
-
-6. **Firebase Configuration (5 checks):**
-   - `GoogleService-Info.plist` exists
-   - Firebase service credentials exist
-   - Firebase app ID configured
-   - Firebase tester groups configured
-
-7. **Code Signing (10 checks):**
-   - Team ID set
-   - Bundle identifier set
-   - Provisioning profile name format
-   - Match type configured
-   - SSH config for Match repository
-   - Can connect to Match repository
-   - Certificates exist in Match repository
-
-8. **Build Configuration (8 checks):**
-   - Scheme exists
-   - Build settings valid
-   - Code signing identity set
-   - Provisioning profile set
-   - Development team set
-   - Version number set
-   - Build number set
-
-9. **Deployment Readiness (6 checks):**
-   - Can build debug
-   - Can build release (dry run)
-   - Can access App Store Connect API
-   - Can fetch Match certificates (dry run)
-   - Firebase credentials valid
-
-10. **Security (5 checks):**
-    - Secrets directory exists
-    - Secret files have correct permissions
-    - No secrets committed to Git
-    - SSH key not world-readable
-    - `.p8` file not world-readable
-
-**Output:**
-- ✅ All checks passed → "iOS deployment configuration is READY"
-- ❌ Some checks failed → Detailed error messages with fixes
-
-**Line Count:** 365 lines
-
-**Exit Codes:**
-- `0`: All checks passed
-- `1`: One or more checks failed
-
----
-
-### 11. `verify_apn_setup.sh`
-
-**Purpose:** Verify Apple Push Notification setup
-
-**Usage:**
-```bash
-./scripts/ios/verify_apn_setup.sh
-```
-
-**What it does:**
-1. Checks `secrets/apple/apn/key_id` exists and is non-empty
-2. Checks APN `.p8` file exists at `secrets/apple/apn/APNAuthKey.p8`
-3. Validates file permissions
-4. Verifies key format
-
-**Output:**
-- ✅ APN setup valid
-- ❌ Missing configuration or invalid key
-
----
-
-### 12. `check_ios_version.sh`
-
-**Purpose:** Display version handling and sanitization explanation
-
-**Usage:**
-```bash
-./scripts/ios/check_ios_version.sh
-```
-
-**What it does:**
-1. Reads current version from `version.txt` (generated by Gradle)
-2. Shows version formats:
-   ```
-   Gradle Version:    2026.1.1-beta.0.9+abc123
-   Firebase Version:  2026.1.1-beta.0.9
-   App Store Version: 2026.1.9
-   ```
-3. Explains sanitization logic:
-   - Why: App Store requires `MAJOR.MINOR.PATCH` format
-   - How: Extract year, month, commit count
-   - Result: `YYYY.M.{commitCount}`
-4. Shows Fastlane code that performs sanitization (from Fastfile:383-429)
-
-**Educational Output:**
-- Version comparison table
-- Sanitization explanation
-- Code snippet from Fastfile
-
-See [Version Handling Guide](../docs/claude/version-handling.md)
-
----
-
-## Utility Scripts
-
-### 13. `check_environment.sh`
-
-**Purpose:** Validate development environment prerequisites
-
-**Usage:**
-```bash
-./scripts/check_environment.sh
-```
-
-**What it does:**
-- Checks for required tools:
-  - Git
-  - Java (version 17+)
-  - Gradle
-  - Ruby
-  - Bundler
-  - Firebase CLI
-  - GitHub CLI (`gh`)
-- Displays versions
-- Reports missing tools
-
-**Output:**
-- ✅ All prerequisites met
-- ⚠️ Missing tools (with installation instructions)
-
----
-
-### 14. `check_file_env_keys.sh`
-
-**Purpose:** Validate environment variable files
-
-**Usage:**
-```bash
-./scripts/check_file_env_keys.sh <file.env>
-```
-
-**What it does:**
-1. Reads `.env` file
-2. Checks for required keys
-3. Validates format (KEY=VALUE)
-4. Detects multiline blocks
-5. Reports missing or malformed entries
-
-**Use cases:**
-- Validate `secrets.env` after manual edits
-- Check any `.env`-formatted file format
-
----
-
-### 15. `check-commit-signing.sh`
-
-**Purpose:** Check if Git commits are GPG-signed
-
-**Usage:**
-```bash
-./scripts/check-commit-signing.sh
-```
-
-**What it does:**
-- Checks Git configuration for GPG signing
-- Verifies GPG key exists
-- Validates signing setup
-- Provides setup instructions if not configured
-
-**Output:**
-- ✅ Commit signing configured
-- ℹ️ Setup instructions
-
----
-
-### 16. `ensure_base64.sh`
-
-**Purpose:** Helper to encode files to base64
-
-**Usage:**
-```bash
-./scripts/ensure_base64.sh <file>
-```
-
-**What it does:**
-- Encodes file to base64
-- Handles platform differences (macOS vs Linux)
-- Outputs to stdout or file
-
-**Use cases:**
-- Manually encode secrets for GitHub Actions
-- Quick base64 encoding
-
----
-
-### 17. `fix-detekt-permissions.sh`
-
-**Purpose:** Fix Detekt configuration file permissions
-
-**Usage:**
-```bash
-./scripts/fix-detekt-permissions.sh
-```
-
-**What it does:**
-- Finds Detekt config files (`detekt.yml`, `detekt-config.yml`)
-- Sets correct permissions (644)
-- Fixes "Permission denied" errors
-
-**When needed:**
-- After cloning repository
-- If Detekt fails with permission errors
-
----
-
-## Common Tasks
-
-### Initial Project Setup
-
-```bash
-# Complete setup (interactive)
-./setup-project.sh
-
-# OR step-by-step:
-
-# 1. Customize package names
-scripts/white-label/customize.sh
-
-# 2. Setup Firebase
-scripts/white-label/firebase.sh
-
-# 3. Generate keystores
-scripts/white-label/keystore.sh generate
-
-# 4. Encode secrets for GitHub Actions
-scripts/white-label/keystore.sh encode-secrets
-
-# 5. Add secrets to GitHub (requires gh CLI)
-scripts/white-label/keystore.sh add
-
-# 6. Setup iOS (if needed)
-./scripts/ios/setup_ios_complete.sh
-```
-
----
-
-### iOS Deployment
-
-```bash
-# Deploy to Firebase
-./scripts/deploy/deploy_firebase.sh
-
-# Deploy to TestFlight
-./scripts/deploy/deploy_testflight.sh
-
-# Deploy to App Store (double confirmation required)
-./scripts/deploy/deploy_appstore.sh
-```
-
----
-
-### Secrets Management
-
-```bash
-# Synchronize all secrets to secrets.env (recommended)
-scripts/white-label/keystore.sh sync
-
-# View current secrets
-scripts/white-label/keystore.sh view
-
-# Encode all secrets
-scripts/white-label/keystore.sh encode-secrets
-
-# Add secrets to GitHub
-scripts/white-label/keystore.sh add
-
-# List GitHub secrets
-scripts/white-label/keystore.sh list
-
-# Delete a secret
-scripts/white-label/keystore.sh delete --name SECRET_NAME
-
-# Delete all secrets (with confirmation)
-scripts/white-label/keystore.sh delete-all
-```
-
----
-
-### Verification
-
-```bash
-# Check environment prerequisites
-./scripts/check_environment.sh
-
-# Verify iOS deployment setup
-./scripts/ios/verify_ios_deployment.sh
-
-# Check version sanitization
-./scripts/ios/check_ios_version.sh
-
-# Validate environment file
-./scripts/check_file_env_keys.sh secrets.env
+# strip the demo showcase
+scripts/remove-demo.sh --apply
 ```
 
 ---
 
 ## Troubleshooting
 
-### Setup Issues
+**`bundle exec` fails inside `activate_bin_path`** — the interpreter, not the gems. Run
+`eval "$(rbenv init -)"`, or check with `. scripts/ruby-exec.sh && ruby_exec_report`.
 
-#### 1. `setup-project.sh` fails with "Command not found"
+**A script cannot find `gradle/fork.properties` values** — it is derived from `app-profile/`. Run
+`./gradlew syncForkConfig`; never hand-edit the bridge.
 
-**Cause:** Missing prerequisite tools
+**`customization-surface.sh resolve` disagrees with what a sync did** — the contract's default is
+**template-first** (`**` → `template`); fork territory is declared explicitly. A path resolving
+`template` unexpectedly means no rule claims it.
 
-**Fix:**
-```bash
-# Check what's missing
-./scripts/check_environment.sh
-
-# Install missing tools (macOS)
-brew install git gh firebase-cli
-```
-
----
-
-#### 2. `scripts/white-label/customize.sh` doesn't update package names
-
-**Cause:** Script requires interactive input
-
-**Fix:**
-- Run script in terminal (not via IDE)
-- Provide valid package name (e.g., `com.example.app`)
-
----
-
-#### 3. `scripts/white-label/firebase.sh` fails with "Authentication error"
-
-**Cause:** Not logged into Firebase CLI
-
-**Fix:**
-```bash
-firebase login
-```
-
----
-
-### Keystore Issues
-
-#### 4. `scripts/white-label/keystore.sh generate` fails
-
-**Cause:** Missing `keytool` or `openssl`
-
-**Fix:**
-```bash
-# Check if Java is installed
-java -version
-
-# Install if missing (macOS)
-brew install openjdk@17
-
-# Check OpenSSL
-openssl version
-brew install openssl  # if missing
-```
-
----
-
-#### 5. Secrets not added to GitHub
-
-**Cause:** GitHub CLI not authenticated
-
-**Fix:**
-```bash
-gh auth login
-gh auth status  # Verify
-
-# Then retry
-scripts/white-label/keystore.sh add
-```
-
----
-
-### iOS Setup Issues
-
-#### 6. `setup_ios_complete.sh` can't generate SSH key
-
-**Cause:** Missing `ssh-keygen`
-
-**Fix:**
-```bash
-# macOS (should be installed by default)
-xcode-select --install
-
-# Verify
-ssh-keygen -V
-```
-
----
-
-#### 7. Match repository access denied
-
-**Cause:** SSH public key not added to repository
-
-**Fix:**
-1. Get public key:
-   ```bash
-   cat secrets/apple/match/match_ci_key.pub
-   ```
-2. Go to Match repository → Settings → Deploy keys
-3. Add public key with write access
-
----
-
-### Deployment Issues
-
-#### 8. `deploy_firebase.sh` fails with "Secrets not found"
-
-**Cause:** Required secret files missing under `secrets/apple/` or `gradle/fork.properties` not filled in.
-
-**Fix:**
-```bash
-# Run iOS setup wizard
-./scripts/ios/setup_ios_complete.sh
-
-# OR manually create the required files:
-# - gradle/fork.properties (from gradle/fork.properties.template)
-# - secrets/apple/appstore/key_id, issuer_id, AuthKey.p8
-# - secrets/apple/match/match_ci_key, .match_password
-```
-
----
-
-#### 9. `verify_ios_deployment.sh` reports failures
-
-**Cause:** Incomplete iOS setup
-
-**Fix:**
-- Read failure messages carefully
-- Each check has specific fix instructions
-- Re-run setup wizard if needed:
-  ```bash
-  ./scripts/ios/setup_ios_complete.sh
-  ```
-
----
-
-### Version Issues
-
-#### 10. Version mismatch between platforms
-
-**Cause:** Gradle version not compatible with App Store
-
-**Fix:**
-- Fastlane automatically sanitizes versions
-- Check with: `./scripts/ios/check_ios_version.sh`
-- See [Version Handling Guide](../docs/claude/version-handling.md)
-
----
-
-**Need more help?**
-- [Deployment Playbook](../docs/claude/deployment-playbook.md)
-- [Secrets Management Guide](../docs/claude/secrets-management.md)
-- [Troubleshooting Guide](../docs/claude/troubleshooting.md)
-- [Known Issues](../docs/analysis/BUGS_AND_ISSUES.md)
+Deeper guides: [Troubleshooting](../docs/claude/troubleshooting.md) ·
+[Deployment Playbook](../docs/claude/deployment-playbook.md) ·
+[Secrets Management](../docs/claude/secrets-management.md)
 
 [← Back to Main](../CLAUDE.md)

--- a/scripts/customization-surface.sh
+++ b/scripts/customization-surface.sh
@@ -154,7 +154,21 @@ cs_match_g() {
       return 0
     fi
   done
-  CS_M_OWNER="fork"; CS_M_STRAT=""; CS_M_DEFAULT="1"   # fallback = fork (never clobber unknown)
+  # TEMPLATE-FIRST fallback. This repo IS the template: the default answer to "who owns this?" is
+  # the template, and FORK territory is declared explicitly (`core/**`, `feature/**`, `app-profile/**`,
+  # the branding carve-outs) rather than inferred from silence.
+  #
+  # It used to be `fork` — "never clobber unknown" — which is the safe default for a CONSUMER but the
+  # wrong one for a template: a directory the template ADDS and nobody writes a rule for silently
+  # becomes fork-owned and never syncs to anyone. `tools/**` (the KSP processors driving every
+  # @StoreProvider / @DbEntity / @ApiBinding) and `.bundle/**` both sat in exactly that state.
+  #
+  # Flipping is safe BECAUSE fork territory is explicitly claimed: `core/store/.../quests/X.kt` and
+  # `feature/quests/X.kt` resolve `fork` through their module catch-alls, not through this line.
+  # Verified against the tree at the time of the change — all 2712 tracked files matched an explicit
+  # rule, so ZERO existing paths change owner. Only genuinely-unclaimed NEW paths move, and by the
+  # template-first principle those are the template's.
+  CS_M_OWNER="template"; CS_M_STRAT=""; CS_M_DEFAULT="1"
 }
 
 cs_resolve_owner()    { cs_match_g "$1"; printf '%s' "$CS_M_OWNER"; }

--- a/scripts/ios/setup_ios_complete.sh
+++ b/scripts/ios/setup_ios_complete.sh
@@ -469,15 +469,19 @@ export MATCH_PASSWORD
 
 # Install Fastlane
 print_info "Installing Fastlane dependencies..."
-bundle install
+# Bundler through the ONE resolver (scripts/ruby-exec.sh) rather than PATH: without rbenv's shims on
+# PATH a bare `bundle` runs under macOS's system ruby 2.6.10 and dies inside rubygems'
+# activate_bin_path with an error about GEMS, when the interpreter is the actual problem.
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/ruby-exec.sh"
+ruby_bundle "$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/deployment" -- install
 
 # Run Match for adhoc
 print_info "Syncing adhoc certificates..."
-bundle exec fastlane ios sync_certificates match_type:adhoc || print_warning "Match sync encountered issues (this is normal for first run)"
+ruby_bundle "$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/deployment" -- exec fastlane ios sync_certificates match_type:adhoc || print_warning "Match sync encountered issues (this is normal for first run)"
 
 # Run Match for appstore
 print_info "Syncing appstore certificates..."
-bundle exec fastlane ios sync_certificates match_type:appstore || print_warning "Match sync encountered issues (this is normal for first run)"
+ruby_bundle "$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/deployment" -- exec fastlane ios sync_certificates match_type:appstore || print_warning "Match sync encountered issues (this is normal for first run)"
 
 echo
 

--- a/scripts/product-health/checks/ios-pbxproj-identity.sh
+++ b/scripts/product-health/checks/ios-pbxproj-identity.sh
@@ -18,6 +18,18 @@
 #   PBX-2  every PRODUCT_BUNDLE_IDENTIFIER value ∈ { "$(APP_BUNDLE_ID)", "$(inherited)" }.
 #   PBX-3  every PROVISIONING_PROFILE_SPECIFIER is empty "" OR references $(APP_BUNDLE_ID) —
 #          never a hardcoded profile name (let match / automatic signing resolve it).
+#   PBX-4  every DEVELOPMENT_TEAM is "" or "$(TEAM_ID)" — never a literal 10-char Apple team id.
+#
+# PBX-4 exists because the gap was not hypothetical: this template shipped
+# `DEVELOPMENT_TEAM = L432S2FZP5` — one real organisation's Apple team id — to every fork, through
+# TWO separate commits (862f2e4a, 99083ed2), and it survived until 2026-09-10. PBX-1..3 all passed
+# the whole time; none of them looks at DEVELOPMENT_TEAM. The value reached at least one downstream
+# fork whose own team is different, where it would sign against the wrong team.
+#
+# `team_id` is already a first-class app-profile field with a complete projection chain —
+# app-profile/platforms/apple/apple.yaml#apple.team_id → fork.properties#apple.team.id →
+# SyncForkConfigPlugin → Config.xcconfig#TEAM_ID → $(TEAM_ID). A literal in the pbxproj bypasses all
+# of it, and because syncForkConfig never touches project.pbxproj, nothing downstream corrects it.
 #
 # exit 0 = PASS · 1 = FAIL (blocks customize + CI). No cmp-ios project → PASS (nothing to guard).
 set -uo pipefail
@@ -37,11 +49,22 @@ if grep -q 'org\.mifos\.kmp\.template' "$PBX"; then
   fail=1
 fi
 
-# PBX-2 — PRODUCT_BUNDLE_IDENTIFIER must be a derived token, never a literal id.
+# PBX-2 — PRODUCT_BUNDLE_IDENTIFIER must be DERIVED from $(APP_BUNDLE_ID), never a literal id.
+#
+# A SUFFIXED derivation is correct and must pass. Apple requires an app extension's bundle id to be
+# a child of its host app's ("$(APP_BUNDLE_ID).widgets"), so any fork shipping a WidgetKit widget,
+# share extension, or notification-service extension has one — that is the platform's rule, not a
+# fork's shortcut, and it contains no literal. An exact-match-only regex rejected it and would have
+# blocked that whole class of fork: measured on mbs/cappy, whose real project carries
+# "$(APP_BUNDLE_ID).widgets" and "$(APP_BUNDLE_ID).demo.widgets" for its CappyWidgets target.
+#
+# The invariant this check exists for is "no hardcoded identity", and a value BUILT FROM the token
+# satisfies it. PBX-3 next door already matched on substring for exactly this reason; PBX-2 was the
+# inconsistent one.
 bad_bid="$(grep -oE 'PRODUCT_BUNDLE_IDENTIFIER = "[^"]*"' "$PBX" \
-  | grep -vE 'PRODUCT_BUNDLE_IDENTIFIER = "\$\((APP_BUNDLE_ID|inherited)\)"' || true)"
+  | grep -vE 'PRODUCT_BUNDLE_IDENTIFIER = "[^"]*\$\((APP_BUNDLE_ID|inherited)\)[^"]*"' || true)"
 if [ -n "$bad_bid" ]; then
-  echo "${C_RED}✗ PBX-2${C_RST}: PRODUCT_BUNDLE_IDENTIFIER must be \"\$(APP_BUNDLE_ID)\" or \"\$(inherited)\", found:"
+  echo "${C_RED}✗ PBX-2${C_RST}: PRODUCT_BUNDLE_IDENTIFIER must derive from \"\$(APP_BUNDLE_ID)\" (a \".suffix\" is fine) or be \"\$(inherited)\", found:"
   printf '%s\n' "$bad_bid" | sort -u | sed 's/^/       /'
   fail=1
 fi
@@ -55,10 +78,28 @@ if [ -n "$bad_prof" ]; then
   fail=1
 fi
 
+# PBX-4 — DEVELOPMENT_TEAM must be the $(TEAM_ID) indirection or empty; never a literal team id.
+# Apple team ids are exactly 10 uppercase alphanumerics, which is specific enough to match on
+# without flagging "" or $(TEAM_ID).
+bad_team="$(grep -oE 'DEVELOPMENT_TEAM = [^;]*' "$PBX" \
+  | grep -vE 'DEVELOPMENT_TEAM = ""|DEVELOPMENT_TEAM = "?\$\(TEAM_ID\)"?' || true)"
+if [ -n "$bad_team" ]; then
+  echo "${C_RED}✗ PBX-4${C_RST}: DEVELOPMENT_TEAM must be \"\$(TEAM_ID)\" or empty — found a literal team id:"
+  printf '%s\n' "$bad_team" | sort -u | sed 's/^/       /'
+  echo "       The team id belongs in app-profile/platforms/apple/apple.yaml#apple.team_id;"
+  echo "       ./gradlew syncForkConfig projects it to Config.xcconfig#TEAM_ID."
+  fail=1
+fi
+
 if [ "$fail" = 0 ]; then
-  echo "${C_GRN}✓${C_RST} iOS project derives bundle id + provisioning from Config.xcconfig (no hardcoded identity)"
+  echo "${C_GRN}✓${C_RST} iOS project derives bundle id + team + provisioning from Config.xcconfig (no hardcoded identity)"
   exit 0
 fi
 echo "  ↳ fix: on the offending XCBuildConfiguration(s) in cmp-ios/iosApp.xcodeproj/project.pbxproj set"
-echo "         PRODUCT_BUNDLE_IDENTIFIER = \"\$(APP_BUNDLE_ID)\"  and  PROVISIONING_PROFILE_SPECIFIER = \"\"."
+echo "         PRODUCT_BUNDLE_IDENTIFIER = \"\$(APP_BUNDLE_ID)\"   (an app extension may suffix it: \".widgets\")"
+echo "         DEVELOPMENT_TEAM          = \"\$(TEAM_ID)\""
+echo "         PROVISIONING_PROFILE_SPECIFIER = \"\""
+echo "       The real values come from app-profile — app.yaml / platforms/apple/apple.yaml#apple.team_id —"
+echo "       via ./gradlew syncForkConfig, which writes Config.xcconfig. It never edits project.pbxproj,"
+echo "       so a literal here is invisible to the SoT and survives every sync."
 exit 1

--- a/scripts/product-health/checks/pbxproj-merge.sh
+++ b/scripts/product-health/checks/pbxproj-merge.sh
@@ -72,7 +72,7 @@ done
 # ── ruby availability (skip, don't fail) ────────────────────────────────────
 # shellcheck source=/dev/null
 . "$HEALTH_ROOT/scripts/ruby-exec.sh" 2>/dev/null || true
-if ! declare -F ruby_bundle >/dev/null 2>&1; then
+if ! declare -F ruby_exec >/dev/null 2>&1; then
   say "⚠️ PBX" "ruby-exec.sh unavailable — merge checks skipped (engine falls back to KEEP-OURS)"
   # ── PM-6 — plist union ──────────────────────────────────────────────────────
 PLIST_MERGER="${PM_PLIST_MERGER:-$HEALTH_ROOT/scripts/white-label/merge-plist.rb}"
@@ -192,7 +192,12 @@ proj = Xcodeproj::Project.open(File.dirname(ARGV[0]))
 abort "no targets" if proj.targets.empty?
 puts "#{proj.objects.count} objects, targets: #{proj.targets.map(&:name).sort.join(', ')}"
 RB
-  if out5="$(ruby_bundle "$HEALTH_ROOT" -- exec ruby "$WORK/verify.rb" "$OUT" 2>&1 | tail -1)"; then
+  # ruby_exec, NOT ruby_bundle — the same path the merger itself took two checks above. Routing this
+  # one through bundler asks for a fully-installed Gemfile in the repo, which CI deliberately does
+  # not have (`bundler-cache: false`, so the ~10s job does not drag in the fastlane tree). It died in
+  # `<internal:gem_prelude>` on the runner while PM-2..PM-4 passed on the very same merged file —
+  # a failure about bundler, reported as "the merged graph does not re-open".
+  if out5="$(ruby_exec "$WORK/verify.rb" "$OUT" 2>&1 | tail -1)"; then
     say "✅ PM-5" "graph re-opens — $out5"
   else
     bad PM-5 "merged graph does not re-open: $out5"

--- a/scripts/product-health/checks/pbxproj-merge.sh
+++ b/scripts/product-health/checks/pbxproj-merge.sh
@@ -101,6 +101,7 @@ else
   [ "$pm6" -eq 0 ] && say "✅ PM-6" "plist union keeps both sides' keys and the result parses"
 fi
 
+# 0 PASS · 1 FAIL (blocks) · 2 WARN (gem unavailable — canary not exercised, non-blocking)
 exit "$fail"
 fi
 
@@ -116,9 +117,30 @@ if [ "$lm" -eq 0 ]; then
   bad PM-2 "git merge-file does NOT conflict on this fixture — the canary no longer proves anything"
 fi
 
-if ruby_bundle "$HEALTH_ROOT" -- exec ruby "$MERGER" \
-     --ours "$FIX/ours.pbxproj" --base "$FIX/base.pbxproj" --theirs "$FIX/theirs.pbxproj" \
-     --out "$OUT" >"$WORK/log" 2>&1; then
+# Plain interpreter first, bundler only if the gem is genuinely absent — mirrors what
+# merge_pbxproj_3way does in the engine, so this check exercises the real code path.
+ruby_exec "$MERGER" --ours "$FIX/ours.pbxproj" --base "$FIX/base.pbxproj" \
+  --theirs "$FIX/theirs.pbxproj" --out "$OUT" >"$WORK/log" 2>&1
+mrc=$?
+if [ "$mrc" -eq 2 ] && declare -F ruby_bundle >/dev/null 2>&1; then
+  ruby_bundle "$HEALTH_ROOT" -- exec ruby "$MERGER" \
+    --ours "$FIX/ours.pbxproj" --base "$FIX/base.pbxproj" --theirs "$FIX/theirs.pbxproj" \
+    --out "$OUT" >"$WORK/log" 2>&1
+  mrc=$?
+fi
+
+# Exit 2 means the `xcodeproj` gem is unavailable — NOT that the merge is broken. merge-pbxproj.rb
+# reserves that code for exactly this, and the engine treats it the same way (keep-ours, never
+# take-theirs). A runner without the gem cannot exercise the canary, and failing the build there
+# would block every fork whose CI does not install it for a capability the fork may never use.
+# It is a WARN — visible and clearable — not a pass and not a failure.
+GEM_MISSING=0
+if [ "$mrc" -eq 2 ]; then
+  GEM_MISSING=1
+  say "⚠️ PM-2" "the xcodeproj gem is unavailable here — pbxproj merge NOT exercised (PM-3..PM-5 skipped)"
+  echo "           clear it with:  gem install xcodeproj --no-document   (it also ships as a fastlane transitive)"
+  [ "$fail" -eq 0 ] && fail=2
+elif [ "$mrc" -eq 0 ]; then
   m="$(grep -c '^<<<<<<<\|^>>>>>>>' "$OUT" 2>/dev/null || true)"; m="${m:-0}"
   if [ "$m" -eq 0 ]; then
     say "✅ PM-2" "structural merge clean (git merge-file left $lm marker(s) on the same inputs)"
@@ -129,6 +151,11 @@ else
   bad PM-2 "merger exited non-zero: $(tail -3 "$WORK/log" | tr '\n' ' ')"
 fi
 
+# A sub-check that quietly does not run reads exactly like one that passed. When the merge produced
+# no output these three used to disappear from the report entirely — say so instead.
+if [ ! -f "$OUT" ] && [ "$GEM_MISSING" -eq 0 ]; then
+  bad PM-3 "no merged pbxproj was produced — PM-3..PM-5 could not run"
+fi
 if [ -f "$OUT" ]; then
   # ── PM-3 ─────────────────────────────────────────────────────────────────
   miss=""

--- a/scripts/product-health/checks/pbxproj-merge.sh
+++ b/scripts/product-health/checks/pbxproj-merge.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# checks/pbxproj-merge.sh — the Xcode project survives a template sync intact.
+#
+# `project.pbxproj` is the one file in the sync surface where a line-based 3-way is not merely worse
+# but UNUSABLE. It is a serialized object graph keyed by 24-hex UUIDs, so "add a target" rewrites
+# UUID arrays three levels away from the object it adds; git merge-file reads adjacent array
+# insertions as a conflict, and a conflict marker inside a pbxproj makes the project unopenable —
+# a human cannot even use Xcode to resolve what the merge produced.
+#
+# It is tractable anyway because the UUIDs are STABLE ACROSS THE FORK BOUNDARY: a fork's project
+# descends from the template's, so the same object carries the same key on both sides (measured:
+# 33 of 36 shared). That turns a hopeless text merge into an ordinary keyed 3-way.
+#
+# Run against tests/fixtures/pbxproj-3way-canary/ — real captured data, both sides genuinely
+# diverged from the base. See that directory's README for what each file is.
+#
+#   PM-1  the merger exists, is valid ruby, and the contract routes pbxproj to pbxproj-3way
+#   PM-2  the canary merges with exit 0 and ZERO conflict markers
+#          (and git merge-file on the same inputs really does conflict — else PM-2 is vacuous)
+#   PM-3  both sides' content survives: template SPM migration AND the fork's extension target
+#   PM-4  no dangling UUID references — every UUID named in a list has an object
+#   PM-5  the merged graph re-opens through the xcodeproj gem (the real structural validation)
+#   PM-6  Info.plist / *.entitlements union: both sides' keys survive and the result PARSES
+#
+# PM-6 covers the same sync surface with a different failure. Both files are a flat <dict> each
+# side adds its OWN keys to, and every one of those keys is required: the template's
+# keychain-access-groups (without it core-base/datastore fails errSecMissingEntitlement -34018 at
+# launch) alongside the fork's app-group (widget shared container) and CFBundleURLTypes (the OAuth
+# redirect — delete it and sign-in silently never returns). Union is the only answer that keeps the
+# app working, so PM-6 asserts BOTH sides' keys survive AND the output parses.
+# Measured: `iosApp.entitlements` is add/add against the fork's base, where a line merge conflicts
+# and the result fails plutil. `Info.plist` line-merges cleanly today and is covered for the same
+# shape, not for a present breakage.
+#
+# Skips (exit 0, WARN) when ruby/bundler is unavailable — the same degradation the engine takes,
+# where the fallback is KEEP-OURS, never take-theirs.
+#
+# exit 0 PASS / 1 FAIL. Bash + ruby.
+set -uo pipefail
+: "${HEALTH_ROOT:?pbxproj-merge: HEALTH_ROOT not set (run via product-health.sh)}"
+# PM_MERGER lets the canary point at a deliberately-broken copy while still using THIS repo's
+# bundler/ruby toolchain — a RED fixture that fakes HEALTH_ROOT instead loses the gem environment
+# and fails for the wrong reason, which proves nothing.
+MERGER="${PM_MERGER:-$HEALTH_ROOT/scripts/white-label/merge-pbxproj.rb}"
+FIX="${PM_FIXTURE:-$HEALTH_ROOT/tests/fixtures/pbxproj-3way-canary}"
+CS="$HEALTH_ROOT/scripts/customization-surface.sh"
+
+fail=0
+say() { printf '  %-8s %s\n' "$1" "$2"; }
+bad() { say "❌ $1" "$2"; fail=1; }
+
+# ── PM-1 ───────────────────────────────────────────────────────────────────
+if [ ! -f "$MERGER" ]; then
+  bad PM-1 "merge-pbxproj.rb missing — pbxproj would fall back to a line merge"
+elif ! { . "$HEALTH_ROOT/scripts/ruby-exec.sh" 2>/dev/null; ruby_exec -c "$MERGER" >/dev/null 2>&1; }; then
+  # Pinned interpreter, never PATH ruby: macOS ships 2.6.10, which rejects 3.x syntax the mergers
+  # legitimately use (endless method defs). A PATH check would fail a perfectly valid script.
+  bad PM-1 "merge-pbxproj.rb is not valid ruby"
+else
+  got="$( (cd "$HEALTH_ROOT" && bash "$CS" resolve "cmp-ios/iosApp.xcodeproj/project.pbxproj" 2>/dev/null) )"
+  case "$got" in
+    *merge*pbxproj-3way*) say "✅ PM-1" "merger present; contract routes pbxproj → pbxproj-3way" ;;
+    *) bad PM-1 "contract resolves pbxproj to '${got#* }' — expected merge (strategy: pbxproj-3way)" ;;
+  esac
+fi
+
+for f in base ours theirs; do
+  [ -f "$FIX/$f.pbxproj" ] || { bad PM-0 "canary input missing: $FIX/$f.pbxproj"; fail=1; }
+done
+[ "$fail" -eq 0 ] || exit 1
+
+# ── ruby availability (skip, don't fail) ────────────────────────────────────
+# shellcheck source=/dev/null
+. "$HEALTH_ROOT/scripts/ruby-exec.sh" 2>/dev/null || true
+if ! declare -F ruby_bundle >/dev/null 2>&1; then
+  say "⚠️ PBX" "ruby-exec.sh unavailable — merge checks skipped (engine falls back to KEEP-OURS)"
+  # ── PM-6 — plist union ──────────────────────────────────────────────────────
+PLIST_MERGER="${PM_PLIST_MERGER:-$HEALTH_ROOT/scripts/white-label/merge-plist.rb}"
+if [ ! -f "$PLIST_MERGER" ]; then
+  bad PM-6 "merge-plist.rb missing — Info.plist/entitlements would fall back to a line merge"
+else
+  pm6=0
+  for pair in "entitlements:com.apple.security.application-groups:keychain-access-groups" \
+              "infoplist:CFBundleURLTypes:CFBundleIdentifier"; do
+    n="${pair%%:*}"; rest="${pair#*:}"; forkkey="${rest%%:*}"; tmplkey="${rest##*:}"
+    [ -f "$FIX/$n.ours" ] && [ -f "$FIX/$n.theirs" ] || { bad PM-6 "canary input missing: $FIX/$n.*"; pm6=1; continue; }
+    out="$WORK/$n.union"
+    # `--base -` is the measured reality: both files are add/add against the fork's base.
+    if ruby_exec "$PLIST_MERGER" --ours "$FIX/$n.ours" --base - --theirs "$FIX/$n.theirs" \
+         --out "$out" >"$WORK/plog.$n" 2>&1 && [ -f "$out" ]; then
+      grep -q "<key>$forkkey</key>" "$out" || { bad PM-6 "$n: lost the fork's $forkkey"; pm6=1; }
+      grep -q "<key>$tmplkey</key>" "$out" || { bad PM-6 "$n: lost the template's $tmplkey"; pm6=1; }
+      if command -v plutil >/dev/null 2>&1 && ! plutil -lint "$out" >/dev/null 2>&1; then
+        bad PM-6 "$n: merged plist does not parse"; pm6=1
+      fi
+      grep -q '^<<<<<<<' "$out" && { bad PM-6 "$n: conflict markers in an XML plist"; pm6=1; }
+    else
+      bad PM-6 "$n: merger failed — $(tail -2 "$WORK/plog.$n" | tr '\n' ' ')"; pm6=1
+    fi
+  done
+  [ "$pm6" -eq 0 ] && say "✅ PM-6" "plist union keeps both sides' keys and the result parses"
+fi
+
+exit "$fail"
+fi
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/out.xcodeproj"
+OUT="$WORK/out.xcodeproj/project.pbxproj"
+
+# ── PM-2 — and prove the check is not vacuous ──────────────────────────────
+cp "$FIX/ours.pbxproj" "$WORK/lineattempt"
+git merge-file "$WORK/lineattempt" "$FIX/base.pbxproj" "$FIX/theirs.pbxproj" >/dev/null 2>&1
+lm="$(grep -c '^<<<<<<<\|^>>>>>>>' "$WORK/lineattempt" 2>/dev/null || true)"; lm="${lm:-0}"
+if [ "$lm" -eq 0 ]; then
+  bad PM-2 "git merge-file does NOT conflict on this fixture — the canary no longer proves anything"
+fi
+
+if ruby_bundle "$HEALTH_ROOT" -- exec ruby "$MERGER" \
+     --ours "$FIX/ours.pbxproj" --base "$FIX/base.pbxproj" --theirs "$FIX/theirs.pbxproj" \
+     --out "$OUT" >"$WORK/log" 2>&1; then
+  m="$(grep -c '^<<<<<<<\|^>>>>>>>' "$OUT" 2>/dev/null || true)"; m="${m:-0}"
+  if [ "$m" -eq 0 ]; then
+    say "✅ PM-2" "structural merge clean (git merge-file left $lm marker(s) on the same inputs)"
+  else
+    bad PM-2 "$m conflict marker(s) in the merged pbxproj — the project would not open"
+  fi
+else
+  bad PM-2 "merger exited non-zero: $(tail -3 "$WORK/log" | tr '\n' ' ')"
+fi
+
+if [ -f "$OUT" ]; then
+  # ── PM-3 ─────────────────────────────────────────────────────────────────
+  miss=""
+  for tok in XCLocalSwiftPackageReference KotlinMultiplatformLinkedPackage \
+             CappyWidgets PayCraftStoreKit2.swift CODE_SIGN_ENTITLEMENTS; do
+    grep -q "$tok" "$OUT" || miss="$miss $tok"
+  done
+  if [ -z "$miss" ]; then
+    say "✅ PM-3" "template SPM migration landed AND the fork's extension target survived"
+  else
+    bad PM-3 "merged pbxproj lost:$miss"
+  fi
+
+  # ── PM-4 ─────────────────────────────────────────────────────────────────
+  # Every 24-hex UUID that appears as a LIST ELEMENT must have an object definition. A dangling
+  # reference is the silent-loss failure: the gem drops it on load and the merge still "passes".
+  defined="$WORK/def"; referenced="$WORK/ref"
+  grep -oE '^	*[0-9A-F]{24} ' "$OUT" | tr -d ' \t' | sort -u > "$defined"
+  grep -oE '^				[0-9A-F]{24} ' "$OUT" | tr -d ' \t' | sort -u > "$referenced"
+  dang="$(comm -13 "$defined" "$referenced" | wc -l | tr -d ' ')"; dang="${dang:-0}"
+  if [ "$dang" -eq 0 ]; then
+    say "✅ PM-4" "no dangling UUID references"
+  else
+    bad PM-4 "$dang UUID(s) referenced in a list with no object definition"
+    comm -13 "$defined" "$referenced" | head -5 | sed 's/^/           /'
+  fi
+
+  # ── PM-5 ─────────────────────────────────────────────────────────────────
+  # The merger already round-trips through Xcodeproj::Project on write; re-open independently so a
+  # regression that removes that validation is still caught here.
+  cat > "$WORK/verify.rb" <<'RB'
+require 'xcodeproj'
+proj = Xcodeproj::Project.open(File.dirname(ARGV[0]))
+abort "no targets" if proj.targets.empty?
+puts "#{proj.objects.count} objects, targets: #{proj.targets.map(&:name).sort.join(', ')}"
+RB
+  if out5="$(ruby_bundle "$HEALTH_ROOT" -- exec ruby "$WORK/verify.rb" "$OUT" 2>&1 | tail -1)"; then
+    say "✅ PM-5" "graph re-opens — $out5"
+  else
+    bad PM-5 "merged graph does not re-open: $out5"
+  fi
+fi
+
+# ── PM-6 — plist union ──────────────────────────────────────────────────────
+PLIST_MERGER="${PM_PLIST_MERGER:-$HEALTH_ROOT/scripts/white-label/merge-plist.rb}"
+if [ ! -f "$PLIST_MERGER" ]; then
+  bad PM-6 "merge-plist.rb missing — Info.plist/entitlements would fall back to a line merge"
+else
+  pm6=0
+  for pair in "entitlements:com.apple.security.application-groups:keychain-access-groups" \
+              "infoplist:CFBundleURLTypes:CFBundleIdentifier"; do
+    n="${pair%%:*}"; rest="${pair#*:}"; forkkey="${rest%%:*}"; tmplkey="${rest##*:}"
+    [ -f "$FIX/$n.ours" ] && [ -f "$FIX/$n.theirs" ] || { bad PM-6 "canary input missing: $FIX/$n.*"; pm6=1; continue; }
+    out="$WORK/$n.union"
+    # `--base -` is the measured reality: both files are add/add against the fork's base.
+    if ruby_exec "$PLIST_MERGER" --ours "$FIX/$n.ours" --base - --theirs "$FIX/$n.theirs" \
+         --out "$out" >"$WORK/plog.$n" 2>&1 && [ -f "$out" ]; then
+      grep -q "<key>$forkkey</key>" "$out" || { bad PM-6 "$n: lost the fork's $forkkey"; pm6=1; }
+      grep -q "<key>$tmplkey</key>" "$out" || { bad PM-6 "$n: lost the template's $tmplkey"; pm6=1; }
+      if command -v plutil >/dev/null 2>&1 && ! plutil -lint "$out" >/dev/null 2>&1; then
+        bad PM-6 "$n: merged plist does not parse"; pm6=1
+      fi
+      grep -q '^<<<<<<<' "$out" && { bad PM-6 "$n: conflict markers in an XML plist"; pm6=1; }
+    else
+      bad PM-6 "$n: merger failed — $(tail -2 "$WORK/plog.$n" | tr '\n' ' ')"; pm6=1
+    fi
+  done
+  [ "$pm6" -eq 0 ] && say "✅ PM-6" "plist union keeps both sides' keys and the result parses"
+fi
+
+exit "$fail"

--- a/scripts/product-health/checks/ruby-toolchain-coherence.sh
+++ b/scripts/product-health/checks/ruby-toolchain-coherence.sh
@@ -33,6 +33,14 @@
 #         deployment`. Left at its default '.', fastlane resolves against the ROOT Fastfile — whose
 #         only lane is `ios build_ios` — and the job dies with "Could not find lane" after a full
 #         build. Checked across ALL callers, because a repo accumulates them.
+#   RT-9  no tracked script invokes bundler DIRECTLY — every caller goes through scripts/ruby-exec.sh.
+#         RT-4 bans the `#!/usr/bin/ruby` shebang for bypassing rbenv; a bare `bundle exec` bypasses it
+#         exactly the same way, just one level up: `bundle` on PATH belongs to whichever ruby owns it,
+#         which on a shell without rbenv's shims is the system 2.6.10. ruby-exec.sh resolves the pinned
+#         interpreter from .ruby-version DIRECTLY (via `$(rbenv root)/versions/<pin>/bin/ruby`), so it
+#         works whether or not shims are on PATH — that is the whole point, and a caller that skips it
+#         re-opens the trap for everyone.
+#
 #   RT-8  (WARN, non-blocking) the live interpreter matches .ruby-version. This is the trap in the
 #         header above, made self-diagnosing: a shell without rbenv's shims on PATH silently gets
 #         /usr/bin/ruby 2.6 and `bundle exec` dies deep inside rubygems' activate_bin_path with
@@ -172,6 +180,41 @@ if command -v ruby >/dev/null 2>&1; then
     echo "       Fix the shell:  eval \"\$(rbenv init -)\"   (or add ~/.rbenv/shims to PATH)"
     warn=2
   fi
+fi
+
+# ── RT-9 — bundler is reached ONLY through scripts/ruby-exec.sh ────────────────────────────────
+# Sibling of RT-4: that bans `#!/usr/bin/ruby` for bypassing rbenv, this bans a bare `bundle` for
+# bypassing it one level up. `bundle` on PATH belongs to whichever ruby owns it, so on a shell
+# without rbenv shims it is the system 2.6.10 and every gem was installed for the pinned version.
+#
+# Scope: tracked *.sh only, excluding the resolver itself (it must name `bundle` to call it), this
+# checker (it must name the pattern to detect it), and the canary fixtures. ECHOED instructions are
+# allowed — a script printing "run: bundle exec fastlane …" for a human is documentation, not an
+# invocation, so the match is anchored to a command position.
+rt9_offenders=""
+while IFS= read -r f; do
+  case "$f" in
+    scripts/ruby-exec.sh|scripts/product-health/checks/ruby-toolchain-coherence.sh) continue ;;
+    scripts/product-health/tests/*) continue ;;
+  esac
+  # command position: start of line, or after `&&`, `||`, `;`, `(`, or a pipe — never inside echo/printf
+  if grep -nE '(^|[;&|(]|&&|\|\|)[[:space:]]*bundle[[:space:]]+(exec|install|update|lock)\b' "$f" 2>/dev/null \
+       | grep -qvE '^[0-9]+:[[:space:]]*#'; then
+    rt9_offenders="$rt9_offenders $f"
+  fi
+done < <(git ls-files '*.sh' 2>/dev/null)
+
+if [ -n "$rt9_offenders" ]; then
+  echo "${C_RED}✗ RT-9${C_RST}: script(s) invoke bundler directly instead of via scripts/ruby-exec.sh:"
+  for f in $rt9_offenders; do
+    echo "       $f"
+    grep -nE '(^|[;&|(]|&&|\|\|)[[:space:]]*bundle[[:space:]]+(exec|install|update|lock)\b' "$f" \
+      | grep -vE '^[0-9]+:[[:space:]]*#' | sed 's/^/         /'
+  done
+  echo "       A bare \`bundle\` runs under whatever ruby owns it on PATH — the system 2.6.10 on a shell"
+  echo "       without rbenv shims — while the gems were installed for \$(cat .ruby-version). Use:"
+  echo "         . \"\$REPO_ROOT/scripts/ruby-exec.sh\"  &&  ruby_bundle <app-root> -- exec <cmd>"
+  fail=1
 fi
 
 if [ "$fail" -ne 0 ]; then exit "$fail"; fi

--- a/scripts/product-health/checks/ruby-toolchain-coherence.sh
+++ b/scripts/product-health/checks/ruby-toolchain-coherence.sh
@@ -41,10 +41,26 @@
 #         works whether or not shims are on PATH — that is the whole point, and a caller that skips it
 #         re-opens the trap for everyone.
 #
-#   RT-8  (WARN, non-blocking) the live interpreter matches .ruby-version. This is the trap in the
-#         header above, made self-diagnosing: a shell without rbenv's shims on PATH silently gets
-#         /usr/bin/ruby 2.6 and `bundle exec` dies deep inside rubygems' activate_bin_path with
-#         nothing naming the real cause.
+#   RT-8  (WARN, non-blocking) THE REPO can reach its pinned interpreter — asked of the repo, not of
+#         whatever shell happens to be invoking the suite.
+#
+#         It used to ask "is the ruby on PATH the pinned one?", which is a question about the
+#         OPERATOR'S SHELL. Its own message conceded as much ("Nothing is wrong in the repo"), and it
+#         warned on every terminal that had not run `eval "$(rbenv init -)"`, every CI runner, and
+#         every fresh shell — a permanent, unactionable warning, and that is the kind that teaches
+#         people to skim past the warn column.
+#
+#         Two things closed the gap it was standing in for. `scripts/ruby-exec.sh` resolves
+#         $(rbenv root)/versions/<pin>/bin/ruby DIRECTLY, so the repo reaches its interpreter whether
+#         or not shims are on PATH; and RT-9 (below) forbids any tracked *.sh from invoking bundler
+#         directly, so no script in this repo can fall into the trap at all.
+#
+#         What survives is narrower and real: the deployment docs tell a HUMAN to run a bundler lane
+#         by hand, and in a shim-less shell that still dies inside rubygems' activate_bin_path with
+#         an error naming gems rather than the interpreter. So a PATH mismatch is now an
+#         informational hint next to a PASS, and the WARN is reserved for what is genuinely the
+#         repo's problem: the resolver cannot reach the pinned version at all (no rbenv, or the pin
+#         is not installed).
 #
 # exit 0 = PASS · 1 = FAIL (blocks) · 2 = WARN. No .ruby-version → PASS (no Ruby toolchain declared).
 set -uo pipefail
@@ -169,15 +185,45 @@ if [ -d "$HEALTH_ROOT/deployment/fastlane" ] && [ -d "$HEALTH_ROOT/.github/workf
   done
 fi
 
-# RT-8 — WARN only: the interpreter this shell actually reaches.
+# RT-8 — can THIS REPO reach its pinned interpreter? (not: is PATH's ruby the pinned one)
 warn=0
-if command -v ruby >/dev/null 2>&1; then
+# RT8_RESOLVER lets the canary point at an absent/broken resolver while the rest of the tree stays
+# real. A synthetic HEALTH_ROOT cannot isolate this check — RT-6 needs a git repo to decide whether
+# .bundle/config is tracked, so it fails in any scratch dir and masks RT-8's own exit code.
+RESOLVER="${RT8_RESOLVER:-$HEALTH_ROOT/scripts/ruby-exec.sh}"
+if [ -f "$RESOLVER" ]; then
+  # Ask the resolver, in a subshell so sourcing cannot leak into this check.
+  rt8_report="$(bash -c ". '$RESOLVER' >/dev/null 2>&1; ruby_exec_report" 2>/dev/null || true)"
+  rt8_bin="$(printf '%s' "$rt8_report" | sed -n 's/^ruby-exec: \([^ ]*\).*/\1/p')"
+  rt8_ver=""
+  [ -n "$rt8_bin" ] && [ -x "$rt8_bin" ] && rt8_ver="$("$rt8_bin" -e 'print RUBY_VERSION' 2>/dev/null || true)"
+
+  if [ -z "$rt8_ver" ] || [ "$rt8_ver" != "$want" ]; then
+    # The repo's own resolver cannot produce the pinned interpreter. THIS is repo-scoped: every
+    # script that goes through ruby-exec.sh is affected, on every machine in this state.
+    echo "${C_YEL}⚠ RT-8${C_RST}: scripts/ruby-exec.sh cannot reach the pinned ruby $want."
+    echo "       resolver said: ${rt8_report:-<no output>}"
+    echo "       Install it:  rbenv install $want    (or set RUBY_EXEC_BIN to a $want interpreter)"
+    warn=2
+  else
+    # Repo is healthy. A PATH mismatch is only a hint, because the deployment docs instruct a human
+    # to run a bundler lane directly and that path does NOT go through the resolver.
+    live=""
+    command -v ruby >/dev/null 2>&1 && live="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"
+    if [ -n "$live" ] && [ "$live" != "$want" ]; then
+      echo "  note: this shell's ruby is $live ($(command -v ruby)); the repo resolves $want directly,"
+      echo "        so every script is unaffected. Only a hand-typed bundler lane would break — run"
+      echo "        eval \"\$(rbenv init -)\"  first if you intend to invoke one by hand."
+    fi
+  fi
+elif command -v ruby >/dev/null 2>&1; then
+  # No resolver in this tree (a fork that stripped it) — fall back to the old PATH question, the best
+  # available signal when nothing shim-independent exists.
   live="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"
   if [ -n "$live" ] && [ "$live" != "$want" ]; then
-    echo "${C_YEL}⚠ RT-8${C_RST}: live ruby is $live but .ruby-version declares $want ($(command -v ruby))."
-    echo "       Nothing is wrong in the repo — this shell just is not reaching the project interpreter,"
-    echo "       and 'bundle exec' will die inside rubygems' activate_bin_path with a misleading error."
-    echo "       Fix the shell:  eval \"\$(rbenv init -)\"   (or add ~/.rbenv/shims to PATH)"
+    echo "${C_YEL}⚠ RT-8${C_RST}: live ruby is $live but .ruby-version declares $want ($(command -v ruby)),"
+    echo "       and scripts/ruby-exec.sh is absent so nothing resolves the pin independently."
+    echo "       Fix the shell:  eval \"\$(rbenv init -)\"   (or restore scripts/ruby-exec.sh)"
     warn=2
   fi
 fi

--- a/scripts/product-health/checks/sync-merge-base.sh
+++ b/scripts/product-health/checks/sync-merge-base.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# checks/sync-merge-base.sh — an `owner: merge` row must actually 3-way, not silently full-copy.
+#
+# THE FAILURE THIS CATCHES
+# `owner: merge` is the contract's promise that a template update and a fork's edits BOTH survive.
+# The engine keeps that promise with `git merge-file ours base theirs` — and the promise is only as
+# good as `base`. Two fork topologies exist:
+#
+#   forked  `gh repo fork` / clone of the template. Shares history, so `git merge-base` works.
+#   copied  the template TREE copied into a fresh repo — the common case in practice. Different root
+#           commits, ZERO shared commits, and `git merge-base` returns EMPTY.
+#
+# With an empty base the engine used `ours` as the base. `git merge-file` then sees every template
+# difference as a clean addition onto an untouched base and takes ALL of theirs — reproducing exactly
+# the full-copy that `merge` exists to prevent. It printed "Merged (…) — fork edits preserved" while
+# doing it, so the loss was invisible in the log AND in the diff.
+#
+# Measured on mbs/cappy 2026-09-10: zero shared commits with openMF/kmp-project-template, and 11
+# platform-shell files (Info.plist's OAuth CFBundleURLTypes, the WidgetKit app-group entitlement, a
+# whole CappyWidgets Xcode target) that a degraded merge would have taken from the template wholesale.
+#
+# `.template-version#template_sha` is the anchor for the copied case — it records the template commit
+# the tree last synced FROM, which is precisely the ancestor git cannot compute across unrelated
+# histories. Its own file header already said it "anchors the next sync's 3-way merge base"; the merge
+# loops simply were not reading it. That gap is what these checks pin.
+#
+#   MB-1  resolve_merge_base() exists and consults PREV_TEMPLATE_SHA
+#   MB-2  every merge loop resolves its base through it — no bare `git merge-base` assignment
+#   MB-3  a missing base is WARNED about, never reported as a successful merge
+#   MB-4  the engine refuses to line-merge a binary
+#   MB-5  the four platform application shells resolve `merge` (they carry fork platform wiring
+#         that has no other seam — an Xcode target and a plist key have nowhere else to live)
+#   MB-6  .template-version carries a parseable template_sha (the anchor MB-1 depends on)
+#
+# exit 0 PASS / 1 FAIL. Pure bash + grep.
+set -uo pipefail
+: "${HEALTH_ROOT:?sync-merge-base: HEALTH_ROOT not set (run via product-health.sh)}"
+ENGINE="${MB_ENGINE:-$HEALTH_ROOT/scripts/white-label/sync-dirs.sh}"
+CS="${MB_CS:-$HEALTH_ROOT/scripts/customization-surface.sh}"
+TV="${MB_TV:-$HEALTH_ROOT/.template-version}"
+
+fail=0
+say() { printf '  %-7s %s\n' "$1" "$2"; }
+bad() { say "❌ $1" "$2"; fail=1; }
+
+[ -f "$ENGINE" ] || { bad MB-0 "engine not found: $ENGINE"; exit 1; }
+
+# ── MB-1 ─────────────────────────────────────────────────────────────────────
+if grep -q '^resolve_merge_base()' "$ENGINE" \
+   && sed -n '/^resolve_merge_base()/,/^}/p' "$ENGINE" | grep -q 'PREV_TEMPLATE_SHA'; then
+  say "✅ MB-1" "resolve_merge_base() falls back to PREV_TEMPLATE_SHA"
+else
+  bad MB-1 "resolve_merge_base() missing or does not consult PREV_TEMPLATE_SHA — copied forks get base==ours"
+fi
+
+# ── MB-2 ─────────────────────────────────────────────────────────────────────
+# A bare `mbase=$(git merge-base …)` assignment is the regression. Calls INSIDE resolve_merge_base
+# are the legitimate ones, so exclude that function's body.
+# Match the ASSIGNMENT, in any of its shell spellings — `mbase=$(…)`, `local mbase=$(…)` and
+# `local mbase; mbase=$(…)`. An earlier pattern anchored `local[[:space:]]+mbase=` and so missed the
+# semicolon form, which is the one the engine actually used: the check passed on a fixture with the
+# defect fully reintroduced. Keyed on `merge base` + assignment, not on declaration syntax.
+bare="$(sed '/^resolve_merge_base()/,/^}/d' "$ENGINE" \
+        | grep -cE '_?mbase="?\$\(git merge-base' || true)"
+bare="${bare:-0}"
+if [ "$bare" -eq 0 ]; then
+  say "✅ MB-2" "every merge loop resolves its base via resolve_merge_base"
+else
+  bad MB-2 "$bare merge loop(s) still assign a bare \`git merge-base\` — empty on a copied fork"
+fi
+
+# ── MB-3 ─────────────────────────────────────────────────────────────────────
+# Two distinct absences, and BOTH must be visible rather than silently resolved:
+#   no repo merge base    a copied (non-forked) tree — resolve_merge_base falls back to the anchor
+#   no per-FILE ancestor  add/add, where the file has no base blob even though the repo has a base
+# The second is the subtle one: seeding base:=ours there makes every fork-owned key look like an
+# upstream deletion, so the merge drops it and still reports "fork edits preserved". Keyed on the
+# `: > "$_b"` empty-base seeding plus a warning, not on one literal string, so rewording the message
+# does not silently disarm the check (which is exactly what happened when it read 'No merge base for').
+if grep -qE 'No (merge base|common ancestor) for' "$ENGINE" \
+   && grep -q ': > "\$_b"' "$ENGINE"; then
+  say "✅ MB-3" "missing base (repo-level or per-file add/add) warns and seeds an EMPTY base"
+else
+  bad MB-3 "an absent base is silently seeded from ours — fork-only content is dropped as an 'upstream deletion' while the merge reports success"
+fi
+
+# ── MB-4 ─────────────────────────────────────────────────────────────────────
+if grep -q 'is merge-owned — took the template' "$ENGINE"; then
+  say "✅ MB-4" "binaries are excluded from the line merge"
+else
+  bad MB-4 "no binary guard in the merge loop — a 3-way on a .webp/.ico corrupts it silently"
+fi
+
+# ── MB-5 ─────────────────────────────────────────────────────────────────────
+# Probe a real fork-wiring path per shell — the file that actually carries fork additions, not the
+# directory, so a carve-out that accidentally reclaims it is caught too.
+if [ -x "$CS" ] || [ -f "$CS" ]; then
+  mb5=0
+  for probe in \
+      "cmp-ios/iosApp/Info.plist" \
+      "cmp-ios/iosApp/iosApp.entitlements" \
+      "cmp-ios/iosApp.xcodeproj/project.pbxproj" \
+      "cmp-android/src/main/kotlin/cmp/android/app/MainActivity.kt" \
+      "cmp-desktop/mac-app-store.entitlements" \
+      "cmp-web/build.gradle.kts" \
+      "build-logic/convention/build.gradle.kts" ; do
+    got="$( (cd "$HEALTH_ROOT" && bash "$CS" resolve "$probe" 2>/dev/null) | awk '{print $2}' )"
+    [ "$got" = "merge" ] || { bad MB-5 "$probe resolves '$got', expected merge"; mb5=1; }
+  done
+  [ "$mb5" -eq 0 ] && say "✅ MB-5" "platform shells + build-logic resolve merge (fork wiring survives)"
+else
+  bad MB-5 "customization-surface.sh not found at $CS"
+fi
+
+# ── MB-6 ─────────────────────────────────────────────────────────────────────
+if [ -f "$TV" ] && grep -qE '^template_sha=[0-9a-f]{7,40}$' "$TV"; then
+  say "✅ MB-6" "template_sha anchor present ($(grep '^template_sha=' "$TV" | cut -d= -f2 | cut -c1-8))"
+else
+  bad MB-6 ".template-version has no parseable template_sha — a copied fork has no anchor to merge against"
+fi
+
+exit "$fail"

--- a/scripts/ruby-exec.sh
+++ b/scripts/ruby-exec.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# ruby-exec.sh — the ONE way this repo reaches Ruby/Bundler. Source it; do not reimplement it.
+#
+# THE TRAP THIS CLOSES
+# rbenv works by PATH interception: it puts shims ahead of the system ruby, and each shim reads
+# `.ruby-version` to pick a version. If `~/.rbenv/shims` is NOT on PATH — a shell without
+# `eval "$(rbenv init -)"`, a cron job, a GUI-launched terminal, a CI step that reset PATH — then
+# nothing intercepts, `ruby` falls through to macOS's /usr/bin/ruby 2.6.10, and the pinned interpreter
+# is simply not used. rbenv is installed and inert.
+#
+# The failure that produces is actively misleading. The Gemfile's gems were installed for the pinned
+# ruby, so `bundle exec` under 2.6.10 dies inside rubygems' `activate_bin_path` with an error about
+# GEM ACTIVATION. Every instinct says "the gems are wrong"; the gems are fine and the interpreter is
+# wrong. RT-8 in ruby-toolchain-coherence.sh exists to name that, and this file exists so scripts do
+# not hit it in the first place.
+#
+# Resolution order — first hit wins, most-specific first:
+#   1. RUBY_EXEC_BIN            explicit override (CI, or a human debugging)
+#   2. framework provisioner    core/scripts/ruby-toolchain-ensure.sh, when this fork lives inside
+#                               the framework tree — it INSTALLS the pinned ruby + bundler if absent
+#   3. rbenv version dir        $(rbenv root)/versions/<pinned>/bin/ruby — used DIRECTLY, so it works
+#                               whether or not shims are on PATH. This is the case that fixes the trap.
+#   4. provision                pinned version absent → framework helper installs it, or
+#                               RUBY_EXEC_AUTO_INSTALL=1 runs `rbenv install`. Otherwise FAIL LOUDLY
+#                               with the exact command — a wrong interpreter is worse than a stop.
+#   5. PATH ruby                only when there is no rbenv at all; warns if it misses the pin
+#
+# The pinned version is read from `.ruby-version` — the SoT that RT-1 keeps in step with
+# Gemfile.lock's `RUBY VERSION`. It is deliberately NOT a literal in this file: a hardcoded default
+# silently stops tracking the pin the moment someone bumps `.ruby-version`, which is how
+# doctor.sh's `RBENV_VERSION="${RBENV_VERSION:-3.3.6}"` could have gone stale.
+#
+# Usage:
+#   . "$REPO_ROOT/scripts/ruby-exec.sh"
+#   ruby_exec  <script.rb> [args...]              # run a ruby script under the pinned interpreter
+#   ruby_bundle <app-root> -- <cmd> [args...]     # run `bundle <cmd>` in an app root, pinned
+#   ruby_exec_report                              # one line: which interpreter was chosen and why
+
+# Guard against double-sourcing — this file defines functions only, it runs nothing on load.
+[ -n "${RUBY_EXEC_SH_LOADED:-}" ] && return 0 2>/dev/null || true
+RUBY_EXEC_SH_LOADED=1
+
+_ruby_exec_repo_root() {
+  # scripts/ruby-exec.sh → repo root is one level up from scripts/
+  local d; d="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  printf '%s' "$d"
+}
+
+# The pinned version, from the SoT. Empty if .ruby-version is absent (a fork that stripped it).
+ruby_exec_pinned_version() {
+  local root; root="$(_ruby_exec_repo_root)"
+  local vf="$root/.ruby-version"
+  [ -f "$vf" ] || return 0
+  tr -d '[:space:]' < "$vf"
+}
+
+RUBY_EXEC_RESOLVED=""   # absolute interpreter path
+RUBY_EXEC_SOURCE=""     # how it was found — surfaced by ruby_exec_report
+
+_ruby_exec_resolve() {
+  [ -n "$RUBY_EXEC_RESOLVED" ] && return 0
+  local want; want="$(ruby_exec_pinned_version)"
+
+  # 1 — explicit override
+  if [ -n "${RUBY_EXEC_BIN:-}" ] && [ -x "${RUBY_EXEC_BIN}" ]; then
+    RUBY_EXEC_RESOLVED="$RUBY_EXEC_BIN"; RUBY_EXEC_SOURCE="RUBY_EXEC_BIN override"; return 0
+  fi
+
+  # 3 — rbenv version dir, used DIRECTLY. Ahead of the shim on purpose: this path does not care
+  #     whether shims are on PATH, which is the entire failure this file exists for.
+  if [ -n "$want" ] && command -v rbenv >/dev/null 2>&1; then
+    local rr; rr="$(rbenv root 2>/dev/null)"
+    if [ -n "$rr" ] && [ -x "$rr/versions/$want/bin/ruby" ]; then
+      RUBY_EXEC_RESOLVED="$rr/versions/$want/bin/ruby"
+      RUBY_EXEC_SOURCE="rbenv versions/$want (direct — shims not required)"; return 0
+    fi
+    # The pinned version is NOT installed. Try to provision it before degrading — and NEVER degrade
+    # silently, which is what the shim fallback used to do: with an uninstalled pin it reported
+    # "rbenv shim" as though resolved, and the shim then failed at RUN time with rbenv's own
+    # "version not installed" error, far from the code that chose it.
+    if [ -n "$want" ]; then
+      local fw; fw="$(_ruby_exec_framework_helper || true)"
+      if [ -n "$fw" ]; then
+        # The framework provisioner is CHECK-FIRST and idempotent: it runs `rbenv install -s` only
+        # when the version is genuinely absent, so calling it here is cheap on a warm machine.
+        RBENV_VERSION="$want" bash "$fw" "$(_ruby_exec_repo_root)" >/dev/null 2>&1 || true
+        if [ -x "$rr/versions/$want/bin/ruby" ]; then
+          RUBY_EXEC_RESOLVED="$rr/versions/$want/bin/ruby"
+          RUBY_EXEC_SOURCE="rbenv versions/$want (provisioned by framework helper)"; return 0
+        fi
+      fi
+      if [ "${RUBY_EXEC_AUTO_INSTALL:-0}" = "1" ]; then
+        echo "ruby-exec: installing ruby $want (RUBY_EXEC_AUTO_INSTALL=1) — this compiles, expect minutes…" >&2
+        rbenv install -s "$want" >&2 || true
+        if [ -x "$rr/versions/$want/bin/ruby" ]; then
+          RUBY_EXEC_RESOLVED="$rr/versions/$want/bin/ruby"
+          RUBY_EXEC_SOURCE="rbenv versions/$want (auto-installed)"; return 0
+        fi
+      fi
+      # Loud, actionable failure beats a wrong interpreter. Auto-installing by default would compile
+      # Ruby inside an unrelated script for minutes with no warning, so it is opt-in.
+      echo "❌ ruby-exec: .ruby-version pins $want but it is not installed." >&2
+      echo "    Install it:   rbenv install $want" >&2
+      echo "    Or re-run with RUBY_EXEC_AUTO_INSTALL=1 to install it here (compiles, takes minutes)." >&2
+      return 1
+    fi
+  fi
+
+  # 5 — whatever PATH gives, with a warning when it does not match the pin
+  local p; p="$(command -v ruby 2>/dev/null)"
+  if [ -n "$p" ]; then
+    RUBY_EXEC_RESOLVED="$p"
+    local have; have="$("$p" -e 'print RUBY_VERSION' 2>/dev/null)"
+    if [ -n "$want" ] && [ "$have" != "$want" ]; then
+      RUBY_EXEC_SOURCE="PATH ruby $have — DOES NOT MATCH .ruby-version $want"
+      echo "⚠️  ruby-exec: using $p ($have) but .ruby-version pins $want." >&2
+      echo "    Install it (rbenv install $want) or fix the shell (eval \"\$(rbenv init -)\")." >&2
+    else
+      RUBY_EXEC_SOURCE="PATH ruby $have"
+    fi
+    return 0
+  fi
+  echo "❌ ruby-exec: no ruby interpreter found at all." >&2
+  return 1
+}
+
+# The framework provisioner, when this fork lives inside the framework tree. Resolved by SEARCHING
+# UPWARD rather than by a fixed number of `../` hops: doctor.sh hardcoded five levels, which resolves
+# only at workspaces/{ws}/{proj}/source/{proj}/ and silently misses for a standalone clone — exactly
+# the shape an OSS fork has.
+_ruby_exec_framework_helper() {
+  local d; d="$(_ruby_exec_repo_root)"
+  local i=0
+  while [ "$d" != "/" ] && [ $i -lt 8 ]; do
+    if [ -x "$d/core/scripts/ruby-toolchain-ensure.sh" ]; then
+      printf '%s' "$d/core/scripts/ruby-toolchain-ensure.sh"; return 0
+    fi
+    d="$(dirname "$d")"; i=$((i+1))
+  done
+  return 1
+}
+
+/usr/bin/true   # keep the file harmless if executed rather than sourced
+
+# Run a ruby script under the pinned interpreter.
+ruby_exec() {
+  _ruby_exec_resolve || return 1
+  "$RUBY_EXEC_RESOLVED" "$@"
+}
+
+# Run bundler in <app-root> under the pinned interpreter.
+#   ruby_bundle <app-root> -- exec fastlane ios beta
+ruby_bundle() {
+  local app_root="$1"; shift
+  [ "${1:-}" = "--" ] && shift
+  [ -d "$app_root" ] || { echo "❌ ruby-exec: no such bundler app root: $app_root" >&2; return 1; }
+
+  # 2 — prefer the framework provisioner: it INSTALLS the pinned ruby + bundler when absent, which
+  #     plain resolution cannot do.
+  local fw; fw="$(_ruby_exec_framework_helper || true)"
+  if [ -n "$fw" ]; then
+    RBENV_VERSION="${RBENV_VERSION:-$(ruby_exec_pinned_version)}" bash "$fw" "$app_root" -- bundle "$@"
+    return $?
+  fi
+
+  _ruby_exec_resolve || return 1
+  # Call bundle through the resolved ruby, not through PATH — `bundle` on PATH belongs to whichever
+  # ruby owns it, which is the same trap one level up.
+  local bundle_bin; bundle_bin="$(dirname "$RUBY_EXEC_RESOLVED")/bundle"
+  if [ -x "$bundle_bin" ]; then
+    ( cd "$app_root" && "$RUBY_EXEC_RESOLVED" "$bundle_bin" "$@" )
+  else
+    ( cd "$app_root" && bundle "$@" )
+  fi
+}
+
+ruby_exec_report() {
+  # stdout only is silenced. stderr carries the ACTIONABLE message ("pins X but it is not installed
+  # — rbenv install X"), and swallowing it left the report saying `none (unresolved)` with no hint of
+  # why or what to do — a diagnostic that diagnoses nothing.
+  _ruby_exec_resolve >/dev/null || true
+  printf 'ruby-exec: %s  (%s)  pinned=%s\n' \
+    "${RUBY_EXEC_RESOLVED:-none}" "${RUBY_EXEC_SOURCE:-UNRESOLVED — see the error above}" \
+    "$(ruby_exec_pinned_version)"
+  [ -n "$RUBY_EXEC_RESOLVED" ]
+}

--- a/scripts/ruby-exec.sh
+++ b/scripts/ruby-exec.sh
@@ -41,9 +41,26 @@
 RUBY_EXEC_SH_LOADED=1
 
 _ruby_exec_repo_root() {
-  # scripts/ruby-exec.sh → repo root is one level up from scripts/
-  local d; d="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-  printf '%s' "$d"
+  # scripts/ruby-exec.sh → repo root is one level up from scripts/.
+  #
+  # BASH_SOURCE is UNSET when this file is sourced from zsh — the macOS default shell, and exactly
+  # what scripts/CLAUDE.md tells a human to do interactively (`. scripts/ruby-exec.sh && ruby_exec_report`).
+  # `dirname ""` is `.`, so the root resolved to the PARENT OF THE CWD, `.ruby-version` was not found,
+  # and ruby_exec_report printed `pinned=` empty — a diagnostic quietly reporting no pin on a repo
+  # that has one. Never guess a root: derive it if we can, then VERIFY it by marker, then search.
+  local d=""
+  # shellcheck disable=SC2128
+  if [ -n "${BASH_SOURCE:-}" ]; then d="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." 2>/dev/null && pwd)"; fi
+  [ -n "$d" ] || { [ -n "${ZSH_VERSION:-}" ] && [ -n "${0:-}" ] && d="$(cd "$(dirname "$0")/.." 2>/dev/null && pwd)"; }
+  # A derived root only counts if it actually looks like this repo — otherwise fall through.
+  if [ -n "$d" ] && { [ -f "$d/.ruby-version" ] || [ -f "$d/Gemfile" ]; }; then printf '%s' "$d"; return 0; fi
+  # Last resort: walk up from the CWD for the marker. Works from any subdirectory and any shell.
+  d="$PWD"; local i=0
+  while [ "$d" != "/" ] && [ $i -lt 8 ]; do
+    if [ -f "$d/.ruby-version" ] || [ -f "$d/Gemfile" ]; then printf '%s' "$d"; return 0; fi
+    d="$(dirname "$d")"; i=$((i+1))
+  done
+  printf '%s' "$PWD"
 }
 
 # The pinned version, from the SoT. Empty if .ruby-version is absent (a fork that stripped it).

--- a/scripts/white-label/doctor.sh
+++ b/scripts/white-label/doctor.sh
@@ -56,15 +56,20 @@ esac
 
 [ -f "$REPO_ROOT/app-profile/app.yaml" ] || { err "app-profile/app.yaml missing — not a white-label fork of kmp-project-template"; exit 3; }
 
-# ── Ruby runner: prefer the framework toolchain manager (install-once), else the deployment bundle,
-#    else system ruby. Keeps the derive reproducible without assuming a global gem state. ──────────────
+# ── Ruby runner — delegates to the ONE resolver (scripts/ruby-exec.sh). ─────────────────────────
+# This used to inline its own fallback, with two defects that only bite on a machine nobody tests on:
+#   * the framework helper was found by a fixed five-level `../` climb, so it resolved ONLY at
+#     workspaces/{ws}/{proj}/source/{proj}/ and silently missed for a standalone clone — the shape an
+#     OSS fork actually has. ruby-exec.sh searches upward instead.
+#   * `RBENV_VERSION="${RBENV_VERSION:-3.3.6}"` hardcoded the pin, so bumping .ruby-version would
+#     leave this asking for a stale interpreter. ruby-exec.sh reads .ruby-version, the SoT RT-1 guards.
+. "$REPO_ROOT/scripts/ruby-exec.sh"
 run_ruby() {  # run_ruby <abs-script> [args...]
-  local fw="$REPO_ROOT/../../../../../core/scripts/ruby-toolchain-ensure.sh"  # framework, if present
-  if [ -x "$fw" ] && [ -d "$REPO_ROOT/deployment" ]; then
-    RBENV_VERSION="${RBENV_VERSION:-3.3.6}" bash "$fw" "$REPO_ROOT/deployment" -- bundle exec ruby "$@" 2>&1 | grep -avE 'ruby toolchain ready|exec under ruby'
+  if [ -d "$REPO_ROOT/deployment" ]; then
+    ruby_bundle "$REPO_ROOT/deployment" -- exec ruby "$@" 2>&1 | grep -avE 'ruby toolchain ready|exec under ruby'
     return "${PIPESTATUS[0]}"
   fi
-  ( cd "$REPO_ROOT/deployment" 2>/dev/null && bundle exec ruby "$@" ) 2>/dev/null || ruby "$@"
+  ruby_exec "$@"
 }
 
 DERIVE="$REPO_ROOT/scripts/white-label/derive.rb"

--- a/scripts/white-label/merge-pbxproj.rb
+++ b/scripts/white-label/merge-pbxproj.rb
@@ -1,0 +1,326 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# merge-pbxproj.rb — a 3-way merge for Xcode project files that produces NO conflict markers.
+#
+# WHY A DEDICATED MERGER
+# `project.pbxproj` is the one file in the sync surface where a line-based 3-way is structurally
+# wrong. It is not a document, it is a SERIALIZED OBJECT GRAPH: ~50 objects keyed by stable 24-hex
+# UUIDs, where "add a target" rewrites a UUID list three levels away from the object it adds. git
+# merge-file sees adjacent lines in a container array and calls it a conflict; worse, a merge marker
+# inside a pbxproj makes the project UNOPENABLE, so a human cannot even use Xcode to resolve it.
+#
+# WHY IT IS TRACTABLE ANYWAY
+# The UUIDs are stable ACROSS THE FORK BOUNDARY. Measured template ⋈ mbs/cappy 2026-09-10:
+# 36 and 52 objects, **33 UUIDs shared** — a fork's project descends from the template's, so the
+# same object carries the same key on both sides. That turns an intractable text merge into an
+# ordinary keyed 3-way, and every real difference falls into exactly three mechanical classes:
+#
+#   1. UUID-LIST additions        PBXProject.targets / .packageReferences, PBXGroup.children,
+#                                 PBXSourcesBuildPhase.files, PBXNativeTarget.buildPhases …
+#                                 Template added XCLocalSwiftPackageReference (the SwiftPM
+#                                 migration); the fork added a CappyWidgets target. Different
+#                                 elements of the same array → UNION. No judgement needed.
+#   2. buildSettings KEY additions  the fork added CODE_SIGN_ENTITLEMENTS; the template adds its
+#                                 own keys over time → per-key union.
+#   3. buildSettings VALUE conflict  exactly one in the measured pair:
+#                                 DEVELOPMENT_TEAM "$(TEAM_ID)" (template placeholder) vs
+#                                 L432S2FZP5 (the fork's real team). Fork identity → fork wins.
+#
+# So this is not heuristic reconstruction — it is a keyed 3-way with a union rule for arrays and a
+# declared precedence for the identity keys. Anything it CANNOT decide is reported and the merge
+# FAILS loudly, because a silently-wrong pbxproj costs more than a stopped sync.
+#
+# The `xcodeproj` gem does the parsing and (critically) the WRITING — it is already resolved in
+# Gemfile.lock as a fastlane transitive (1.28.1), so this adds no dependency. Writing through the
+# gem is what keeps Xcode's canonical formatting and the `/* comment */` annotations intact.
+#
+#   usage: merge-pbxproj.rb --ours <f> --base <f> --theirs <f> --out <f> [--report]
+#   exit 0 merged · 1 undecidable difference (nothing written) · 2 usage/IO error
+
+require 'set'
+begin
+  require 'xcodeproj'
+rescue LoadError
+  warn "❌ merge-pbxproj: the `xcodeproj` gem is not available to #{RUBY_VERSION} at #{RbConfig.ruby}."
+  warn "   It ships as a fastlane transitive, so it is usually already present. Either:"
+  warn "     gem install xcodeproj          # for the pinned interpreter (.ruby-version)"
+  warn "     bundle install && bundle exec ruby scripts/white-label/merge-pbxproj.rb …"
+  warn "   Exit code 2 specifically means GEM MISSING — sync-dirs.sh retries under bundler on it."
+  exit 2
+end
+
+# ── Identity build settings: PREFER THE INDIRECTION, never a literal ────────
+# The first version of this list said "fork wins" for these keys, on the reasoning that they are
+# per-fork deployment identity. That is right about the VALUE and wrong about the LOCATION, and
+# picking the fork's literal would have entrenched the exact defect the template just finished
+# removing.
+#
+# None of these is authored in the pbxproj at all. Each is an INDIRECTION resolved from
+# Config.xcconfig, which syncForkConfig generates from the app-profile SoT:
+#
+#   app-profile/platforms/apple/apple.yaml#apple.team_id
+#     → gradle/fork.properties#apple.team.id        (derive.rb, AppProfile::MAP)
+#     → Config.xcconfig#TEAM_ID                     (SyncForkConfigPlugin)
+#     → $(TEAM_ID)                                  ← what the pbxproj must contain
+#
+# So a LITERAL here is a defect no matter which side wrote it — syncForkConfig never touches
+# project.pbxproj, so nothing downstream can correct one. This template shipped
+# `DEVELOPMENT_TEAM = L432S2FZP5` to every fork through two commits and it survived until
+# 2026-09-10; `PBX-4` in product-health/checks/ios-pbxproj-identity.sh now blocks the recurrence.
+#
+# The merge rule follows from that: whichever side holds the `$(…)` indirection wins. It is
+# direction-agnostic — it repairs a fork that hardcoded a value AND declines to import a literal
+# the template leaked — and it needs no notion of "who owns this", because the answer is always
+# "app-profile does".
+XCCONFIG_ROUTED_KEYS = %w[
+  DEVELOPMENT_TEAM
+  PRODUCT_BUNDLE_IDENTIFIER
+  PROVISIONING_PROFILE_SPECIFIER
+  CODE_SIGN_ENTITLEMENTS
+  CODE_SIGN_IDENTITY
+].freeze
+
+# An xcconfig indirection: "$(TEAM_ID)", "$(inherited)", "$(APP_BUNDLE_ID).widgets", …
+def indirection?(v)
+  v.is_a?(String) && v.include?('$(')
+end
+
+# Attributes whose value is an ORDERED LIST OF UUIDs (or of plain strings, for a few settings).
+# A change on either side is an insertion into a shared array, never a replacement.
+LIST_ATTRS = %w[
+  children files targets buildPhases buildRules dependencies
+  packageReferences packageProductDependencies buildConfigurations
+  projectReferences knownRegions
+].freeze
+
+def die(msg, code = 2)
+  warn "❌ merge-pbxproj: #{msg}"
+  exit code
+end
+
+opts = { report: false }
+args = ARGV.dup
+until args.empty?
+  case (a = args.shift)
+  when '--ours'   then opts[:ours]   = args.shift
+  when '--base'   then opts[:base]   = args.shift
+  when '--theirs' then opts[:theirs] = args.shift
+  when '--out'    then opts[:out]    = args.shift
+  when '--report' then opts[:report] = true
+  when '-h', '--help'
+    puts 'usage: merge-pbxproj.rb --ours <f> --base <f> --theirs <f> --out <f> [--report]'
+    exit 0
+  else die("unknown arg: #{a}")
+  end
+end
+%i[ours base theirs out].each { |k| opts[k] || die("missing --#{k}") }
+%i[ours base theirs].each { |k| File.file?(opts[k]) || die("no such file: #{opts[k]}") }
+
+def read_objects(path)
+  plist = Xcodeproj::Plist.read_from_path(path)
+  die("#{path} has no `objects` dict — is it really a pbxproj?") unless plist.is_a?(Hash) && plist['objects']
+  [plist, plist['objects']]
+end
+
+ours_plist,   ours   = read_objects(opts[:ours])
+base_plist,   base   = read_objects(opts[:base])
+theirs_plist, theirs = read_objects(opts[:theirs])
+
+conflicts = []
+notes     = []
+
+# ── merge one ordered UUID list ─────────────────────────────────────────────
+# Union, in a deterministic order: the fork's order first (its file is the one being updated, so
+# its layout is the one a human recognises), then whatever the template added. An element both
+# sides DELETED stays deleted; one deleted by only the template but kept by the fork survives,
+# because the fork may have re-parented it.
+def merge_list(o, b, t)
+  o = Array(o); b = Array(b); t = Array(t)
+  ob = Set.new(o); bb = Set.new(b)
+  deleted_by_ours = bb - ob
+  result = o.dup
+  # anything the template has that the fork does not, and the fork did not delete on purpose
+  t.each { |e| result << e unless result.include?(e) || deleted_by_ours.include?(e) }
+  result
+end
+
+# Drop every list element that names an object the merge did not keep.
+#
+# THIS IS NOT DEFENCE-IN-DEPTH, IT IS THE ONLY CORRECT PLACE FOR THE DECISION.
+# Whether a template-side deletion propagates is decided per OBJECT, using base/ours/theirs. A list
+# cannot re-derive that from its own elements — they are bare UUID strings with no history — so an
+# earlier attempt to filter inside merge_list wrote a guard that could never fire (it tested whether
+# an element of `ours` was in `ours`). The result: `Configs/iOSApp.xcconfig`, deleted upstream and
+# untouched by the fork, had its object dropped while the PBXGroup child reference survived — a
+# DANGLING REFERENCE. The gem discards those on load with a warning, so the merge "succeeded" while
+# silently losing whatever the reference pointed at.
+#
+# Pruning against the merged object set makes the graph consistent BY CONSTRUCTION: exactly one
+# place decides what exists, and lists follow.
+def prune_dangling!(merged, list_attrs, notes)
+  live = Set.new(merged.keys)
+  pruned = 0
+  merged.each do |uuid, obj|
+    next unless obj.is_a?(Hash)
+    list_attrs.each do |k|
+      v = obj[k]
+      next unless v.is_a?(Array)
+      kept = v.reject { |e| e.is_a?(String) && e =~ /\A[0-9A-F]{24}\z/ && !live.include?(e) }
+      next if kept.size == v.size
+      pruned += v.size - kept.size
+      obj[k] = kept
+      notes << "pruned #{v.size - kept.size} dangling ref(s) from #{obj['isa']} #{uuid}.#{k}"
+    end
+  end
+  pruned
+end
+
+# ── merge a buildSettings-style hash, per key ───────────────────────────────
+def merge_settings(o, b, t, ctx, conflicts)
+  o ||= {}; b ||= {}; t ||= {}
+  return t unless o.is_a?(Hash) && t.is_a?(Hash)
+  out = {}
+  (o.keys | t.keys).each do |k|
+    ov, bv, tv = o[k], b[k], t[k]
+    # ── xcconfig-routed keys are decided FIRST, ahead of the generic 3-way ──
+    # Ordering is load-bearing. The ordinary rules ask WHO CHANGED IT; for these keys that is the
+    # wrong question, because a literal is a defect regardless of who wrote it. Placed after
+    # `tv == bv → take ours`, a fork that hardcoded its own team id kept the literal on every sync
+    # (the template's side had not moved, so "only the fork moved" fired and won) — measured: 14
+    # literals survived. Deciding on the VALUE's shape rather than on authorship repairs it.
+    if o.key?(k) && t.key?(k) && XCCONFIG_ROUTED_KEYS.include?(k) &&
+       indirection?(ov) != indirection?(tv)
+      out[k] = indirection?(ov) ? ov : tv
+      next
+    end
+    if !o.key?(k)            then out[k] = tv          # template added it
+    elsif !t.key?(k)
+      # Template removed it. Keep it only if the fork changed it (deliberate fork setting);
+      # otherwise honour the template's removal.
+      out[k] = ov if ov != bv
+    elsif ov == tv           then out[k] = ov
+    elsif ov == bv           then out[k] = tv          # only the template moved
+    elsif tv == bv           then out[k] = ov          # only the fork moved
+    else
+      conflicts << "#{ctx}: buildSettings[#{k}] fork=#{ov.inspect} template=#{tv.inspect} (base=#{bv.inspect})"
+      out[k] = ov
+    end
+  end
+  out
+end
+
+def merge_object(uuid, o, b, t, conflicts)
+  b ||= {}
+  isa = t['isa'] || o['isa']
+  ctx = "#{isa} #{uuid}"
+  out = {}
+  (o.keys | t.keys).each do |k|
+    ov, bv, tv = o[k], b[k], t[k]
+    if LIST_ATTRS.include?(k) && (ov.is_a?(Array) || tv.is_a?(Array))
+      out[k] = merge_list(ov, bv, tv)
+    elsif k == 'buildSettings'
+      out[k] = merge_settings(ov, bv, tv, ctx, conflicts)
+    elsif !o.key?(k)  then out[k] = tv
+    elsif !t.key?(k)  then out[k] = ov if ov != bv
+    elsif ov == tv    then out[k] = ov
+    elsif ov == bv    then out[k] = tv
+    elsif tv == bv    then out[k] = ov
+    else
+      conflicts << "#{ctx}: #{k} fork=#{ov.inspect} template=#{tv.inspect} (base=#{bv.inspect})"
+      out[k] = ov
+    end
+  end
+  out.compact
+end
+
+merged = {}
+all = ours.keys | theirs.keys | base.keys
+added_t = added_o = deleted = merged_both = 0
+
+all.each do |uuid|
+  o, b, t = ours[uuid], base[uuid], theirs[uuid]
+  if o && t
+    if o == t then merged[uuid] = o
+    else merged[uuid] = merge_object(uuid, o, b, t, conflicts); merged_both += 1
+    end
+  elsif t && !o
+    # Present upstream, absent in the fork: template ADDED it (not in base) → take it.
+    # In base and gone from the fork → the fork deleted it deliberately → stay deleted.
+    if b.nil? then merged[uuid] = t; added_t += 1 else deleted += 1 end
+  elsif o && !t
+    # Present in the fork, absent upstream: fork ADDED it → keep.
+    # In base and gone upstream → template deleted it; honour that only if the fork did not touch it.
+    if b.nil? then merged[uuid] = o; added_o += 1
+    elsif o == b then deleted += 1
+    else merged[uuid] = o
+         notes << "kept #{o['isa']} #{uuid} — template deleted it but the fork had modified it"
+    end
+  end
+end
+
+pruned = prune_dangling!(merged, LIST_ATTRS, notes)
+
+# ── INVARIANT: no dangling references may reach the writer ──────────────────
+# This is not redundant with prune_dangling!, it is what makes the pruning TRUSTWORTHY. The gem's
+# writer silently DISCARDS a reference to an unknown UUID (it prints an `attempted to initialize an
+# object with an unknown UUID … being discarded` warning to stderr and carries on), so a merge that
+# leaves one still produces a well-formed file that re-opens, validates, and passes every downstream
+# check — while having quietly dropped whatever the reference pointed at. Post-hoc inspection of the
+# OUTPUT can therefore never detect this class; only asserting before the write can.
+dangling = []
+live = Set.new(merged.keys)
+merged.each do |uuid, obj|
+  next unless obj.is_a?(Hash)
+  LIST_ATTRS.each do |k|
+    Array(obj[k]).each do |e|
+      next unless e.is_a?(String) && e =~ /\A[0-9A-F]{24}\z/
+      dangling << "#{obj['isa']} #{uuid}.#{k} → #{e}" unless live.include?(e)
+    end
+  end
+end
+unless dangling.empty?
+  warn "❌ merge-pbxproj: #{dangling.size} dangling reference(s) survived pruning — refusing to write."
+  dangling.first(10).each { |d| warn "     #{d}" }
+  warn "   The gem would DISCARD these on load and the file would still look valid; that silent"
+  warn "   loss is the bug this invariant exists to stop. prune_dangling! is not doing its job."
+  exit 1
+end
+
+if conflicts.any?
+  warn "❌ merge-pbxproj: #{conflicts.size} difference(s) this merger will not decide:"
+  conflicts.each { |c| warn "     #{c}" }
+  warn "   Nothing was written. Resolve in app-profile / the contract, or extend FORK_IDENTITY_KEYS"
+  warn "   if this is a per-fork identity setting the template can only placeholder."
+  exit 1
+end
+
+# Root keys (archiveVersion / objectVersion / rootObject / classes): template wins — they are the
+# file-format envelope and Xcode version marker, never fork content.
+out_plist = theirs_plist.dup
+out_plist['objects'] = merged
+
+Xcodeproj::Plist.write_to_path(out_plist, opts[:out])
+
+# Round-trip through the full object model. This is the real validation: the gem refuses to open a
+# graph with a dangling UUID reference, so a union that produced an inconsistent project fails HERE
+# rather than in Xcode on someone's machine. It also rewrites the file in Xcode's canonical form.
+begin
+  dir = File.dirname(opts[:out])
+  if File.basename(dir).end_with?('.xcodeproj')
+    proj = Xcodeproj::Project.open(dir)
+    proj.save
+    notes << "validated: #{proj.objects.count} objects, targets #{proj.targets.map(&:name).join(', ')}"
+  end
+rescue StandardError => e
+  warn "❌ merge-pbxproj: merged graph failed to re-open (#{e.class}: #{e.message})"
+  warn "   The output is inconsistent — treat this as a FAILED merge, do not commit it."
+  exit 1
+end
+
+if opts[:report]
+  warn "  pbxproj 3-way: +#{added_t} from template · +#{added_o} kept from fork · " \
+       "#{merged_both} objects merged · #{deleted} deletions propagated · #{pruned} refs pruned"
+  notes.each { |n| warn "     #{n}" }
+end
+exit 0

--- a/scripts/white-label/merge-plist.rb
+++ b/scripts/white-label/merge-plist.rb
@@ -1,0 +1,242 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# merge-plist.rb — key-level 3-way union for Info.plist / *.entitlements.
+#
+# WHY NOT git merge-file
+# These files are a flat top-level <dict> where template and fork each add their OWN keys. The
+# additions land at the same place in the text — just inside <dict> — so a line merge can report a
+# conflict for changes that do not overlap in meaning.
+#
+# Measured on mbs/cappy ⋈ template 2026-09-10, against each file's REAL ancestor:
+#
+#   iosApp.entitlements  ADD/ADD — absent at the fork's base b97eb73d (the template added its own
+#                        in 99083ed2, the fork added its own separately). No ancestor, so a line
+#                        merge CONFLICTS, and the result does not even parse:
+#                        `plutil: Encountered unexpected character = on line 15`. The build breaks.
+#                        This file is why the strategy exists.
+#   Info.plist           has a real ancestor, and a line merge is currently CLEAN — 0 conflicts,
+#                        CFBundleURLTypes preserved, plutil OK. It is routed here anyway because it
+#                        is the same flat-dict shape and one template key added near the fork's
+#                        block turns it into the entitlements case. Correct today, robust tomorrow —
+#                        not a fix for a present breakage, and this comment should not imply it is.
+#
+# (An earlier draft of this header claimed BOTH files were add/add with 2 conflicts each. That came
+# from a broken measurement — the base was extracted with `"$SHA:cmp-ios/…"` in zsh, where `:c` is
+# eaten as a modifier, so every `git show` silently returned nothing and every file looked add/add.
+# Quote it `"${SHA}:cmp-ios/…"`.)
+#
+# The keys involved are genuinely disjoint and both are required:
+#   template  keychain-access-groups          core-base/datastore's KeychainSettings needs it, or
+#                                             iOS fails errSecMissingEntitlement (-34018) at launch
+#   fork      com.apple.security.application-groups   the WidgetKit shared container
+#   fork      CFBundleURLTypes                the OAuth redirect scheme — delete it and sign-in
+#                                             silently never returns to the app
+# Neither side may win. The merge is a UNION.
+#
+# WHY TEXT-LEVEL RATHER THAN parse-and-rewrite
+# Round-tripping through a plist parser is easier and loses every comment. That is not cosmetic
+# here: the template's entitlements carries 14 lines explaining WHY the keychain group is required
+# and what happens without it — exactly the knowledge a fork needs when it later edits the file.
+# So this merges at the text level, treating each key and its value element (plus the comments
+# attached above it) as an opaque block. Comments survive because they are never re-serialized.
+#
+#   usage: merge-plist.rb --ours <f> --base <f|-> --theirs <f> --out <f> [--report]
+#          --base -   there is no common ancestor (add/add); union both sides
+#   exit 0 merged · 1 undecidable difference (nothing written) · 2 usage/IO error
+
+def die(msg, code = 2)
+  warn "❌ merge-plist: #{msg}"
+  exit code
+end
+
+opts = { report: false }
+args = ARGV.dup
+until args.empty?
+  case (a = args.shift)
+  when '--ours' then opts[:ours] = args.shift
+  when '--base' then opts[:base] = args.shift
+  when '--theirs' then opts[:theirs] = args.shift
+  when '--out' then opts[:out] = args.shift
+  when '--report' then opts[:report] = true
+  when '-h', '--help'
+    puts 'usage: merge-plist.rb --ours <f> --base <f|-> --theirs <f> --out <f> [--report]'; exit 0
+  else die("unknown arg: #{a}")
+  end
+end
+%i[ours base theirs out].each { |k| opts[k] || die("missing --#{k}") }
+
+# ── split a plist into: header (through the opening top-level <dict>), ordered key blocks, footer ──
+# A block is [key_name, text] where text includes any comments/blank lines immediately above the
+# <key> line — those comments document that key and must travel with it.
+def split_plist(src)
+  lines = src.lines
+  dict_at = lines.index { |l| l.strip == '<dict>' }
+  return [nil, nil, nil] unless dict_at
+
+  depth = 0; close_at = nil
+  lines.each_with_index do |l, i|
+    next if i < dict_at
+    s = l.strip
+    depth += 1 if s == '<dict>'
+    if s == '</dict>'
+      depth -= 1
+      if depth.zero? then close_at = i; break end
+    end
+  end
+  return [nil, nil, nil] unless close_at
+
+  header = lines[0..dict_at].join
+  footer = lines[close_at..].join
+  body   = lines[(dict_at + 1)...close_at]
+
+  # Net element-depth change contributed by one line, ignoring comments, declarations and
+  # self-closing tags. Used to find where a multi-line value element ends.
+  def_depth = lambda do |line|
+    text = line.gsub(/<!--.*?-->/m, '')
+    d = 0
+    text.scan(/<[^>]*>/).each do |tag|
+      next if tag.start_with?('<?', '<!')
+      if tag.start_with?('</') then d -= 1
+      elsif tag.end_with?('/>') then d += 0
+      else d += 1
+      end
+    end
+    d
+  end
+
+  blocks = []
+  pending = []          # comments / blank lines waiting to attach to the next key
+  in_comment = false
+  i = 0
+  while i < body.length
+    line = body[i]
+
+    # ── comment state ────────────────────────────────────────────────────
+    # A <key> inside a comment is DOCUMENTATION, not a key. The template's entitlements shows
+    # `<key>com.apple.developer.applesignin</key>` inside its explanatory block as an example for
+    # forks adding Sign in with Apple; parsing that as a real key invented an entitlement the file
+    # does not grant and left the real one's <array> orphaned.
+    if in_comment
+      pending << line
+      in_comment = false if line.include?('-->')
+      i += 1
+      next
+    end
+    if line =~ /<!--/ && !line.include?('-->')
+      pending << line; in_comment = true; i += 1; next
+    end
+    if line.strip.start_with?('<!--') || line.strip.empty?
+      pending << line; i += 1; next
+    end
+
+    # ── a real key ───────────────────────────────────────────────────────
+    if (m = line.match(%r{<key>(.*?)</key>}))
+      key = m[1]
+      chunk = pending.dup + [line]
+      pending = []
+      # The value element may finish on this line or span several. Track element depth from just
+      # after </key>; the value is complete when depth returns to zero having seen a tag.
+      after = line.split('</key>', 2)[1].to_s
+      d = def_depth.call(after)
+      saw = after.match?(/<[^>]*>/)
+      while (d > 0 || !saw) && (i + 1) < body.length
+        i += 1
+        nxt = body[i]
+        chunk << nxt
+        d += def_depth.call(nxt)
+        saw ||= nxt.match?(/<[^>]*>/)
+      end
+      blocks << [key, chunk.join]
+      i += 1
+      next
+    end
+
+    blocks << [nil, (pending.dup + [line]).join]
+    pending = []
+    i += 1
+  end
+  blocks << [nil, pending.join] unless pending.empty?
+  [header, blocks, footer]
+end
+
+def load_side(path)
+  return [nil, [], nil] if path == '-' || path.nil? || !File.file?(path)
+  src = File.read(path)
+  h, b, f = split_plist(src)
+  die("#{path}: could not locate a top-level <dict> — not a plist?") if b.nil?
+  [h, b, f]
+end
+
+o_head, o_blocks, o_foot = load_side(opts[:ours])
+_b_head, b_blocks, _b_foot = load_side(opts[:base])
+t_head, t_blocks, t_foot = load_side(opts[:theirs])
+
+die("--ours is not a readable plist: #{opts[:ours]}") if o_head.nil?
+die("--theirs is not a readable plist: #{opts[:theirs]}") if t_head.nil?
+
+def to_map(blocks)
+  blocks.each_with_object({}) { |(k, txt), h| h[k] = txt if k }
+end
+o_map, b_map, t_map = to_map(o_blocks), to_map(b_blocks), to_map(t_blocks)
+
+def norm(t) = t.to_s.gsub(%r{<!--.*?-->}m, '').gsub(/\s+/, ' ').strip
+
+conflicts = []
+merged = []
+seen = {}
+
+# Fork order first: its file is the one being updated, so its layout is what a human recognises.
+o_blocks.each do |k, txt|
+  next unless k
+  seen[k] = true
+  if t_map.key?(k)
+    if norm(txt) == norm(t_map[k])
+      merged << t_map[k]                                   # identical — prefer the template's
+                                                           # copy so its comments come along
+    elsif b_map.key?(k) && norm(txt) == norm(b_map[k])
+      merged << t_map[k]                                   # only the template moved
+    elsif b_map.key?(k) && norm(t_map[k]) == norm(b_map[k])
+      merged << txt                                        # only the fork moved
+    else
+      conflicts << "key `#{k}` differs on both sides#{b_map.key?(k) ? '' : ' (add/add, no ancestor)'}"
+      merged << txt
+    end
+  else
+    # Not upstream. Template deleted it and the fork never touched it → honour the deletion.
+    if b_map.key?(k) && norm(txt) == norm(b_map[k]) then nil else merged << txt end
+  end
+end
+
+t_blocks.each do |k, txt|
+  next unless k
+  next if seen[k]
+  # Present upstream, absent in the fork: template added it (or the fork deleted it deliberately).
+  merged << txt unless b_map.key?(k) && !o_map.key?(k)
+end
+
+if conflicts.any?
+  warn "❌ merge-plist: #{conflicts.size} key(s) this merger will not decide:"
+  conflicts.each { |c| warn "     #{c}" }
+  warn "   Nothing was written. Both sides changed the same key to different values — decide which"
+  warn "   belongs in the template and which is fork identity, then re-run."
+  exit 1
+end
+
+# Template's header/footer: it owns the file format (DOCTYPE, plist version).
+File.write(opts[:out], t_head + merged.join + t_foot)
+
+# Validate. An unparseable plist fails the BUILD, so never ship one from a merge.
+if system('which plutil > /dev/null 2>&1')
+  unless system("plutil -lint #{opts[:out].inspect} > /dev/null 2>&1")
+    warn "❌ merge-plist: the merged plist does not parse (plutil -lint failed) — refusing it."
+    File.delete(opts[:out]) if File.file?(opts[:out])
+    exit 1
+  end
+end
+
+if opts[:report]
+  kept = merged.length
+  warn "  plist union: #{kept} key block(s) — #{o_map.keys.length} from fork, #{t_map.keys.length} from template"
+end
+exit 0

--- a/scripts/white-label/sync-dirs.sh
+++ b/scripts/white-label/sync-dirs.sh
@@ -69,9 +69,13 @@ SYNC_DIRS=(
     "feature/profile"       # backbone (owner: template) — demo/** excluded below (WS4/T5)
     "feature/settings"      # backbone (owner: template) — demo/** excluded below (WS4/T5)
     "kotlin-js-store"       # JS lockfile tree (owner: template) — full copy (WS4/T5)
+    "tools"                 # KSP processors (store/database/network/data) — the codegen engine
+                            # the @StoreProvider / @DbEntity / @ApiBinding annotations depend on.
+                            # Was unreachable AND unowned: no fork ever got a processor update.
 )
 
 SYNC_FILES=(
+    ".bundle/config"        # BUNDLE_PATH for the vendored Ruby toolchain (owner: template)
     "Gemfile"
     "Gemfile.lock"
     "ci-prepush.bat"

--- a/scripts/white-label/sync-dirs.sh
+++ b/scripts/white-label/sync-dirs.sh
@@ -72,10 +72,26 @@ SYNC_DIRS=(
     "tools"                 # KSP processors (store/database/network/data) — the codegen engine
                             # the @StoreProvider / @DbEntity / @ApiBinding annotations depend on.
                             # Was unreachable AND unowned: no fork ever got a processor update.
+    # app-profile — REQUIRED for the yaml-schema-merge to ever run. app.yaml + platforms/**/*.yaml
+    # are `owner: merge / yaml-schema-merge` precisely so the template can deliver freshly-added
+    # keys and demo access-points while the fork's identity scalars win. Unreachable, that merge
+    # NEVER executed and every fork's schema silently skewed — the exact defect the blanket
+    # `app-profile/** -> fork` glob was removed to fix. sync_directory runs cs_merge per-file for
+    # owner:merge paths, and fork-owned subpaths (icons, media, app-content, store json, README)
+    # carry explicit `fork` rules preserved by is_excluded.
+    "app-profile"
+    "legal"                 # generator + rendered output (owner: template); legal/*/template.md is
+                            # the fork's real legal document and stays fork-owned by contract.
+    "tests"                 # contract test harness (E0/T1)
+    "META-INF"              # MANIFEST.MF
 )
 
 SYNC_FILES=(
     ".bundle/config"        # BUNDLE_PATH for the vendored Ruby toolchain (owner: template)
+    "LICENSE"
+    "CONTRIBUTING.md"
+    "CODE_OF_CONDUCT.md"
+    "lib-integrate.properties"
     "Gemfile"
     "Gemfile.lock"
     "ci-prepush.bat"
@@ -535,7 +551,10 @@ merge_contract_root_files() {
 
     local mbase; mbase="$(git merge-base "$BASE_BRANCH" "$TEMP_BRANCH" 2>/dev/null)"
     local f strat o b t rc
-    for f in "settings.gradle.kts" "gradle/libs.versions.toml"; do
+    # gradle.properties joins these rather than SYNC_FILES: it is `owner: merge` and carries the
+      # fork's own `fork.project.name`, so a full checkout would clobber it. A 3-way takes the
+      # template's added build-tuning keys while the fork's values win.
+      for f in "settings.gradle.kts" "gradle/libs.versions.toml" "gradle.properties"; do
         cs_match_g "$f"
         [ "${CS_M_OWNER:-}" = "merge" ] || continue
         git show "$TEMP_BRANCH:$f" >/dev/null 2>&1 || { print_warning "Template has no $f — skipping."; continue; }

--- a/scripts/white-label/sync-dirs.sh
+++ b/scripts/white-label/sync-dirs.sh
@@ -7,6 +7,28 @@
 # customization-surface contract library (white-label-template-completion E0/T3).
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# ── SOURCE the contract library — without this the entire merge engine is dead code ─────────────
+# Four sites in this file gate on `declare -F cs_match_g` / `declare -F cs_merge`, including the
+# per-directory 3-way merge loop and merge_contract_root_files(). Nothing ever sourced the library,
+# so every one of those guards was permanently FALSE and every `owner: merge` path was full-copied
+# in silence — the exact clobber the contract's merge class exists to prevent, on every fork, on
+# every sync. The guards read as defensive ("no-op on forks that don't ship the reader"); they were
+# unconditional.
+#
+# Proven end-to-end 2026-09-10 by running the real sync on a clone of mbs/cappy: the CappyWidgets
+# app-extension target vanished from project.pbxproj (40 refs → 0) and the fork's
+# com.apple.security.application-groups entitlement was dropped, while the 12 widget source files
+# stayed on disk as unbuildable orphans. No conflict, no warning, exit 0.
+#
+# A comment at the is_excluded() call site claimed the library must be a SUBPROCESS because it uses
+# "bash-4 syntax". It does not: sourcing it under macOS's /bin/bash 3.2.57 defines cs_match_g and
+# cs_merge correctly (the only `mapfile` matches are a local VARIABLE of that name, not the bash-4
+# builtin). Sourcing is fail-soft — a fork without the reader keeps the old full-copy behaviour.
+if [ -f "$SCRIPT_DIR/../customization-surface.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$SCRIPT_DIR/../customization-surface.sh" >/dev/null 2>&1 || true
+fi
+
 # Capture the invocation args verbatim so the self-update re-exec (below) can restart the sync with
 # the SAME flags (--dry-run / --only / --force …) on the freshly-materialized engine.
 ORIGINAL_ARGS=("$@")
@@ -266,6 +288,10 @@ get_sync_branch_name() {
 print_items() {
     echo -e "${BLUE}Items to sync:${NC}"
     echo -e "${BOLD}Directories:${NC}"
+    # Loop variables are declared local even in a pure-print helper — same dynamic-scope hazard that
+    # made is_excluded() rewrite its caller's `dir`. This one is called at top level today, which is
+    # exactly how it stays harmless until someone calls it from inside a function.
+    local dir file
     for dir in "${SYNC_DIRS[@]}"; do
         echo -e "  ${BOLD}→${NC} $dir"
     done
@@ -338,21 +364,33 @@ is_excluded() {
     fi
 
     # Check directory-specific exclusions
-    for dir in "${!EXCLUSIONS[@]}"; do
+    # `_ex_dir`, NOT `dir` — bash has DYNAMIC scope, so an undeclared loop variable here assigns to
+    # the CALLER's `local dir`. sync_directory() calls is_excluded() from its convention-exclusion
+    # loop, so this `for dir in …` silently rewrote sync_directory's own `dir` to the LAST key of
+    # EXCLUSIONS, and every step after that point ran against the wrong directory:
+    #   propagate_template_deletions "$dir"   → wrong dir
+    #   the 3-way merge loop's `-- "$dir"`     → wrong dir
+    #   the "Restore excluded files" block     → wrong EXCLUSIONS entry
+    # Proven 2026-09-10: a real `--only cmp-ios` run printed "Syncing cmp-ios", then the merge loop
+    # reported `dir=[feature/settings]` and merged 63 feature/settings strings files while cmp-ios
+    # got ZERO merge passes — its project.pbxproj was full-copied (-404/+35), deleting the fork's
+    # CappyWidgets target. The loop variable is now function-private and can never reach a caller.
+    local _ex_dir
+    for _ex_dir in "${!EXCLUSIONS[@]}"; do
         # Skip the root key as we've already checked it
-        if [ "$dir" = "root" ]; then
+        if [ "$_ex_dir" = "root" ]; then
             continue
         fi
 
         # Check if the path starts with the directory we're looking at
-        if [[ "$full_path" == "$dir"* ]]; then
+        if [[ "$full_path" == "$_ex_dir"* ]]; then
             local IFS=' '
-            read -ra EXCLUDE_ITEMS <<< "${EXCLUSIONS[$dir]}"
+            read -ra EXCLUDE_ITEMS <<< "${EXCLUSIONS[$_ex_dir]}"
 
             for item in "${EXCLUDE_ITEMS[@]}"; do
                 local IFS=':'
                 read -ra PARTS <<< "$item"
-                local exclude_path="$dir/${PARTS[0]}"
+                local exclude_path="$_ex_dir/${PARTS[0]}"
                 local exclude_type="${PARTS[1]}"
 
                 # Remove any duplicate slashes
@@ -469,6 +507,103 @@ merge_settings_include_union() {
 #   • both diverged (ours != base, theirs != base, ≠)    → CONFLICT        → keep ours + surface
 # The fork's file formatting/comments are preserved (we walk OURS and only swap bumped values
 # + append template-added keys). Returns 0 clean · 1 if a real conflict was surfaced.
+# ── project.pbxproj — a STRUCTURAL 3-way, delegated to merge-pbxproj.rb ──────
+# A line merge is not merely suboptimal on a pbxproj, it is unusable: the file is a serialized
+# object graph, so "add a target" edits UUID arrays three levels from the object it adds, and
+# git merge-file calls adjacent array insertions a conflict. Worse, conflict markers make the
+# project UNOPENABLE — a human cannot even use Xcode to resolve what the merge produced. Measured
+# on mbs/cappy: git merge-file emitted 6 conflict markers where the structural merge has 0.
+#
+# FALLBACK IS "KEEP OURS", NEVER "TAKE THEIRS". Without ruby the merge cannot run, and the two
+# failure modes are not symmetric: taking the template's copy silently deletes the fork's targets
+# (unrecoverable without git archaeology), while keeping the fork's copy merely means this sync
+# skipped the Xcode project — visible, warned, and re-tried on the next run.
+merge_pbxproj_3way() {
+    local ours="$1" base="$2" theirs="$3" out="${4:-$1}"
+    [ -f "$ours" ] && [ -f "$theirs" ] || { [ -f "$theirs" ] && cp "$theirs" "$out"; return 0; }
+    [ -f "$base" ] || cp "$ours" "$base"
+
+    local repo_root; repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+    local merger="$repo_root/scripts/white-label/merge-pbxproj.rb"
+    if [ ! -f "$merger" ]; then
+        print_warning "merge-pbxproj.rb absent — KEPT the fork's $out (this sync skipped the Xcode project)"
+        cp "$ours" "$out"; return 0
+    fi
+
+    # shellcheck source=/dev/null
+    . "$repo_root/scripts/ruby-exec.sh" 2>/dev/null || true
+    if ! declare -F ruby_exec >/dev/null 2>&1; then
+        print_warning "ruby-exec.sh unavailable — KEPT the fork's $out (this sync skipped the Xcode project)"
+        cp "$ours" "$out"; return 0
+    fi
+
+    local tmp_out; tmp_out="$(mktemp -d)/project.pbxproj"
+    mkdir -p "$(dirname "$tmp_out")"
+
+    # PLAIN ruby first, bundler only as a fallback. `xcodeproj` ships as a fastlane transitive, so on
+    # a machine that has ever set up iOS deployment it is already installed for the pinned ruby and
+    # loads with a bare `require` — measured 1.27.0 on both the template and a fresh fork clone.
+    # Going through bundler FIRST breaks that: `bundle exec` demands a fully-installed Gemfile in the
+    # FORK, and a fork that has never run `bundle install` gets bundler resolving against whatever
+    # ruby it lands on. Observed on a real run — the merge died in bundler under macOS's system ruby
+    # 2.6 with `uninitialized constant Gem::Resolver::APISet::GemParser`, nothing to do with the
+    # merge, and the sync fell back to keep-ours for a file it could have merged cleanly.
+    # merge-pbxproj.rb exits 2 (and only 2) when the gem is genuinely unavailable, so that is the
+    # single signal worth retrying under bundler.
+    ruby_exec "$merger" --ours "$ours" --base "$base" --theirs "$theirs" --out "$tmp_out" --report
+    local _rc=$?
+    if [ "$_rc" -eq 2 ] && declare -F ruby_bundle >/dev/null 2>&1; then
+        ruby_bundle "$repo_root" -- exec ruby "$merger" \
+            --ours "$ours" --base "$base" --theirs "$theirs" --out "$tmp_out" --report
+        _rc=$?
+    fi
+    if [ "$_rc" -eq 0 ]; then
+        cp "$tmp_out" "$out"; rm -rf "$(dirname "$tmp_out")"; return 0
+    fi
+    rm -rf "$(dirname "$tmp_out")"
+    # Exit 1 = a difference the merger refuses to decide; exit 2 = the gem/toolchain is missing.
+    print_warning "pbxproj merge did not complete — KEPT the fork's $out. Review the reason above;"
+    print_warning "  a per-fork identity setting belongs in FORK_IDENTITY_KEYS in merge-pbxproj.rb."
+    cp "$ours" "$out"
+    return 1
+}
+
+# ── Info.plist / *.entitlements — key-level union, delegated to merge-plist.rb ───────────────
+# Template and fork each add their OWN keys to a flat top-level <dict>, so the additions land at the
+# same point in the text and a line merge calls non-overlapping changes a conflict. Both files are
+# also ADD/ADD against a fork's older base (neither existed at mbs/cappy's b97eb73d), so there is no
+# ancestor and EVERY line conflicts. A `<<<<<<<` in an XML plist does not parse — the build breaks.
+# Same keep-ours fallback rationale as the pbxproj merger.
+merge_plist_union() {
+    local ours="$1" base="$2" theirs="$3" out="${4:-$1}"
+    [ -f "$ours" ] && [ -f "$theirs" ] || { [ -f "$theirs" ] && cp "$theirs" "$out"; return 0; }
+
+    local repo_root; repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+    local merger="$repo_root/scripts/white-label/merge-plist.rb"
+    if [ ! -f "$merger" ]; then
+        print_warning "merge-plist.rb absent — KEPT the fork's $out (this sync skipped it)"
+        cp "$ours" "$out"; return 0
+    fi
+    # shellcheck source=/dev/null
+    . "$repo_root/scripts/ruby-exec.sh" 2>/dev/null || true
+    if ! declare -F ruby_exec >/dev/null 2>&1; then
+        print_warning "ruby-exec.sh unavailable — KEPT the fork's $out (this sync skipped it)"
+        cp "$ours" "$out"; return 0
+    fi
+    # `-` tells the merger there is no ancestor for THIS FILE, which is different from the repo
+    # having no merge base: a file added on both sides since the last sync has a valid repo base
+    # and still no file base.
+    local base_arg="$base"; [ -s "$base" ] || base_arg="-"
+    local tmp; tmp="$(mktemp)"
+    if ruby_exec "$merger" --ours "$ours" --base "$base_arg" --theirs "$theirs" --out "$tmp" --report; then
+        cp "$tmp" "$out"; rm -f "$tmp"; return 0
+    fi
+    rm -f "$tmp"
+    print_warning "plist union did not complete — KEPT the fork's $out. Review the reason above."
+    cp "$ours" "$out"
+    return 1
+}
+
 merge_libs_catalog_3way() {
     local ours="$1" base="$2" theirs="$3" out="${4:-$1}"
     [ -f "$ours" ] && [ -f "$theirs" ] || { [ -f "$theirs" ] && cp "$theirs" "$out"; return 0; }
@@ -549,7 +684,10 @@ merge_contract_root_files() {
     echo -e "\n${BLUE}${BOLD}Contract-keyed root merges (settings include-union + catalog-3way)...${NC}"
     echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
 
-    local mbase; mbase="$(git merge-base "$BASE_BRANCH" "$TEMP_BRANCH" 2>/dev/null)"
+    # Anchor via resolve_merge_base, NOT `git merge-base` alone — a copied (non-forked) fork has no
+    # shared history and the bare call returns empty, which silently degrades every merge below into
+    # a full-copy. See resolve_merge_base().
+    local mbase; mbase="$(resolve_merge_base "$BASE_BRANCH" "$TEMP_BRANCH")" || mbase=""
     local f strat o b t rc
     # gradle.properties joins these rather than SYNC_FILES: it is `owner: merge` and carries the
       # fork's own `fork.project.name`, so a full checkout would clobber it. A 3-way takes the
@@ -567,6 +705,8 @@ merge_contract_root_files() {
         case "$strat" in
             include-union) merge_settings_include_union "$o" "$b" "$t" "$f"; rc=$? ;;
             catalog-3way)  merge_libs_catalog_3way      "$o" "$b" "$t" "$f"; rc=$? ;;
+            pbxproj-3way)  merge_pbxproj_3way          "$o" "$b" "$t" "$f"; rc=$? ;;
+            plist-union)   merge_plist_union           "$o" "$b" "$t" "$f"; rc=$? ;;
             *)             cs_merge "$strat" "$o" "$b" "$t" "$f"; rc=$? ;;
         esac
         if [ "${rc:-0}" -eq 0 ]; then
@@ -576,6 +716,39 @@ merge_contract_root_files() {
         fi
         rm -f "$o" "$b" "$t"
     done
+}
+
+# ── The 3-way merge BASE, for true forks AND copied ones ─────────────────────
+# `owner: merge` is only worth declaring if the 3-way actually has a common ancestor to diff
+# against. Two fork topologies exist and only one has it:
+#
+#   forked   — `gh repo fork` / `git clone` of the template. Shares history, so
+#              `git merge-base $BASE_BRANCH $TEMP_BRANCH` returns a real commit.
+#   copied   — the template TREE copied into a fresh repo (the common case in practice: measured
+#              on mbs/cappy 2026-09-10 — different root commits, ZERO shared commits).
+#              `git merge-base` returns EMPTY.
+#
+# An empty base is not a harmless degradation. `git merge-file ours <base> theirs` with base==ours
+# sees every template difference as a clean addition onto an untouched base and takes ALL of theirs
+# — so the merge silently produces exactly the full-copy that declaring `merge` was meant to prevent,
+# with a reassuring "Merged (…) — fork edits preserved" line printed over the top of the loss.
+#
+# `.template-version#template_sha` is the anchor for the copied case, and its own header already
+# says so ("anchors the next sync's 3-way merge base") — the merge loops simply were not reading it.
+# It records the template commit this tree last synced FROM, which is precisely the common ancestor
+# git cannot compute across unrelated histories.
+#
+# Order: real merge-base (most accurate) → PREV_TEMPLATE_SHA (correct for copied forks) → empty
+# (first-ever sync of a copied fork with no anchor — the caller then falls back to ours, and the
+# loop WARNS rather than claiming a merge it did not perform).
+resolve_merge_base() {
+    local a="$1" b="$2" mb
+    mb="$(git merge-base "$a" "$b" 2>/dev/null)"
+    if [ -n "$mb" ]; then printf '%s' "$mb"; return 0; fi
+    if [ -n "${PREV_TEMPLATE_SHA:-}" ] && git cat-file -e "$PREV_TEMPLATE_SHA" 2>/dev/null; then
+        printf '%s' "$PREV_TEMPLATE_SHA"; return 0
+    fi
+    return 1
 }
 
 # Function to sync directory with exclusions
@@ -691,14 +864,44 @@ sync_directory() {
             # (BASE_BRANCH), theirs=upstream (temp_branch), base=merge-base. Guarded:
             # no-op on forks that don't ship the reader.
             if declare -F cs_match_g >/dev/null 2>&1 && declare -F cs_merge >/dev/null 2>&1; then
-                local _mbase; _mbase="$(git merge-base "$BASE_BRANCH" "$temp_branch" 2>/dev/null)"
+                local _mbase; _mbase="$(resolve_merge_base "$BASE_BRANCH" "$temp_branch")" || _mbase=""
                 while IFS= read -r _mf; do
                     [ -z "$_mf" ] && continue
                     cs_match_g "$_mf"; [ "${CS_M_OWNER:-}" = "merge" ] || continue
+                    # A line-based 3-way on a binary produces corruption that still LOOKS like a
+                    # successful merge. The blanket `merge` rows cover whole platform shells, so a
+                    # binary reaching here is expected (icons, .webp, .ico) rather than exceptional —
+                    # most are carved out as `fork`, and this catches whatever is not.
+                    if [ -f "$_mf" ] && ! LC_ALL=C grep -qI . "$_mf" 2>/dev/null \
+                       && [ -s "$_mf" ]; then
+                        print_warning "Binary ${BOLD}$_mf${NC} is merge-owned — took the template's copy (no line merge possible)"
+                        continue
+                    fi
                     local _o _b _t; _o="$(mktemp)"; _b="$(mktemp)"; _t="$(mktemp)"
                     if git show "$BASE_BRANCH:$_mf" > "$_o" 2>/dev/null \
                        && git show "$temp_branch:$_mf" > "$_t" 2>/dev/null; then
-                        git show "${_mbase}:$_mf" > "$_b" 2>/dev/null || cp "$_o" "$_b"
+                        # ── The per-FILE ancestor, which is not the same as the repo having one ──
+                        # A file ADDED on both sides since the last sync (add/add) has a valid repo
+                        # merge base and NO base blob of its own. Seeding `base` with OURS in that
+                        # case is not a neutral fallback — it actively inverts the result: every key
+                        # the fork owns then looks like something present in the ancestor and deleted
+                        # upstream, so the merge DROPS it and reports success.
+                        #
+                        # Measured 2026-09-10: cmp-ios/iosApp/iosApp.entitlements is add/add for
+                        # mbs/cappy (absent at b97eb73d; the template added its own in 99083ed2, the
+                        # fork added its own). With base:=ours the union emitted ONE key —
+                        # keychain-access-groups — silently dropping the fork's
+                        # com.apple.security.application-groups, the WidgetKit shared container.
+                        #
+                        # An EMPTY base states the truth: no common ancestor. A union strategy then
+                        # unions (correct), and a line 3-way conflicts (honest, and visible) instead
+                        # of quietly handing the file to the template.
+                        if [ -n "$_mbase" ] && git show "${_mbase}:$_mf" > "$_b" 2>/dev/null; then
+                            :
+                        else
+                            : > "$_b"
+                            print_warning "No common ancestor for ${BOLD}$_mf${NC} (added on both sides) — merging as add/add"
+                        fi
                         mkdir -p "$(dirname "$_mf")"
                         # Route the contract-declared strategy: the two structure-aware unions
                         # (include-union / catalog-3way) use their dedicated engines; everything
@@ -708,6 +911,8 @@ sync_directory() {
                         case "$_ms" in
                             include-union) merge_settings_include_union "$_o" "$_b" "$_t" "$_mf"; _mrc=$? ;;
                             catalog-3way)  merge_libs_catalog_3way      "$_o" "$_b" "$_t" "$_mf"; _mrc=$? ;;
+                            pbxproj-3way)  merge_pbxproj_3way          "$_o" "$_b" "$_t" "$_mf"; _mrc=$? ;;
+                            plist-union)   merge_plist_union           "$_o" "$_b" "$_t" "$_mf"; _mrc=$? ;;
                             *)             cs_merge "$_ms" "$_o" "$_b" "$_t" "$_mf"; _mrc=$? ;;
                         esac
                         if [ "${_mrc:-0}" -eq 0 ]; then

--- a/tests/fixtures/pbxproj-3way-canary/README.md
+++ b/tests/fixtures/pbxproj-3way-canary/README.md
@@ -1,0 +1,45 @@
+# pbxproj-3way canary
+
+Real data, not synthetic. Captured 2026-09-10 from `mbs/cappy` ⋈ `openMF/kmp-project-template`:
+
+| file | what it is |
+|---|---|
+| `base.pbxproj`   | the template at `b97eb73d` — cappy's `.template-version#template_sha` |
+| `ours.pbxproj`   | cappy's current project (adds a `CappyWidgets` app-extension target) |
+| `theirs.pbxproj` | template HEAD (adds the SwiftPM migration, de-hardcodes `DEVELOPMENT_TEAM`) |
+
+It is the honest case because both sides evolved from the base in ways that a line merge cannot
+reconcile — `git merge-file` produces **6 conflict markers** here, and a conflict marker in a
+pbxproj makes the project unopenable in Xcode.
+
+## What the merge must achieve
+
+- template SPM migration lands — `XCLocalSwiftPackageReference`, `KotlinMultiplatformLinkedPackage`
+- fork content survives — the `CappyWidgets` target, its build phases, `PayCraftStoreKit2.swift`
+- template's de-hardcoding of `DEVELOPMENT_TEAM` wins (`L432S2FZP5` → `$(TEAM_ID)`), because the
+  fork never changed it since base — signing then resolves through the fork-owned `Config.xcconfig`
+- zero conflict markers, zero dangling UUID references, graph re-opens through the `xcodeproj` gem
+
+## Why a dangling reference is the interesting failure
+
+`Configs/iOSApp.xcconfig` exists in base and ours, and the template deleted it. The object is
+correctly dropped, and the `PBXGroup.children` entry naming it must be dropped WITH it. An earlier
+version pruned only the object, leaving a dangling reference the gem discards on load with a
+warning — a merge that reports success while silently losing what the reference pointed at. That is
+what `PM-4` pins.
+
+Run: `bash scripts/product-health/checks/pbxproj-merge.sh` (via `product-health.sh`).
+
+## plist union inputs (PM-6)
+
+| file | what it is |
+|---|---|
+| `entitlements.ours` / `.theirs` | cappy's app-group entitlement vs the template's keychain-access-groups |
+| `infoplist.ours` / `.theirs`    | cappy's `CFBundleURLTypes` OAuth redirect vs the template's base keys |
+
+Both are merged with `--base -`. That is the measured truth for `iosApp.entitlements`, which is
+**add/add** — absent at cappy's base `b97eb73d`, added independently on both sides — where a line
+merge conflicts and the output fails `plutil -lint`.
+
+`Info.plist` does have a real ancestor and line-merges cleanly today; it is exercised here for the
+same flat-dict shape, and running it base-less is the stricter test (no ancestor to lean on).

--- a/tests/fixtures/pbxproj-3way-canary/base.pbxproj
+++ b/tests/fixtures/pbxproj-3way-canary/base.pbxproj
@@ -1,0 +1,1035 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557BA273AAA24004C7B11 /* Assets.xcassets */; };
+		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
+		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
+		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
+		BF7FA1D79F34816E320C8EDA /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 450586FEB2DE420D9722E79B /* FirebaseAnalytics */; };
+		D93DFD3AD365436F195168D6 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 7EF40345BBFE68C34625D3D0 /* FirebaseCore */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		058557BA273AAA24004C7B11 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		2152FB032600AC8F00CF470E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
+		7555FF7B242A565900829871 /* iosApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iosApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		7555FF82242A565900829871 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		CAFE001F00000000000000A1 /* iOSApp.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = iOSApp.xcconfig; sourceTree = "<group>"; };
+		CAFE001F00000000000000D1 /* demoDebug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = demoDebug.xcconfig; sourceTree = "<group>"; };
+		CAFE001F00000000000000D2 /* demoStaging.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = demoStaging.xcconfig; sourceTree = "<group>"; };
+		CAFE001F00000000000000D3 /* demoRelease.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = demoRelease.xcconfig; sourceTree = "<group>"; };
+		CAFE001F00000000000000D4 /* prodDebug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = prodDebug.xcconfig; sourceTree = "<group>"; };
+		CAFE001F00000000000000D5 /* prodStaging.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = prodStaging.xcconfig; sourceTree = "<group>"; };
+		CAFE001F00000000000000D6 /* prodRelease.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = prodRelease.xcconfig; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		B92378962B6B1156000C7307 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF7FA1D79F34816E320C8EDA /* FirebaseAnalytics in Frameworks */,
+				D93DFD3AD365436F195168D6 /* FirebaseCore in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		058557D7273AAEEB004C7B11 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		7555FF72242A565900829871 = {
+			isa = PBXGroup;
+			children = (
+				CAFE001F00000000000000A2 /* Configs */,
+				AB1DB47929225F7C00F7AF9C /* Configuration */,
+				7555FF7D242A565900829871 /* iosApp */,
+				7555FF7C242A565900829871 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		7555FF7C242A565900829871 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				7555FF7B242A565900829871 /* iosApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		7555FF7D242A565900829871 /* iosApp */ = {
+			isa = PBXGroup;
+			children = (
+				058557BA273AAA24004C7B11 /* Assets.xcassets */,
+				7555FF82242A565900829871 /* ContentView.swift */,
+				7555FF8C242A565B00829871 /* Info.plist */,
+				2152FB032600AC8F00CF470E /* iOSApp.swift */,
+				058557D7273AAEEB004C7B11 /* Preview Content */,
+			);
+			path = iosApp;
+			sourceTree = "<group>";
+		};
+		AB1DB47929225F7C00F7AF9C /* Configuration */ = {
+			isa = PBXGroup;
+			children = (
+				AB3632DC29227652001CCB65 /* Config.xcconfig */,
+			);
+			path = Configuration;
+			sourceTree = "<group>";
+		};
+		CAFE001F00000000000000A2 /* Configs */ = {
+			isa = PBXGroup;
+			children = (
+				CAFE001F00000000000000A1 /* iOSApp.xcconfig */,
+				CAFE001F00000000000000D1 /* demoDebug.xcconfig */,
+				CAFE001F00000000000000D2 /* demoStaging.xcconfig */,
+				CAFE001F00000000000000D3 /* demoRelease.xcconfig */,
+				CAFE001F00000000000000D4 /* prodDebug.xcconfig */,
+				CAFE001F00000000000000D5 /* prodStaging.xcconfig */,
+				CAFE001F00000000000000D6 /* prodRelease.xcconfig */,
+			);
+			path = Configs;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		7555FF7A242A565900829871 /* iosApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7555FFA5242A565B00829871 /* Build configuration list for PBXNativeTarget "iosApp" */;
+			buildPhases = (
+				A1B2C3D4E5F600000000E001 /* [KMP] Embed and Sign ComposeApp XCFramework */,
+				7555FF77242A565900829871 /* Sources */,
+				B92378962B6B1156000C7307 /* Frameworks */,
+				7555FF79242A565900829871 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = iosApp;
+			packageProductDependencies = (
+				450586FEB2DE420D9722E79B /* FirebaseAnalytics */,
+				7EF40345BBFE68C34625D3D0 /* FirebaseCore */,
+			);
+			productName = iosApp;
+			productReference = 7555FF7B242A565900829871 /* iosApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		7555FF73242A565900829871 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastSwiftUpdateCheck = 1130;
+				LastUpgradeCheck = 1610;
+				ORGANIZATIONNAME = orgName;
+				TargetAttributes = {
+					7555FF7A242A565900829871 = {
+						CreatedOnToolsVersion = 11.3.1;
+					};
+				};
+			};
+			buildConfigurationList = 7555FF76242A565900829871 /* Build configuration list for PBXProject "iosApp" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 7555FF72242A565900829871;
+			packageReferences = (
+				118A06A4848A7CD9FF70BABD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+			);
+			productRefGroup = 7555FF7C242A565900829871 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				7555FF7A242A565900829871 /* iosApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		7555FF79242A565900829871 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */,
+				058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		A1B2C3D4E5F600000000E001 /* [KMP] Embed and Sign ComposeApp XCFramework */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "[KMP] Embed and Sign ComposeApp XCFramework";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"$SRCROOT/scripts/embed-xcframework.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		7555FF77242A565900829871 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
+				7555FF83242A565900829871 /* ContentView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		7555FFA3242A565B00829871 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		7555FFA4242A565B00829871 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		7555FFA6242A565B00829871 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 54;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 2026.1.20;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		7555FFA7242A565B00829871 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 54;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = L432S2FZP5;
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 2026.1.20;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		CAFE001F00000000000000B1 /* demoDebug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = demoDebug;
+		};
+		CAFE001F00000000000000B2 /* demoStaging */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = demoStaging;
+		};
+		CAFE001F00000000000000B3 /* demoRelease */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = demoRelease;
+		};
+		CAFE001F00000000000000B4 /* prodDebug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = prodDebug;
+		};
+		CAFE001F00000000000000B5 /* prodStaging */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = prodStaging;
+		};
+		CAFE001F00000000000000B6 /* prodRelease */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = prodRelease;
+		};
+		CAFE001F00000000000000C1 /* demoDebug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D1 /* demoDebug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 47;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(KMPF_VARIANT)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = demoDebug;
+		};
+		CAFE001F00000000000000C2 /* demoStaging */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D2 /* demoStaging.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 47;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(KMPF_VARIANT)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = demoStaging;
+		};
+		CAFE001F00000000000000C3 /* demoRelease */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D3 /* demoRelease.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 47;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(KMPF_VARIANT)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = demoRelease;
+		};
+		CAFE001F00000000000000C4 /* prodDebug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D4 /* prodDebug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 47;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(KMPF_VARIANT)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = prodDebug;
+		};
+		CAFE001F00000000000000C5 /* prodStaging */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D5 /* prodStaging.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 47;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(KMPF_VARIANT)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = prodStaging;
+		};
+		CAFE001F00000000000000C6 /* prodRelease */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D6 /* prodRelease.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 47;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(KMPF_VARIANT)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = prodRelease;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		7555FF76242A565900829871 /* Build configuration list for PBXProject "iosApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7555FFA3242A565B00829871 /* Debug */,
+				7555FFA4242A565B00829871 /* Release */,
+				CAFE001F00000000000000B1 /* demoDebug */,
+				CAFE001F00000000000000B2 /* demoStaging */,
+				CAFE001F00000000000000B3 /* demoRelease */,
+				CAFE001F00000000000000B4 /* prodDebug */,
+				CAFE001F00000000000000B5 /* prodStaging */,
+				CAFE001F00000000000000B6 /* prodRelease */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7555FFA5242A565B00829871 /* Build configuration list for PBXNativeTarget "iosApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7555FFA6242A565B00829871 /* Debug */,
+				7555FFA7242A565B00829871 /* Release */,
+				CAFE001F00000000000000C1 /* demoDebug */,
+				CAFE001F00000000000000C2 /* demoStaging */,
+				CAFE001F00000000000000C3 /* demoRelease */,
+				CAFE001F00000000000000C4 /* prodDebug */,
+				CAFE001F00000000000000C5 /* prodStaging */,
+				CAFE001F00000000000000C6 /* prodRelease */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		118A06A4848A7CD9FF70BABD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 11.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		450586FEB2DE420D9722E79B /* FirebaseAnalytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 118A06A4848A7CD9FF70BABD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalytics;
+		};
+		7EF40345BBFE68C34625D3D0 /* FirebaseCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 118A06A4848A7CD9FF70BABD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCore;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 7555FF73242A565900829871 /* Project object */;
+}

--- a/tests/fixtures/pbxproj-3way-canary/entitlements.ours
+++ b/tests/fixtures/pbxproj-3way-canary/entitlements.ours
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+	    App Group shared container for the Cappy home-screen widget (WidgetKit).
+	    The KMP app writes a widget snapshot here (cappy_widget_snapshot) + drains the
+	    widget's pending-action queue (cappy_widget_pending_actions). The CappyWidgets
+	    extension reads/appends via the SAME group. Both targets must carry this entitlement.
+	-->
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.mobilebytesensei.cappy</string>
+	</array>
+</dict>
+</plist>

--- a/tests/fixtures/pbxproj-3way-canary/entitlements.theirs
+++ b/tests/fixtures/pbxproj-3way-canary/entitlements.theirs
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+	  Keychain Sharing entitlement — REQUIRED by core-base/datastore's KeychainSettings
+	  (service "kpt.secure"). Without it iOS keychain access fails `errSecMissingEntitlement`
+	  (-34018) at launch and crashes the Koin graph (UserPreferencesRepositoryImpl ->
+	  UserDataRepositoryImpl -> AppViewModel). Affects every fork (the store is template code).
+	  $(AppIdentifierPrefix) is the team prefix on device / empty on the simulator; the app's
+	  own bundle-id group is always permitted by any provisioning profile.
+
+	  Forks that add "Sign in with Apple" also add:
+	      <key>com.apple.developer.applesignin</key><array><string>Default</string></array>
+	  but only after enabling the capability on their App ID (else automatic provisioning fails).
+	-->
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)$(CFBundleIdentifier)</string>
+	</array>
+</dict>
+</plist>

--- a/tests/fixtures/pbxproj-3way-canary/infoplist.ours
+++ b/tests/fixtures/pbxproj-3way-canary/infoplist.ours
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<!-- Google Sign-In OAuth-redirect callback (feature: login). Registers the app bundle-id URL scheme so
+	     Supabase GoTrue's ASWebAuthenticationSession can return to the app after Google consent. Matches
+	     CappyAuthConfig.oauthRedirectUrl (`$(PRODUCT_BUNDLE_IDENTIFIER)://login-callback`); that exact URL
+	     must also be in the Supabase project's Auth → Redirect URLs allowlist. -->
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleShortVersionString</key>
+	<string>2026.1.20</string>
+	<key>CFBundleVersion</key>
+	<string>54</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>This app does not use Bluetooth. This message is required for compliance only.</string>
+	<key>NSContactsUsageDescription</key>
+	<string>This app does not access your contacts. This message is required for compliance only.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>This app does not access your location. This message is required for compliance only.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Allow access to save images to your photo library.</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/tests/fixtures/pbxproj-3way-canary/infoplist.theirs
+++ b/tests/fixtures/pbxproj-3way-canary/infoplist.theirs
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>2026.1.20</string>
+	<key>CFBundleVersion</key>
+	<string>54</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>This app does not use Bluetooth. This message is required for compliance only.</string>
+	<key>NSContactsUsageDescription</key>
+	<string>This app does not access your contacts. This message is required for compliance only.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>This app does not access your location. This message is required for compliance only.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Allow access to save images to your photo library.</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/tests/fixtures/pbxproj-3way-canary/ours.pbxproj
+++ b/tests/fixtures/pbxproj-3way-canary/ours.pbxproj
@@ -1,0 +1,1437 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557BA273AAA24004C7B11 /* Assets.xcassets */; };
+		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
+		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
+		2404C95F9638FCC65D9CD77C /* CappyWidgets.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = CCB55E492609D08F01BF394A /* CappyWidgets.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		3ACACFB655FBB022BA54686A /* GoalsWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDF783EC4D8987EEE5FE227 /* GoalsWidgetView.swift */; };
+		3F008A682B09D1030514872C /* CappyWidgetsBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8853F76EFDCBB2BEC2EE80E /* CappyWidgetsBundle.swift */; };
+		649681032940A9CC18634279 /* Provider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734134B837DD32B6B0E0C242 /* Provider.swift */; };
+		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
+		BC0836AFB856B33642251BA2 /* PayCraftStoreKit2.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE7256219EFE9C6CD787C6EA /* PayCraftStoreKit2.swift */; };
+		A9DD4FE8D2BEDC0F8997EF67 /* CappyTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456D2A031A7E73BBCB0E2217 /* CappyTheme.swift */; };
+		B49CA8B92D6A3234B192EB87 /* MoodWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E8B546B918BF5670830A3AF /* MoodWidgetView.swift */; };
+		BF7FA1D79F34816E320C8EDA /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 450586FEB2DE420D9722E79B /* FirebaseAnalytics */; };
+		CA0FD693EF48EC24969EF10C /* QuickLaunchWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67316387595CDCBD1A206E5 /* QuickLaunchWidgetView.swift */; };
+		CC19F4B7D69DFACDBB785752 /* WidgetIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA29CA2250A8B81CEB21B991 /* WidgetIntents.swift */; };
+		D1A150E309465C63EB907C8F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1856BC37672FE187D8EAB8C /* Foundation.framework */; };
+		D80C392E4DB5F77D27089CDC /* WidgetStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E6DBC48E3E4A755D0988666 /* WidgetStore.swift */; };
+		D93DFD3AD365436F195168D6 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 7EF40345BBFE68C34625D3D0 /* FirebaseCore */; };
+		E4A3177C415513B7A9951EC4 /* FocusWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4AA63AB64E0687F5383F299 /* FocusWidgetView.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		CCD5B9F23561C85AE8302539 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7555FF73242A565900829871 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0998900C80ABF9DF0388BEB7;
+			remoteInfo = CappyWidgets;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		DCBFDAB9F2EE7B15B329ADBB /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				2404C95F9638FCC65D9CD77C /* CappyWidgets.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		058557BA273AAA24004C7B11 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		2152FB032600AC8F00CF470E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
+		2CDF783EC4D8987EEE5FE227 /* GoalsWidgetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GoalsWidgetView.swift; sourceTree = "<group>"; };
+		2E8B546B918BF5670830A3AF /* MoodWidgetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MoodWidgetView.swift; sourceTree = "<group>"; };
+		456D2A031A7E73BBCB0E2217 /* CappyTheme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CappyTheme.swift; sourceTree = "<group>"; };
+		6E6DBC48E3E4A755D0988666 /* WidgetStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WidgetStore.swift; sourceTree = "<group>"; };
+		734134B837DD32B6B0E0C242 /* Provider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Provider.swift; sourceTree = "<group>"; };
+		7555FF7B242A565900829871 /* iosApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iosApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		7555FF82242A565900829871 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		BE7256219EFE9C6CD787C6EA /* PayCraftStoreKit2.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PayCraftStoreKit2.swift; sourceTree = "<group>"; };
+		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8F0066885349E75A7003C068 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A1856BC37672FE187D8EAB8C /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		A67316387595CDCBD1A206E5 /* QuickLaunchWidgetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QuickLaunchWidgetView.swift; sourceTree = "<group>"; };
+		AA29CA2250A8B81CEB21B991 /* WidgetIntents.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WidgetIntents.swift; sourceTree = "<group>"; };
+		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		CAFE001F00000000000000A1 /* iOSApp.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = iOSApp.xcconfig; sourceTree = "<group>"; };
+		CAFE001F00000000000000D1 /* demoDebug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = demoDebug.xcconfig; sourceTree = "<group>"; };
+		CAFE001F00000000000000D2 /* demoStaging.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = demoStaging.xcconfig; sourceTree = "<group>"; };
+		CAFE001F00000000000000D3 /* demoRelease.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = demoRelease.xcconfig; sourceTree = "<group>"; };
+		CAFE001F00000000000000D4 /* prodDebug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = prodDebug.xcconfig; sourceTree = "<group>"; };
+		CAFE001F00000000000000D5 /* prodStaging.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = prodStaging.xcconfig; sourceTree = "<group>"; };
+		CAFE001F00000000000000D6 /* prodRelease.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = prodRelease.xcconfig; sourceTree = "<group>"; };
+		CCB55E492609D08F01BF394A /* CappyWidgets.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = CappyWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		D4AA63AB64E0687F5383F299 /* FocusWidgetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FocusWidgetView.swift; sourceTree = "<group>"; };
+		D8853F76EFDCBB2BEC2EE80E /* CappyWidgetsBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CappyWidgetsBundle.swift; sourceTree = "<group>"; };
+		F13BE1CDF454AAE69963D015 /* CappyWidgets.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = CappyWidgets.entitlements; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		B6250EBA136649043503E5BB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D1A150E309465C63EB907C8F /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B92378962B6B1156000C7307 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF7FA1D79F34816E320C8EDA /* FirebaseAnalytics in Frameworks */,
+				D93DFD3AD365436F195168D6 /* FirebaseCore in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		058557D7273AAEEB004C7B11 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		0C0F71EE3A0C98DAFC123290 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				A1856BC37672FE187D8EAB8C /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		3BC911391AE68551A306F4C8 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				0C0F71EE3A0C98DAFC123290 /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		7555FF72242A565900829871 = {
+			isa = PBXGroup;
+			children = (
+				CAFE001F00000000000000A2 /* Configs */,
+				AB1DB47929225F7C00F7AF9C /* Configuration */,
+				7555FF7D242A565900829871 /* iosApp */,
+				7555FF7C242A565900829871 /* Products */,
+				3BC911391AE68551A306F4C8 /* Frameworks */,
+				BCD830A5D300146F95DE728B /* CappyWidgets */,
+			);
+			sourceTree = "<group>";
+		};
+		7555FF7C242A565900829871 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				7555FF7B242A565900829871 /* iosApp.app */,
+				CCB55E492609D08F01BF394A /* CappyWidgets.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		7555FF7D242A565900829871 /* iosApp */ = {
+			isa = PBXGroup;
+			children = (
+				058557BA273AAA24004C7B11 /* Assets.xcassets */,
+				7555FF82242A565900829871 /* ContentView.swift */,
+				BE7256219EFE9C6CD787C6EA /* PayCraftStoreKit2.swift */,
+				7555FF8C242A565B00829871 /* Info.plist */,
+				2152FB032600AC8F00CF470E /* iOSApp.swift */,
+				058557D7273AAEEB004C7B11 /* Preview Content */,
+			);
+			path = iosApp;
+			sourceTree = "<group>";
+		};
+		AB1DB47929225F7C00F7AF9C /* Configuration */ = {
+			isa = PBXGroup;
+			children = (
+				AB3632DC29227652001CCB65 /* Config.xcconfig */,
+			);
+			path = Configuration;
+			sourceTree = "<group>";
+		};
+		BCD830A5D300146F95DE728B /* CappyWidgets */ = {
+			isa = PBXGroup;
+			children = (
+				D8853F76EFDCBB2BEC2EE80E /* CappyWidgetsBundle.swift */,
+				6E6DBC48E3E4A755D0988666 /* WidgetStore.swift */,
+				456D2A031A7E73BBCB0E2217 /* CappyTheme.swift */,
+				734134B837DD32B6B0E0C242 /* Provider.swift */,
+				AA29CA2250A8B81CEB21B991 /* WidgetIntents.swift */,
+				D4AA63AB64E0687F5383F299 /* FocusWidgetView.swift */,
+				2E8B546B918BF5670830A3AF /* MoodWidgetView.swift */,
+				2CDF783EC4D8987EEE5FE227 /* GoalsWidgetView.swift */,
+				A67316387595CDCBD1A206E5 /* QuickLaunchWidgetView.swift */,
+				8F0066885349E75A7003C068 /* Info.plist */,
+				F13BE1CDF454AAE69963D015 /* CappyWidgets.entitlements */,
+			);
+			name = CappyWidgets;
+			path = CappyWidgets;
+			sourceTree = SOURCE_ROOT;
+		};
+		CAFE001F00000000000000A2 /* Configs */ = {
+			isa = PBXGroup;
+			children = (
+				CAFE001F00000000000000A1 /* iOSApp.xcconfig */,
+				CAFE001F00000000000000D1 /* demoDebug.xcconfig */,
+				CAFE001F00000000000000D2 /* demoStaging.xcconfig */,
+				CAFE001F00000000000000D3 /* demoRelease.xcconfig */,
+				CAFE001F00000000000000D4 /* prodDebug.xcconfig */,
+				CAFE001F00000000000000D5 /* prodStaging.xcconfig */,
+				CAFE001F00000000000000D6 /* prodRelease.xcconfig */,
+			);
+			path = Configs;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		0998900C80ABF9DF0388BEB7 /* CappyWidgets */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E7359F8E3A731DCBF58185FA /* Build configuration list for PBXNativeTarget "CappyWidgets" */;
+			buildPhases = (
+				349C22BECEB533D9960B92EB /* Sources */,
+				B6250EBA136649043503E5BB /* Frameworks */,
+				B52D1DBC4528FDD932680D7F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CappyWidgets;
+			productName = CappyWidgets;
+			productReference = CCB55E492609D08F01BF394A /* CappyWidgets.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		7555FF7A242A565900829871 /* iosApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7555FFA5242A565B00829871 /* Build configuration list for PBXNativeTarget "iosApp" */;
+			buildPhases = (
+				A1B2C3D4E5F600000000E001 /* [KMP] Embed and Sign ComposeApp XCFramework */,
+				7555FF77242A565900829871 /* Sources */,
+				B92378962B6B1156000C7307 /* Frameworks */,
+				7555FF79242A565900829871 /* Resources */,
+				DCBFDAB9F2EE7B15B329ADBB /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CA2DF59D96769C894613F54D /* PBXTargetDependency */,
+			);
+			name = iosApp;
+			packageProductDependencies = (
+				450586FEB2DE420D9722E79B /* FirebaseAnalytics */,
+				7EF40345BBFE68C34625D3D0 /* FirebaseCore */,
+			);
+			productName = iosApp;
+			productReference = 7555FF7B242A565900829871 /* iosApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		7555FF73242A565900829871 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastSwiftUpdateCheck = 1130;
+				LastUpgradeCheck = 1610;
+				ORGANIZATIONNAME = orgName;
+				TargetAttributes = {
+					7555FF7A242A565900829871 = {
+						CreatedOnToolsVersion = 11.3.1;
+					};
+				};
+			};
+			buildConfigurationList = 7555FF76242A565900829871 /* Build configuration list for PBXProject "iosApp" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 7555FF72242A565900829871;
+			packageReferences = (
+				118A06A4848A7CD9FF70BABD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+			);
+			productRefGroup = 7555FF7C242A565900829871 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				7555FF7A242A565900829871 /* iosApp */,
+				0998900C80ABF9DF0388BEB7 /* CappyWidgets */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		7555FF79242A565900829871 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */,
+				058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B52D1DBC4528FDD932680D7F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		A1B2C3D4E5F600000000E001 /* [KMP] Embed and Sign ComposeApp XCFramework */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "[KMP] Embed and Sign ComposeApp XCFramework";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"$SRCROOT/scripts/embed-xcframework.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		349C22BECEB533D9960B92EB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3F008A682B09D1030514872C /* CappyWidgetsBundle.swift in Sources */,
+				D80C392E4DB5F77D27089CDC /* WidgetStore.swift in Sources */,
+				A9DD4FE8D2BEDC0F8997EF67 /* CappyTheme.swift in Sources */,
+				649681032940A9CC18634279 /* Provider.swift in Sources */,
+				CC19F4B7D69DFACDBB785752 /* WidgetIntents.swift in Sources */,
+				E4A3177C415513B7A9951EC4 /* FocusWidgetView.swift in Sources */,
+				B49CA8B92D6A3234B192EB87 /* MoodWidgetView.swift in Sources */,
+				3ACACFB655FBB022BA54686A /* GoalsWidgetView.swift in Sources */,
+				CA0FD693EF48EC24969EF10C /* QuickLaunchWidgetView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7555FF77242A565900829871 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
+				7555FF83242A565900829871 /* ContentView.swift in Sources */,
+				BC0836AFB856B33642251BA2 /* PayCraftStoreKit2.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		CA2DF59D96769C894613F54D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CappyWidgets;
+			target = 0998900C80ABF9DF0388BEB7 /* CappyWidgets */;
+			targetProxy = CCD5B9F23561C85AE8302539 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		2723C09187CB06DE4AC1424F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = CappyWidgets/CappyWidgets.entitlements;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = CappyWidgets/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID).widgets";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		39EB6230E058946174A3A2DC /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = CappyWidgets/CappyWidgets.entitlements;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = CappyWidgets/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID).widgets";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		3E2DDCE35210129CACCF0673 /* demoRelease */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D3 /* demoRelease.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = CappyWidgets/CappyWidgets.entitlements;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = CappyWidgets/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID).demo.widgets";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = demoRelease;
+		};
+		58A291855F9FC0A82D87A3EE /* prodStaging */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D5 /* prodStaging.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = CappyWidgets/CappyWidgets.entitlements;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = CappyWidgets/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID).widgets";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = prodStaging;
+		};
+		7555FFA3242A565B00829871 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		7555FFA4242A565B00829871 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		7555FFA6242A565B00829871 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 54;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 2026.1.20;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		7555FFA7242A565B00829871 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 54;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = L432S2FZP5;
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 2026.1.20;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		CAFE001F00000000000000B1 /* demoDebug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = demoDebug;
+		};
+		CAFE001F00000000000000B2 /* demoStaging */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = demoStaging;
+		};
+		CAFE001F00000000000000B3 /* demoRelease */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = demoRelease;
+		};
+		CAFE001F00000000000000B4 /* prodDebug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = prodDebug;
+		};
+		CAFE001F00000000000000B5 /* prodStaging */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = prodStaging;
+		};
+		CAFE001F00000000000000B6 /* prodRelease */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = prodRelease;
+		};
+		CAFE001F00000000000000C1 /* demoDebug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D1 /* demoDebug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 47;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(KMPF_VARIANT)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = demoDebug;
+		};
+		CAFE001F00000000000000C2 /* demoStaging */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D2 /* demoStaging.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 47;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(KMPF_VARIANT)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = demoStaging;
+		};
+		CAFE001F00000000000000C3 /* demoRelease */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D3 /* demoRelease.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 47;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(KMPF_VARIANT)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = demoRelease;
+		};
+		CAFE001F00000000000000C4 /* prodDebug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D4 /* prodDebug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 47;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(KMPF_VARIANT)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = prodDebug;
+		};
+		CAFE001F00000000000000C5 /* prodStaging */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D5 /* prodStaging.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 47;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(KMPF_VARIANT)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = prodStaging;
+		};
+		CAFE001F00000000000000C6 /* prodRelease */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D6 /* prodRelease.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 47;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(KMPF_VARIANT)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = prodRelease;
+		};
+		DE8DD9C8477FA26CFC15C836 /* demoDebug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D1 /* demoDebug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = CappyWidgets/CappyWidgets.entitlements;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = CappyWidgets/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID).demo.widgets";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = demoDebug;
+		};
+		EE205D54383D88B7B6093296 /* prodRelease */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D6 /* prodRelease.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = CappyWidgets/CappyWidgets.entitlements;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = CappyWidgets/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID).widgets";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = prodRelease;
+		};
+		F7D26855983854D3C06C0677 /* prodDebug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D4 /* prodDebug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = CappyWidgets/CappyWidgets.entitlements;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = CappyWidgets/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID).widgets";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = prodDebug;
+		};
+		FF26011499F47812B299141B /* demoStaging */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D2 /* demoStaging.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = CappyWidgets/CappyWidgets.entitlements;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = CappyWidgets/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID).demo.widgets";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = demoStaging;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		7555FF76242A565900829871 /* Build configuration list for PBXProject "iosApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7555FFA3242A565B00829871 /* Debug */,
+				7555FFA4242A565B00829871 /* Release */,
+				CAFE001F00000000000000B1 /* demoDebug */,
+				CAFE001F00000000000000B2 /* demoStaging */,
+				CAFE001F00000000000000B3 /* demoRelease */,
+				CAFE001F00000000000000B4 /* prodDebug */,
+				CAFE001F00000000000000B5 /* prodStaging */,
+				CAFE001F00000000000000B6 /* prodRelease */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7555FFA5242A565B00829871 /* Build configuration list for PBXNativeTarget "iosApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7555FFA6242A565B00829871 /* Debug */,
+				7555FFA7242A565B00829871 /* Release */,
+				CAFE001F00000000000000C1 /* demoDebug */,
+				CAFE001F00000000000000C2 /* demoStaging */,
+				CAFE001F00000000000000C3 /* demoRelease */,
+				CAFE001F00000000000000C4 /* prodDebug */,
+				CAFE001F00000000000000C5 /* prodStaging */,
+				CAFE001F00000000000000C6 /* prodRelease */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E7359F8E3A731DCBF58185FA /* Build configuration list for PBXNativeTarget "CappyWidgets" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				39EB6230E058946174A3A2DC /* Release */,
+				2723C09187CB06DE4AC1424F /* Debug */,
+				DE8DD9C8477FA26CFC15C836 /* demoDebug */,
+				FF26011499F47812B299141B /* demoStaging */,
+				3E2DDCE35210129CACCF0673 /* demoRelease */,
+				F7D26855983854D3C06C0677 /* prodDebug */,
+				58A291855F9FC0A82D87A3EE /* prodStaging */,
+				EE205D54383D88B7B6093296 /* prodRelease */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		118A06A4848A7CD9FF70BABD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 11.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		450586FEB2DE420D9722E79B /* FirebaseAnalytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 118A06A4848A7CD9FF70BABD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalytics;
+		};
+		7EF40345BBFE68C34625D3D0 /* FirebaseCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 118A06A4848A7CD9FF70BABD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCore;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 7555FF73242A565900829871 /* Project object */;
+}

--- a/tests/fixtures/pbxproj-3way-canary/theirs.pbxproj
+++ b/tests/fixtures/pbxproj-3way-canary/theirs.pbxproj
@@ -1,0 +1,1068 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557BA273AAA24004C7B11 /* Assets.xcassets */; };
+		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
+		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
+		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
+		BF7FA1D79F34816E320C8EDA /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 450586FEB2DE420D9722E79B /* FirebaseAnalytics */; };
+		D93DFD3AD365436F195168D6 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 7EF40345BBFE68C34625D3D0 /* FirebaseCore */; };
+		A1B2C3D4E5F600000000F001 /* KotlinMultiplatformLinkedPackage in Frameworks */ = {isa = PBXBuildFile; productRef = A1B2C3D4E5F600000000F002 /* KotlinMultiplatformLinkedPackage */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		058557BA273AAA24004C7B11 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		2152FB032600AC8F00CF470E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
+		7555FF7B242A565900829871 /* iosApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iosApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		7555FF82242A565900829871 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		CAFE001F00000000000000D1 /* demoDebug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = demoDebug.xcconfig; sourceTree = "<group>"; };
+		CAFE001F00000000000000D2 /* demoStaging.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = demoStaging.xcconfig; sourceTree = "<group>"; };
+		CAFE001F00000000000000D3 /* demoRelease.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = demoRelease.xcconfig; sourceTree = "<group>"; };
+		CAFE001F00000000000000D4 /* prodDebug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = prodDebug.xcconfig; sourceTree = "<group>"; };
+		CAFE001F00000000000000D5 /* prodStaging.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = prodStaging.xcconfig; sourceTree = "<group>"; };
+		CAFE001F00000000000000D6 /* prodRelease.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = prodRelease.xcconfig; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		B92378962B6B1156000C7307 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF7FA1D79F34816E320C8EDA /* FirebaseAnalytics in Frameworks */,
+				D93DFD3AD365436F195168D6 /* FirebaseCore in Frameworks */,
+				A1B2C3D4E5F600000000F001 /* KotlinMultiplatformLinkedPackage in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		058557D7273AAEEB004C7B11 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		7555FF72242A565900829871 = {
+			isa = PBXGroup;
+			children = (
+				CAFE001F00000000000000A2 /* Configs */,
+				AB1DB47929225F7C00F7AF9C /* Configuration */,
+				7555FF7D242A565900829871 /* iosApp */,
+				7555FF7C242A565900829871 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		7555FF7C242A565900829871 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				7555FF7B242A565900829871 /* iosApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		7555FF7D242A565900829871 /* iosApp */ = {
+			isa = PBXGroup;
+			children = (
+				058557BA273AAA24004C7B11 /* Assets.xcassets */,
+				7555FF82242A565900829871 /* ContentView.swift */,
+				7555FF8C242A565B00829871 /* Info.plist */,
+				2152FB032600AC8F00CF470E /* iOSApp.swift */,
+				058557D7273AAEEB004C7B11 /* Preview Content */,
+			);
+			path = iosApp;
+			sourceTree = "<group>";
+		};
+		AB1DB47929225F7C00F7AF9C /* Configuration */ = {
+			isa = PBXGroup;
+			children = (
+				AB3632DC29227652001CCB65 /* Config.xcconfig */,
+			);
+			path = Configuration;
+			sourceTree = "<group>";
+		};
+		CAFE001F00000000000000A2 /* Configs */ = {
+			isa = PBXGroup;
+			children = (
+				CAFE001F00000000000000D1 /* demoDebug.xcconfig */,
+				CAFE001F00000000000000D2 /* demoStaging.xcconfig */,
+				CAFE001F00000000000000D3 /* demoRelease.xcconfig */,
+				CAFE001F00000000000000D4 /* prodDebug.xcconfig */,
+				CAFE001F00000000000000D5 /* prodStaging.xcconfig */,
+				CAFE001F00000000000000D6 /* prodRelease.xcconfig */,
+			);
+			path = Configs;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		7555FF7A242A565900829871 /* iosApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7555FFA5242A565B00829871 /* Build configuration list for PBXNativeTarget "iosApp" */;
+			buildPhases = (
+				A1B2C3D4E5F600000000E001 /* [KMP] Embed and Sign ComposeApp XCFramework */,
+				7555FF77242A565900829871 /* Sources */,
+				B92378962B6B1156000C7307 /* Frameworks */,
+				7555FF79242A565900829871 /* Resources */,
+				A1B2C3D4E5F600000000E002 /* [KMP] Copy Compose Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = iosApp;
+			packageProductDependencies = (
+				450586FEB2DE420D9722E79B /* FirebaseAnalytics */,
+				7EF40345BBFE68C34625D3D0 /* FirebaseCore */,
+				A1B2C3D4E5F600000000F002 /* KotlinMultiplatformLinkedPackage */,
+			);
+			productName = iosApp;
+			productReference = 7555FF7B242A565900829871 /* iosApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		7555FF73242A565900829871 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastSwiftUpdateCheck = 1130;
+				LastUpgradeCheck = 1610;
+				ORGANIZATIONNAME = orgName;
+				TargetAttributes = {
+					7555FF7A242A565900829871 = {
+						CreatedOnToolsVersion = 11.3.1;
+					};
+				};
+			};
+			buildConfigurationList = 7555FF76242A565900829871 /* Build configuration list for PBXProject "iosApp" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 7555FF72242A565900829871;
+			packageReferences = (
+				118A06A4848A7CD9FF70BABD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				A1B2C3D4E5F600000000F003 /* XCLocalSwiftPackageReference "KotlinMultiplatformLinkedPackage" */,
+			);
+			productRefGroup = 7555FF7C242A565900829871 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				7555FF7A242A565900829871 /* iosApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		7555FF79242A565900829871 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */,
+				058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		A1B2C3D4E5F600000000E001 /* [KMP] Embed and Sign ComposeApp XCFramework */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "[KMP] Embed and Sign ComposeApp XCFramework";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"$SRCROOT/scripts/embed-xcframework.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A1B2C3D4E5F600000000E002 /* [KMP] Copy Compose Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "[KMP] Copy Compose Resources";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"$SRCROOT/scripts/copy-compose-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		7555FF77242A565900829871 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
+				7555FF83242A565900829871 /* ContentView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		7555FFA3242A565B00829871 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		7555FFA4242A565B00829871 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		7555FFA6242A565B00829871 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 54;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 2026.1.20;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		7555FFA7242A565B00829871 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 54;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 2026.1.20;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		CAFE001F00000000000000B1 /* demoDebug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = demoDebug;
+		};
+		CAFE001F00000000000000B2 /* demoStaging */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = demoStaging;
+		};
+		CAFE001F00000000000000B3 /* demoRelease */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = demoRelease;
+		};
+		CAFE001F00000000000000B4 /* prodDebug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = prodDebug;
+		};
+		CAFE001F00000000000000B5 /* prodStaging */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = prodStaging;
+		};
+		CAFE001F00000000000000B6 /* prodRelease */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = prodRelease;
+		};
+		CAFE001F00000000000000C1 /* demoDebug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D1 /* demoDebug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 47;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(KMPF_VARIANT)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = demoDebug;
+		};
+		CAFE001F00000000000000C2 /* demoStaging */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D2 /* demoStaging.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 47;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(KMPF_VARIANT)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = demoStaging;
+		};
+		CAFE001F00000000000000C3 /* demoRelease */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D3 /* demoRelease.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 47;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(KMPF_VARIANT)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = demoRelease;
+		};
+		CAFE001F00000000000000C4 /* prodDebug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D4 /* prodDebug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 47;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(KMPF_VARIANT)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = prodDebug;
+		};
+		CAFE001F00000000000000C5 /* prodStaging */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D5 /* prodStaging.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 47;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(KMPF_VARIANT)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = prodStaging;
+		};
+		CAFE001F00000000000000C6 /* prodRelease */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFE001F00000000000000D6 /* prodRelease.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 47;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
+				ENABLE_PREVIEWS = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../cmp-shared/build/xcode-frameworks/$(KMPF_VARIANT)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_NAME)";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = prodRelease;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		7555FF76242A565900829871 /* Build configuration list for PBXProject "iosApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7555FFA3242A565B00829871 /* Debug */,
+				7555FFA4242A565B00829871 /* Release */,
+				CAFE001F00000000000000B1 /* demoDebug */,
+				CAFE001F00000000000000B2 /* demoStaging */,
+				CAFE001F00000000000000B3 /* demoRelease */,
+				CAFE001F00000000000000B4 /* prodDebug */,
+				CAFE001F00000000000000B5 /* prodStaging */,
+				CAFE001F00000000000000B6 /* prodRelease */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7555FFA5242A565B00829871 /* Build configuration list for PBXNativeTarget "iosApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7555FFA6242A565B00829871 /* Debug */,
+				7555FFA7242A565B00829871 /* Release */,
+				CAFE001F00000000000000C1 /* demoDebug */,
+				CAFE001F00000000000000C2 /* demoStaging */,
+				CAFE001F00000000000000C3 /* demoRelease */,
+				CAFE001F00000000000000C4 /* prodDebug */,
+				CAFE001F00000000000000C5 /* prodStaging */,
+				CAFE001F00000000000000C6 /* prodRelease */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		A1B2C3D4E5F600000000F003 /* XCLocalSwiftPackageReference "KotlinMultiplatformLinkedPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = KotlinMultiplatformLinkedPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		118A06A4848A7CD9FF70BABD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 12.17.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		450586FEB2DE420D9722E79B /* FirebaseAnalytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 118A06A4848A7CD9FF70BABD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalytics;
+		};
+		7EF40345BBFE68C34625D3D0 /* FirebaseCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 118A06A4848A7CD9FF70BABD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCore;
+		};
+		A1B2C3D4E5F600000000F002 /* KotlinMultiplatformLinkedPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = KotlinMultiplatformLinkedPackage;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 7555FF73242A565900829871 /* Project object */;
+}


### PR DESCRIPTION
## Summary

Repairs the white-label sync's merge engine, which was **entirely non-functional**: `owner: merge`
had never taken effect for any file in any fork, so every merge-owned path — `AndroidManifest.xml`
permissions, `libs.versions.toml`, `settings.gradle.kts`, every localized `strings.xml` — was being
silently full-copied on every sync. Three independent defects had to be fixed before a single 3-way
merge could run. On top of that, the platform application shells are reclassified from `template` to
`merge` (they are the one place fork-specific platform wiring has nowhere else to live), and two
structure-aware merge strategies are added for the file types a line merge cannot handle.

Also lands the template-first ownership flip, engine⋈contract coverage reconciliation (333 leaks →
0), and a single Ruby/Bundler resolver.

**And one runtime fix that is not about sync at all.** Hardening the merge canary surfaced a flaky
test, whose root cause turned out to be a live production bug: `categorize()` did not recognise the
exception Ktor's Darwin engine throws, so **every iOS cold start with an empty cache showed a
blocking full-screen NoNetwork instead of the screen's own Empty** — precisely the bug
`DecisionEngine`'s offline-first rule exists to prevent. Details below.

Verified by running the real sync end-to-end against a throwaway clone of a downstream consumer —
not by reasoning about the code.

## Changes

### Merge engine — three defects, each independently fatal

- **The engine never sourced its own contract library.** `sync-dirs.sh` invoked
  `customization-surface.sh` only as a subprocess, so `cs_match_g` / `cs_merge` were never defined —
  and four sites gate on `declare -F cs_match_g`. Every guard was permanently false. A comment
  claimed a subprocess was required for "bash-4 syntax"; it is not (macOS `/bin/bash` 3.2.57 sources
  it fine — the only `mapfile` matches are a local variable of that name). Now sourced, fail-soft.
- **`is_excluded()` clobbered its caller's `dir`.** It ran `for dir in "${!EXCLUSIONS[@]}"` without
  `local`; bash's dynamic scoping wrote straight into `sync_directory`'s `local dir`. A real
  `--only cmp-ios` run printed "Syncing cmp-ios", then the merge loop reported
  `dir=[feature/settings]` — cmp-ios got zero merge passes and its `project.pbxproj` was full-copied
  (−404/+35), deleting a downstream fork's entire widget-extension target.
  `propagate_template_deletions` and the exclusion-restore block were reading the wrong directory
  too. Loop variable is now function-private; `print_items()` localized for the same class.
- **A missing base was seeded from `ours`, inverting the result.** Two distinct absences: no repo
  merge base (a *copied* rather than forked tree — measured: zero shared commits with the template),
  and no per-file ancestor (add/add). Seeding `base := ours` makes every fork-owned key look like an
  upstream deletion, so the merge drops it and reports "fork edits preserved". `resolve_merge_base()`
  now falls back to `.template-version#template_sha` (the anchor that file's own header always
  claimed it was for), and an add/add seeds an **empty** base and warns.

### Platform shells are `merge`, not `template`

`build-logic/**`, `cmp-android/**`, `cmp-ios/**`, `cmp-desktop/**`, `cmp-web/**` reclassified. There
is no `module-deps.gradle.kts`-style seam for an Xcode target, an entitlement, or a plist key, so a
full copy destroys fork platform wiring with no recovery path. `cmp-shared` / `cmp-navigation` stay
`template` — they carry no platform project files and their fork surface already has named seams.

### Two structure-aware merge strategies

- **`pbxproj-3way`** (`scripts/white-label/merge-pbxproj.rb`) — a pbxproj is a serialized object
  graph, not a document; a conflict marker inside one makes the project unopenable in Xcode, so it
  cannot even be resolved by hand. Tractable because UUIDs are stable across the fork boundary
  (measured: 33 of 36 objects shared). Keyed 3-way with array union and per-key `buildSettings`
  merge. Uses `xcodeproj`, already a fastlane transitive — no new dependency. Prefers the pinned
  interpreter with a bare `require`, retrying under bundler only on gem-missing (exit 2).
- **`plist-union`** (`scripts/white-label/merge-plist.rb`) — comment-preserving key-level union for
  `Info.plist` / `*.entitlements`, `plutil -lint` validated, refuses to write an unparseable plist.
  Text-level so the template's rationale comments travel with the keys they document.

### Identity guards

- `ios-pbxproj-identity.sh` **PBX-4**: `DEVELOPMENT_TEAM` must be `""` or `$(TEAM_ID)`. This template
  shipped a real organisation's team id (`L432S2FZP5`) to every fork through two commits and it
  survived until now with PBX-1..3 green — none of them looked at `DEVELOPMENT_TEAM`.
- `ios-pbxproj-identity.sh` **PBX-2 relaxed**: a suffixed derivation (`$(APP_BUNDLE_ID).widgets`) is
  correct — Apple requires an app extension's bundle id to be a child of its host's. Exact-match-only
  rejected it and blocked every fork with a widget or share extension.

### Ruby health check now asks a repo-scoped question

`RT-8` used to ask "is the `ruby` on PATH the pinned one?" — a property of the *operator's shell*, not
the repo. Its own message conceded it ("Nothing is wrong in the repo"), and it warned on every
terminal that had not run `rbenv init`, every CI runner, every fresh shell. A permanent unactionable
warning is the kind that teaches people to skim past the warn column.

Two things in this PR closed the gap it stood in for: `ruby-exec.sh` resolves the pinned interpreter
directly (shims irrelevant), and `RT-9` forbids any tracked `*.sh` from invoking bundler at all. So
RT-8 now runs the resolver and checks the answer — **WARN** only when the resolver genuinely cannot
reach the pin (no rbenv, or the pin is not installed), or when a fork has stripped the resolver
entirely. A PATH mismatch is reported as an informational note beside a PASS, because the one path
that still breaks is a **hand-typed** lane, which does not go through the resolver. `RT8_RESOLVER`
makes both failure modes testable against the real tree — a synthetic `HEALTH_ROOT` cannot isolate
this check, since `RT-6` needs a git repo and fails in any scratch dir.

### Ruby single source of truth

`scripts/ruby-exec.sh` is the one way this repo reaches Ruby/Bundler — resolves
`$(rbenv root)/versions/<pin>/bin/ruby` directly so it works whether or not shims are on PATH,
provisions or fails loudly rather than silently running the wrong interpreter. Repo-root resolution
fixed for zsh (`BASH_SOURCE` is unset there, so the root resolved to the parent of the CWD and the
diagnostic reported no pin on a repo that has one). `RT-9` fails the build if any tracked `*.sh`
invokes bundler directly; `doctor.sh` and `setup_ios_complete.sh` converged onto it;
`deployment/_shared/before_all.rb` warns on an interpreter mismatch.

### Offline-first was broken on iOS — `ErrorCategory` did not know Ktor's engines

`DecisionEngine` may only apply the offline-first rule (offline + empty cache → `Empty`, not a
blocking `NoNetwork`) when the accompanying error is a transport failure, which it decides via
`categorize()`. That matcher works on the **class-name chain** — commonMain has no shared supertype
to test against, since `java.io.IOException` does not exist on iOS or Web. Coverage is therefore a
question of evidence, and two names were missing. Both were verified against real artifacts, not
assumed:

| exception | thrown by | before |
|---|---|---|
| `DarwinHttpRequestException` | Ktor Darwin engine (iOS/macOS) — confirmed in the cached `ktor-client-darwin` 3.2.1 klib | `Generic` |
| `IosHttpRequestException` | same engine, deprecated alias | `Generic` |
| `SocketException` | `java.net`, JVM/Android | `Generic` |

`SocketException` is the sharpest: it **is** an `IOException` subclass, but a name match cannot see
that, and "SocketException" contains none of the six original patterns — while its sibling
`SocketTimeoutException` matched via "Timeout". A dropped connection and a timed-out one were
categorized differently for no discoverable reason.

On iOS the consequence was user-facing on every cold start with an empty cache:
`DarwinHttpRequestException` → `Generic` → `isExpectedWhenOffline()` false → blocking `NoNetwork`.
The NSError is a *property* of the Darwin exception rather than its `cause`, so the chain never
reaches its "offline" text.

Fixed by adding `HttpRequestException` and `Socket` to the matcher. The suffix match is deliberately
narrow — Ktor reports HTTP *status* failures as `ClientRequestException` / `ServerResponseException`,
neither of which contains it, so a 500 stays real signal. A negative test asserts exactly that.
Proven RED (3 failures against the real names) before the fix.

**Not** a `kmptoolkit/cmp-network` issue: that module is the connectivity *monitor* and behaves
correctly. This is the HTTP client's error surface, owned here.

### Two flaky tests were lying fixtures, not scheduling

`ScreenDataStreamIntegrationTest` failed under Kover on two tests. Not timeouts — wrong-state
assertions. The file already carried a history of this pair flaking (2026-09-02, -09-05, -09-10) and
an explicit note that the next failure would be signal. It was: both fixtures modelled a fetcher that
cannot exist.

- **T2** threw `RuntimeException("no network")`, which categorizes `Generic` (see above), so the
  outcome depended on whether the empty emission or the doomed fetch won the race. Its comment
  claimed the fetcher "is never invoked" — the exact assumption `DecisionEngine` documents as false,
  since Store5's `cached(key, refresh = false)` **does** fetch on a cold cache.
- **T4** returned `"refreshed"` unconditionally, so the doomed *offline* fetch succeeded and the
  offline half asserted `Empty` against a stream that had legitimately reached `Content`.

Both now use an `IOException`-named error and a connectivity-aware fetcher. **No assertion weakened
and no timeout widened** — those are the contract under test.

### The pbxproj canary could not run on CI

Two bugs in the new gate itself, both found by running it upstream rather than locally:

- `PM-2` treated the merger's exit **2** — its designed *gem-missing* signal — as failure. A runner
  without `xcodeproj` cannot exercise the canary, and no fork should be blocked by that. Now a WARN
  with the `gem install` hint; a genuine merge failure still fails.
- `PM-5` still routed through `ruby_bundle`, which needs an installed Gemfile that CI deliberately
  does not have (`bundler-cache: false` keeps the job ~10s). It died in `<internal:gem_prelude>`
  while PM-2..PM-4 passed on the very same merged file — a bundler failure reported as "the merged
  graph does not re-open".

The quality gate now installs `xcodeproj` (a few seconds, versus ~1-2 min for the whole fastlane
tree under bundler), so the canary genuinely runs where merger regressions must be caught rather
than WARNing forever upstream.

### `RT-8` now asks a repo-scoped question

It used to ask whether the `ruby` on PATH was the pinned one — a property of the operator's shell,
which its own message conceded ("Nothing is wrong in the repo"). It warned on every terminal that had
not run `rbenv init`, every CI runner, every fresh shell. `ruby-exec.sh` resolves the pin directly
and `RT-9` bans direct bundler calls, so it now runs the resolver and checks the answer: WARN only
when the pin is genuinely unreachable, informational note otherwise. A hand-typed lane is the one
path that still needs the shell fixed, and the note says so.

### Docs + gates

- `scripts/CLAUDE.md` rewritten — it documented 8 scripts that no longer exist and omitted 22 that do.
- New: `sync-merge-base.sh` (MB-1..MB-6), `pbxproj-merge.sh` (PM-1..PM-6). Suite is 30 checks.
- Canary `tests/fixtures/pbxproj-3way-canary/` — real captured data, not synthetic. PM-2 asserts
  `git merge-file` *does* conflict on the same inputs so the fixture cannot go vacuous.

## Notable files

| File | Why |
|---|---|
| `scripts/white-label/sync-dirs.sh` | all three engine defects; both new strategies wired into both dispatch sites |
| `scripts/white-label/merge-pbxproj.rb` | new — keyed 3-way over the Xcode object graph |
| `scripts/white-label/merge-plist.rb` | new — comment-preserving plist key union |
| `scripts/ruby-exec.sh` | new — the single Ruby/Bundler resolver |
| `customization-surface.yaml` | template-first default; platform shells → `merge`; strategy rows |
| `scripts/product-health/checks/ios-pbxproj-identity.sh` | PBX-4 added, PBX-2 corrected |
| `scripts/product-health/checks/ruby-toolchain-coherence.sh` | RT-9 added; RT-8 re-scoped to the repo |
| `core-base/store/.../error/ErrorCategory.kt` | the iOS offline-first fix — Ktor Darwin + SocketException |
| `core-base/store/.../screen/ScreenDataStreamIntegrationTest.kt` | fixtures now model a real offline fetcher |
| `.github/workflows/quality-gate.yml` | installs `xcodeproj` so the pbxproj canary actually runs |

## Verification

Real sync run against a clone of a downstream consumer, `--only cmp-ios`:

```
targets           : iosApp (application) · CappyWidgets (app-extension)
widget sources    : 9 files      widget files on disk : 12 / 12
local SPM package : KotlinMultiplatformLinkedPackage   ← template migration landed
entitlements      : application-groups + keychain-access-groups   (both, parses OK)
Info.plist        : 21 keys incl. CFBundleURLTypes    conflict markers : 0
```

Before these fixes the same run deleted the widget target (40 refs → 0) and dropped the fork's
app-group entitlement, exit 0, no warning.

`TEMPLATE_SELF_BUILD=1 bash scripts/product-health/product-health.sh` → **29 passed · 0 warn · 0 failed**.

For the store changes: all 6 `categorize()` consumer modules (`core-base/store`, `core-base/ui`,
`core/store`, `feature/{alerts,bills,loans}`), the flaky pair re-executed 3× with `--rerun-tasks`,
plus root `spotlessCheck` and `detekt` — green locally before each push.

> Note for consumers: these contract rows only reach a fork once merged to `dev` — `STEP 0 BOOTSTRAP`
> materializes `customization-surface.yaml` from the template before any directory sync.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved network error detection for dropped connections, socket failures, and platform-specific request errors.
  - Offline-first screens now handle connection failures more consistently and refresh correctly after reconnection.

- **Improvements**
  - Template synchronization now preserves platform-specific changes more reliably, including Xcode projects, property lists, entitlements, and shared configuration.
  - Added safeguards to prevent invalid or incomplete project merges.

- **Documentation**
  - Updated customization and script documentation to reflect current synchronization and deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->