### PR TITLE
fix(sync): bootstrap the merge helpers, implement strings-union, stop reporting a skipped merge as a success

### DIFF
--- a/scripts/customization-surface.sh
+++ b/scripts/customization-surface.sh
@@ -228,6 +228,98 @@ cs_merge_manifest() {
   return 0
 }
 
+# ── strings-union (localized composeResources strings.xml) ───────────────────
+# Declared on 4 contract rules since the merge class was introduced, and until now it had NO
+# implementation: `cs_merge` had no branch for it, so it fell through to `cs_merge_3way` — a plain
+# `git merge-file`. The contract promised a union and the engine performed a line merge.
+#
+# That gap is invisible while a fork and the template share an ancestor for the file. It stops being
+# invisible the moment they do not: locale files are typically ADD/ADD (a fork seeds its own via
+# /idea-locale while the template ships its own), and with no base a line merge conflicts on the
+# WHOLE FILE. Measured on a real mbs/cappy full sync against merged dev: 90 of 98 conflicts were
+# strings-union, every one a whole-file marker starting at line 2.
+#
+# A resource file is a KEYED SET, not prose — `<string name="x">` entries are addressed by name and
+# their order carries no meaning, so a union is both possible and obviously right:
+#
+#   key only in theirs        → take it (the template added a string; the fork needs it)
+#   key only in ours          → keep it (the fork's own string, or its translation)
+#   key in both, same         → one copy
+#   key in both, different    → THE FORK WINS
+#
+# The fork winning is the whole point on this surface. The template ships SOURCE text — `app_name`
+# is "Money Toolkit" upstream and "Cappy" downstream — so taking the template's value would rename
+# the fork's app on every sync and silently discard real translations. A fork that wants the
+# template's new wording deletes its own key.
+#
+# Entry-level, not line-level: `<string-array>` and `<plurals>` span lines, so each element is read
+# from its opening tag to its matching close and carried whole.
+cs_merge_strings() {
+  local ours="$1" base="$2" theirs="$3" out="${4:-$1}"
+  [ -f "$ours" ] || { [ -f "$theirs" ] && cp "$theirs" "$out"; return 0; }
+  [ -f "$theirs" ] || return 0
+
+  local tmp; tmp="$(mktemp)"
+  awk -v oursf="$ours" '
+    # Emit "name\x01<entry text>" for every top-level resource element in FILE.
+    function slurp(file, arr,    line, name, buf, depth, tag) {
+      while ((getline line < file) > 0) {
+        if (line ~ /<(string|string-array|plurals|bool|integer|color|dimen)[ >]/) {
+          name = line; sub(/.*name="/, "", name); sub(/".*/, "", name)
+          buf = line
+          # self-closed or closed on the same line → done
+          if (line ~ /\/>/ || line ~ /<\/(string|string-array|plurals|bool|integer|color|dimen)>/) {
+            arr[name] = buf; continue
+          }
+          depth = 1
+          while (depth > 0 && (getline line < file) > 0) {
+            buf = buf "\n" line
+            if (line ~ /<\/(string-array|plurals)>/) depth--
+            else if (line ~ /<(string-array|plurals)[ >]/) depth++
+            else if (line ~ /<\/string>/) depth--
+          }
+          arr[name] = buf
+        }
+      }
+      close(file)
+    }
+    BEGIN { slurp(oursf, ourset) }
+    # Walk THEIRS, replacing any entry the fork also defines with the fork version.
+    {
+      if ($0 ~ /<(string|string-array|plurals|bool|integer|color|dimen)[ >]/) {
+        nm = $0; sub(/.*name="/, "", nm); sub(/".*/, "", nm)
+        # consume the whole element from theirs
+        buf = $0
+        if (!($0 ~ /\/>/ || $0 ~ /<\/(string|string-array|plurals|bool|integer|color|dimen)>/)) {
+          d = 1
+          while (d > 0 && (getline nxt) > 0) {
+            buf = buf "\n" nxt
+            if (nxt ~ /<\/(string-array|plurals)>/) d--
+            else if (nxt ~ /<(string-array|plurals)[ >]/) d++
+            else if (nxt ~ /<\/string>/) d--
+          }
+        }
+        if (nm in ourset) { print ourset[nm]; seen[nm] = 1 }
+        else              { print buf }
+        next
+      }
+      # Before the closing </resources>, append every fork-only entry.
+      if ($0 ~ /<\/resources>/) {
+        for (k in ourset) if (!(k in seen)) print ourset[k]
+      }
+      print
+    }
+  ' "$theirs" > "$tmp"
+
+  # Never ship an empty or truncated resource file: if the union lost the root element, keep ours.
+  if ! grep -q "</resources>" "$tmp"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  mv "$tmp" "$out"
+  return 0
+}
+
 # ── yaml-schema-merge (app-profile deep-merge) ───────────────────────────────
 # PLACEHOLDER classifier — a fork scalar is TEMPLATE-owned (loses on merge) when its
 # value still equals a template default OR its source line carries a `# PLACEHOLDER`
@@ -489,6 +581,7 @@ cs_merge() {
     include-union)     cs_merge_include_union "$ours" "$base" "$theirs" "$out" ;;
     yaml-schema-merge) cs_merge_yaml_schema   "$ours" "$base" "$theirs" "$out" ;;
     properties-3way)   cs_merge_properties    "$ours" "$base" "$theirs" "$out" ;;
+    strings-union)     cs_merge_strings       "$ours" "$base" "$theirs" "$out" ;;
     *)                 cs_merge_3way          "$ours" "$base" "$theirs" "$out" ;;
   esac
 }

--- a/scripts/white-label/sync-dirs.sh
+++ b/scripts/white-label/sync-dirs.sh
@@ -527,14 +527,14 @@ merge_pbxproj_3way() {
     local merger="$repo_root/scripts/white-label/merge-pbxproj.rb"
     if [ ! -f "$merger" ]; then
         print_warning "merge-pbxproj.rb absent — KEPT the fork's $out (this sync skipped the Xcode project)"
-        cp "$ours" "$out"; return 0
+        cp "$ours" "$out"; return 3
     fi
 
     # shellcheck source=/dev/null
     . "$repo_root/scripts/ruby-exec.sh" 2>/dev/null || true
     if ! declare -F ruby_exec >/dev/null 2>&1; then
         print_warning "ruby-exec.sh unavailable — KEPT the fork's $out (this sync skipped the Xcode project)"
-        cp "$ours" "$out"; return 0
+        cp "$ours" "$out"; return 3
     fi
 
     local tmp_out; tmp_out="$(mktemp -d)/project.pbxproj"
@@ -582,13 +582,13 @@ merge_plist_union() {
     local merger="$repo_root/scripts/white-label/merge-plist.rb"
     if [ ! -f "$merger" ]; then
         print_warning "merge-plist.rb absent — KEPT the fork's $out (this sync skipped it)"
-        cp "$ours" "$out"; return 0
+        cp "$ours" "$out"; return 3
     fi
     # shellcheck source=/dev/null
     . "$repo_root/scripts/ruby-exec.sh" 2>/dev/null || true
     if ! declare -F ruby_exec >/dev/null 2>&1; then
         print_warning "ruby-exec.sh unavailable — KEPT the fork's $out (this sync skipped it)"
-        cp "$ours" "$out"; return 0
+        cp "$ours" "$out"; return 3
     fi
     # `-` tells the merger there is no ancestor for THIS FILE, which is different from the repo
     # having no merge base: a file added on both sides since the last sync has a valid repo base
@@ -709,11 +709,11 @@ merge_contract_root_files() {
             plist-union)   merge_plist_union           "$o" "$b" "$t" "$f"; rc=$? ;;
             *)             cs_merge "$strat" "$o" "$b" "$t" "$f"; rc=$? ;;
         esac
-        if [ "${rc:-0}" -eq 0 ]; then
-            print_step "Merged (${strat}) ${BOLD}$f${NC} — template update + fork edits reconciled"
-        else
-            print_warning "Merged (${strat}) ${BOLD}$f${NC} WITH conflicts — resolve before committing the sync"
-        fi
+        case "${rc:-0}" in
+            0) print_step "Merged (${strat}) ${BOLD}$f${NC} — template update + fork edits reconciled" ;;
+            3) print_warning "SKIPPED (${strat}) ${BOLD}$f${NC} — kept the fork's copy; template changes NOT applied" ;;
+            *) print_warning "Merged (${strat}) ${BOLD}$f${NC} WITH conflicts — resolve before committing the sync" ;;
+        esac
         rm -f "$o" "$b" "$t"
     done
 }
@@ -915,11 +915,16 @@ sync_directory() {
                             plist-union)   merge_plist_union           "$_o" "$_b" "$_t" "$_mf"; _mrc=$? ;;
                             *)             cs_merge "$_ms" "$_o" "$_b" "$_t" "$_mf"; _mrc=$? ;;
                         esac
-                        if [ "${_mrc:-0}" -eq 0 ]; then
-                            print_step "Merged (${_ms}) ${BOLD}$_mf${NC} — fork edits preserved"
-                        else
-                            print_warning "CONFLICT in ${BOLD}$_mf${NC} (${_ms}) — resolve markers before committing the sync"
-                        fi
+                        # THREE outcomes, not two. A strategy that could not run keeps the fork's
+                        # copy and returns 3; reporting that as "Merged — fork edits preserved" is
+                        # true about the file and false about what happened, and it is exactly the
+                        # reassuring-success-over-a-silent-skip pattern this engine keeps being bitten
+                        # by. The helper already warned WHY; this must not contradict it.
+                        case "${_mrc:-0}" in
+                            0) print_step "Merged (${_ms}) ${BOLD}$_mf${NC} — fork edits preserved" ;;
+                            3) print_warning "SKIPPED (${_ms}) ${BOLD}$_mf${NC} — kept the fork's copy; template changes NOT applied" ;;
+                            *) print_warning "CONFLICT in ${BOLD}$_mf${NC} (${_ms}) — resolve markers before committing the sync" ;;
+                        esac
                     fi
                     rm -f "$_o" "$_b" "$_t"
                 done < <(git diff --name-only "$BASE_BRANCH" "$temp_branch" -- "$dir" 2>/dev/null)
@@ -1278,7 +1283,23 @@ if [ "$DRY_RUN" = false ]; then
     # (both files are owner:template / copy-exact, so this is idempotent + safe) so EVERY subsequent
     # dir gets full is_excluded + 3-way-merge protection. Self-bootstrap → auto-resolve; this is what
     # makes the sync run cleanly on a not-yet-white-labelled base instead of clobbering or halting.
-    for _bp in customization-surface.yaml scripts/customization-surface.sh; do
+    # The merge HELPERS bootstrap with the contract, for the same reason the contract does.
+    # `scripts/` is SYNC_DIRS #18; cmp-ios is #3. So on a fork that does not yet carry
+    # merge-pbxproj.rb / merge-plist.rb, cmp-ios (and cmp-android, cmp-desktop) are merged FIFTEEN
+    # directories before `scripts/` delivers them — every one silently degrading to keep-ours with
+    # only a warning, on the very first sync, which is precisely the sync that most needs them.
+    # Measured 2026-09-11 on a real mbs/cappy clone against merged dev: "merge-pbxproj.rb absent —
+    # KEPT the fork's project.pbxproj". Reordering SYNC_DIRS would be the fragile fix (it re-breaks
+    # the moment someone sorts the list); materializing the helpers up front is the same move STEP 0
+    # already makes for customization-surface.{yaml,sh}, and is equally idempotent — all four files
+    # are owner:template / copy-exact.
+    # ruby-exec.sh is in the set because the two mergers SOURCE it — bootstrapping them without it
+    # just moves the failure one step ("ruby-exec.sh unavailable — KEPT the fork's project.pbxproj").
+    # This list is a dependency CLOSURE, not a file list: anything STEP 0's consumers need before
+    # `scripts/` syncs belongs here.
+    for _bp in customization-surface.yaml scripts/customization-surface.sh \
+               scripts/ruby-exec.sh \
+               scripts/white-label/merge-pbxproj.rb scripts/white-label/merge-plist.rb; do
         if git cat-file -e "$TEMP_BRANCH:$_bp" 2>/dev/null; then
             mkdir -p "$(dirname "$_bp")"
             if git show "$TEMP_BRANCH:$_bp" > "$_bp" 2>/dev/null; then


### PR DESCRIPTION
## Summary

Two follow-ups to #302, both found by running the **real** sync against merged `dev` on a throwaway
clone of a downstream consumer rather than by reading the code. Without them the merge engine that
#302 repaired still does not run on a fork's first sync — it completes, exits 0, and reports success
while silently skipping the `pbxproj-3way` and `plist-union` strategies entirely.

## Changes

### The merge helpers are bootstrapped, like the contract already was

`scripts/` is `SYNC_DIRS` **#18**. `cmp-ios` is **#3**, `cmp-android` #1, `cmp-desktop` #2. So on a
fork that does not yet carry `merge-pbxproj.rb` / `merge-plist.rb`, all three platform shells are
merged **fifteen directories before** `scripts/` delivers them — each one degrading to keep-ours with
only a warning, on the very first sync, which is precisely the sync that needs them most.

Measured on a real `mbs/cappy` clone against merged `dev`:

```
⚠ merge-pbxproj.rb absent — KEPT the fork's cmp-ios/iosApp.xcodeproj/project.pbxproj
⚠ merge-plist.rb absent   — KEPT the fork's cmp-ios/iosApp/Info.plist
⚠ merge-plist.rb absent   — KEPT the fork's cmp-ios/iosApp/iosApp.entitlements
```

`STEP 0 BOOTSTRAP` already materializes `customization-surface.{yaml,sh}` up front for exactly this
reason; the helpers now travel with them. Reordering `SYNC_DIRS` would be the fragile alternative —
it re-breaks the moment someone sorts the list.

Fixing that surfaced a third file: the mergers **source** `scripts/ruby-exec.sh`, also in `scripts/`,
so bootstrapping only the two `.rb` files just moved the failure one step (`ruby-exec.sh unavailable
— KEPT the fork's project.pbxproj`). The list is now a dependency **closure**, and the comment says
so, because the next helper added will have the same requirement.

### A skipped merge no longer reports as a successful one

The keep-ours path returned `0`, so the caller printed:

```
⚠ merge-pbxproj.rb absent — KEPT the fork's project.pbxproj (this sync skipped the Xcode project)
✔ Merged (pbxproj-3way) project.pbxproj — fork edits preserved
```

Two lines contradicting each other. "fork edits preserved" is true about the file and false about
what happened — and reassuring-success-over-a-silent-skip is the same pattern that hid the dead merge
engine in #302 for as long as it did.

Keep-ours now returns a distinct code and **both** dispatch sites report three outcomes rather than
two: `Merged` / `SKIPPED — template changes NOT applied` / `CONFLICT`.

### `strings-union` had no implementation

Declared on **4 contract rules** since the merge class was introduced, and `cs_merge` had no branch
for it — so it fell through to `cs_merge_3way`, a plain `git merge-file`. The contract promised a
union; the engine performed a line merge.

The gap is invisible while a fork and the template share an ancestor for the file. It stops being
invisible the moment they do not: locale files are typically **add/add** (a fork seeds its own via
`/idea-locale`, the template ships its own), and with no base a line merge conflicts on the WHOLE
FILE. On the full-sync measurement below, **90 of 98 conflicts were strings-union**, every one a
whole-file marker starting at line 2.

A resource file is a KEYED SET, not prose — entries are addressed by `name` and their order carries
no meaning — so `cs_merge_strings` unions them:

| case | result |
|---|---|
| key only upstream | take it (the template added a string the fork needs) |
| key only in the fork | keep it |
| key in both, equal | one copy |
| key in both, different | **the fork wins** |

The fork winning is the point on this surface: the template ships SOURCE text — `app_name` is
"Money Toolkit" upstream and "Cappy" downstream — so taking the template's value would rename the
fork's app on every sync and discard real translations. A fork that wants the template's new wording
deletes its own key. `<string-array>` and `<plurals>` span lines, so elements are carried whole from
opening tag to matching close rather than line by line.

## Verification

Real sync, merged `dev`, no patches and no bootstrap neutering:

```
targets          : iosApp (application) · CappyWidgets (app-extension)
widget sources   : 9 files              widget files on disk : 12 / 12
local SPM package: KotlinMultiplatformLinkedPackage   ← template migration landed
entitlements     : application-groups + keychain-access-groups   (both; 2/2 plists parse)
CFBundleURLTypes : 1                    conflict markers      : 0
pbxproj 3-way    : +4 template · +45 kept from fork · 17 merged · 1 deletion · 1 ref pruned
```

### Full sync, all `SYNC_DIRS`, real consumer clone against merged `dev`

```
                    before these fixes    after
Merged                             50      140
SKIPPED (helper missing)            3        0
CONFLICT                           98        8
absent/unavailable warnings         3        0
```

By strategy after: 99 `strings-union` · 23 `3way` · 7 `kotlin-3way` · 6 `yaml-schema-merge` ·
3 `plist-union` · 1 each `pbxproj-3way` / `manifest-union` / `include-union` / `catalog-3way`.

The 8 remaining conflicts are the honest ones — 7 `kotlin-3way` in navigation/Android code where both
sides changed the same declarations, plus `desktopAppName` in the catalog. Surfaced, not silently
taken.

Correctness, not just absence of markers:

```
1180/1180  composeResources strings.xml parse as valid XML
values-ar  0 markers · 71 entries · app_name="Cappy" · 76 lines of Arabic preserved
cmp-ios    targets iosApp (application) · CappyWidgets (app-extension)
           KotlinMultiplatformLinkedPackage · widget 12/12 files
           entitlements app-group + keychain · CFBundleURLTypes present
```

`TEMPLATE_SELF_BUILD=1 bash scripts/product-health/product-health.sh` → **29 passed · 0 warn · 0 failed**,
contract `--verify` + flip-preconditions clean, `shell-portability` green over 84 scripts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for merging Android string resources, including strings, arrays, plurals, and multi-line values.
  * Preserves existing template structure while retaining fork-specific values and adding fork-only resources.

* **Bug Fixes**
  * Improved customization sync reporting by distinguishing successful merges, skipped merges, and conflicts.
  * Ensured required merge tools are available before directory synchronization begins.
  * Merge failures now return distinct status codes for more accurate handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->